### PR TITLE
Recover from Proxmox 'CT already exists' create failures in bootstrap runner

### DIFF
--- a/bootstrap/runner.sh
+++ b/bootstrap/runner.sh
@@ -39,6 +39,43 @@ export TF_VAR_pm_api_token_secret="${PVE_TOKEN_SECRET}"
 export TF_VAR_node_name="${PVE_NODE}"
 export TF_VAR_ssh_public_key="$(awk 'NR==1{print;exit}' /root/.ssh/authorized_keys 2>/dev/null || true)"
 
+is_recoverable_container_create_error() {
+  local out="$1"
+  grep -Eq "exit code: WARNINGS: 1|CT [0-9]+ already exists on node" <<<"$out"
+}
+
+recover_container_create_state() {
+  local dir="$1"
+  local res_name vm_id
+
+  res_name="$(awk 'match($0, /resource[[:space:]]+"proxmox_virtual_environment_container"[[:space:]]+"([^"]+)"/, m) { print m[1]; exit }' "$dir"/*.tf 2>/dev/null || true)"
+  vm_id="$(awk 'match($0, /vm_id[[:space:]]*=[[:space:]]*([0-9]+)/, m) { print m[1]; exit }' "$dir"/*.tf 2>/dev/null || true)"
+
+  [[ -n "$res_name" && -n "$vm_id" ]] || {
+    echo "[runner] Could not detect proxmox container resource/vm_id for state recovery"
+    return 1
+  }
+
+  if ! pct config "$vm_id" >/dev/null 2>&1; then
+    echo "[runner] Recovery skipped: CT $vm_id does not exist on host"
+    return 1
+  fi
+
+  echo "[runner] CT $vm_id exists; trying tofu import for proxmox_virtual_environment_container.$res_name"
+
+  local addr="proxmox_virtual_environment_container.$res_name"
+  local import_id
+  for import_id in "$vm_id" "${TF_VAR_node_name}/${vm_id}" "${TF_VAR_node_name}/lxc/${vm_id}"; do
+    if tofu import -input=false "$addr" "$import_id" >/dev/null 2>&1; then
+      echo "[runner] Imported $addr using id '$import_id'"
+      return 0
+    fi
+  done
+
+  echo "[runner] Failed to import $addr"
+  return 1
+}
+
 if [[ "${RUN_STACKS}" != "1" ]]; then
   echo "[runner] RUN_STACKS!=1 → exit"
   exit 0
@@ -89,7 +126,17 @@ for s in "${stacks[@]}"; do
   if [[ -f "main.tf" || -f "versions.tf" ]]; then
     tofu init -input=false
     if [[ "$AUTO_APPLY" == "1" ]]; then
-      tofu apply -auto-approve -input=false
+      apply_output=""
+      if ! apply_output="$(tofu apply -auto-approve -input=false 2>&1)"; then
+        printf '%s\n' "$apply_output"
+        if is_recoverable_container_create_error "$apply_output" && recover_container_create_state "$dir"; then
+          tofu apply -auto-approve -input=false
+        else
+          exit 1
+        fi
+      else
+        printf '%s\n' "$apply_output"
+      fi
     else
       tofu plan -input=false
     fi


### PR DESCRIPTION
### Motivation
- OpenTofu create operations can fail with either `WARNINGS: 1` or an HTTP 500 stating `CT <id> already exists on node` even though the container exists, which should not abort a bootstrap run.
- The runner should reconcile real container state in those cases (import the resource into OpenTofu state) and retry the apply instead of failing the whole bootstrap.

### Description
- Add `is_recoverable_container_create_error()` to detect both `exit code: WARNINGS: 1` and `CT <id> already exists on node` in `tofu apply` output.
- Generalize and rename the recovery helper to `recover_container_create_state()` which parses the stack `.tf` files for the `proxmox_virtual_environment_container` resource and `vm_id`, verifies the CT with `pct config`, and attempts `tofu import` using several common ID formats.
- Wrap `tofu apply` to capture its output, print it on failure, run the recoverability check and state recovery, and re-run `tofu apply` if import succeeds.
- Preserve original behavior for non-recoverable failures by exiting with a non-zero status when recovery is not applicable or fails.

### Testing
- Ran a shell syntax check with `bash -n bootstrap/runner.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c741379e483339d3e3b36d0361996)