### PR TITLE
runner: konsistente Auswahl der Ansible-Playbook-Datei

### DIFF
--- a/bootstrap/runner.sh
+++ b/bootstrap/runner.sh
@@ -281,13 +281,17 @@ for s in "${stacks[@]}"; do
 
   elif [[ -f "playbook.yml" || -f "playbook.yaml" ]]; then
     inv="$RALF_REPO/inventory/hosts.ini"
+    playbook_file="playbook.yml"
+    if [[ -f "playbook.yaml" ]]; then
+      playbook_file="playbook.yaml"
+    fi
     [[ -f "$inv" ]] || { echo "ERROR: missing inventory: $inv" >&2; exit 1; }
 
     if [[ "$AUTO_APPLY" == "1" ]]; then
       play_output=""
       played=0
       for attempt in $(seq 1 12); do
-        if play_output="$(ansible-playbook -i "$inv" playbook.yml 2>&1)"; then
+        if play_output="$(ansible-playbook -i "$inv" "$playbook_file" 2>&1)"; then
           printf '%s\n' "$play_output"
           played=1
           break
@@ -303,7 +307,7 @@ for s in "${stacks[@]}"; do
       [[ "$played" == "1" ]] || exit 1
     else
       echo "[runner] AUTO_APPLY=0 → ansible remote run skipped; running syntax-check only"
-      ansible-playbook -i "$inv" --syntax-check playbook.yml
+      ansible-playbook -i "$inv" --syntax-check "$playbook_file"
     fi
 
   else


### PR DESCRIPTION
### Motivation
- Der Runner erkennt sowohl `playbook.yml` als auch `playbook.yaml`, ruft Ansible aber an zwei Stellen immer fest mit `playbook.yml` auf, wodurch Stacks mit ausschließlich `playbook.yaml` fehlschlagen.

### Description
- Es wurde eine Variable `playbook_file` eingeführt (Default `playbook.yml`, falls `playbook.yaml` vorhanden wird dieses verwendet) und `playbook_file` wird nun sowohl für den regulären `ansible-playbook`-Lauf als auch für den `--syntax-check` verwendet.

### Testing
- Automatisierte Prüfungen ausgeführt: `bash -n bootstrap/start.sh bootstrap/runner.sh` → OK; `tofu fmt -check -recursive` → fehlschlagen/übersprungen weil `tofu` nicht installiert; `ansible-playbook -i inventory/hosts.ini --syntax-check stacks/031-minio-config/playbook.yml` → fehlschlagen/übersprungen weil `ansible-playbook` nicht installiert.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec677e8bc833389200edc8fe34224)