### PR TITLE
Add TUI wizard to ralf and support both playbook.yml/.yaml in runner

### DIFF
--- a/bin/ralf
+++ b/bin/ralf
@@ -283,16 +283,121 @@ tui_input_with_default() {
   fi
 }
 
+tui_confirm() {
+  local backend="$1" title="$2" message="$3" default_no="${4:-0}" rc=0
+  case "$backend" in
+    dialog)
+      if [[ "$default_no" == "1" ]]; then
+        dialog --title "$title" --defaultno --yesno "$message" 14 78 </dev/tty >/dev/tty || rc=$?
+      else
+        dialog --title "$title" --yesno "$message" 14 78 </dev/tty >/dev/tty || rc=$?
+      fi
+      ;;
+    whiptail)
+      if [[ "$default_no" == "1" ]]; then
+        whiptail --title "$title" --defaultno --yesno "$message" 14 78 </dev/tty >/dev/tty 2>&1 || rc=$?
+      else
+        whiptail --title "$title" --yesno "$message" 14 78 </dev/tty >/dev/tty 2>&1 || rc=$?
+      fi
+      ;;
+    *)
+      local ans def_prompt="[y/N]"
+      if [[ "$default_no" != "1" ]]; then
+        def_prompt="[Y/n]"
+      fi
+      ans="$(prompt_with_default "$message $def_prompt" "")"
+      ans="${ans,,}"
+      if [[ "$default_no" == "1" ]]; then
+        [[ "$ans" == "y" || "$ans" == "yes" ]] && return 0
+        return 1
+      fi
+      [[ -z "$ans" || "$ans" == "y" || "$ans" == "yes" ]] && return 0
+      return 1
+      ;;
+  esac
+  [[ "$rc" -eq 0 ]]
+}
+
+tui_render_summary() {
+  cat <<EOF
+1) Base-Domain : ${cfg[base_domain]:-<leer>}
+2) Primary User: ${cfg[owner_name]:-<leer>}
+3) RALF Name   : ${cfg[ralf_name]:-<leer>}
+4) CT Hostname : ${cfg[ct_hostname]:-<leer>}
+5) Network CIDR: ${cfg[network_cidr]:-<leer>}
+
+9) Weiter / bestaetigen
+0) Abbrechen
+EOF
+}
+
+tui_run_wizard() {
+  local backend="$1" choice="" rc=0 menu_text=""
+
+  [[ -n "${cfg[ct_hostname]}" ]] || cfg[ct_hostname]="ralf-bootstrap"
+
+  while true; do
+    menu_text="$(tui_render_summary)"
+    case "$backend" in
+      dialog)
+        choice="$(dialog --stdout --title "RALF Bootstrap TUI" --menu "Werte pruefen/anpassen:" 21 90 10           1 "Base-Domain (${cfg[base_domain]:-<leer>})"           2 "Primary User (${cfg[owner_name]:-<leer>})"           3 "RALF Name (${cfg[ralf_name]:-<leer>})"           4 "CT Hostname (${cfg[ct_hostname]:-<leer>})"           5 "Network CIDR (${cfg[network_cidr]:-<leer>})"           9 "Weiter / bestaetigen"           0 "Abbrechen" </dev/tty)" || rc=$?
+        ;;
+      whiptail)
+        choice="$(whiptail --title "RALF Bootstrap TUI" --menu "Werte pruefen/anpassen:" 21 90 10           1 "Base-Domain (${cfg[base_domain]:-<leer>})"           2 "Primary User (${cfg[owner_name]:-<leer>})"           3 "RALF Name (${cfg[ralf_name]:-<leer>})"           4 "CT Hostname (${cfg[ct_hostname]:-<leer>})"           5 "Network CIDR (${cfg[network_cidr]:-<leer>})"           9 "Weiter / bestaetigen"           0 "Abbrechen" 3>&1 1>&2 2>&3 </dev/tty)" || rc=$?
+        ;;
+      *)
+        echo
+        echo "RALF Bootstrap TUI"
+        printf '%s\n' "$menu_text"
+        choice="$(prompt_with_default 'Auswahl' '9')"
+        rc=0
+        ;;
+    esac
+
+    if [[ "$rc" -ne 0 ]]; then
+      TUI_CANCELLED=1
+      return
+    fi
+
+    case "$choice" in
+      1) cfg[base_domain]="$(tui_input_with_default "$backend" 'Lab DNS / Base-Domain' "${cfg[base_domain]}")" ;;
+      2) cfg[owner_name]="$(tui_input_with_default "$backend" 'Dein Name (Primary User)' "${cfg[owner_name]}")" ;;
+      3) cfg[ralf_name]="$(tui_input_with_default "$backend" 'RALF Name' "${cfg[ralf_name]}")" ;;
+      4) cfg[ct_hostname]="$(tui_input_with_default "$backend" 'CT Hostname' "${cfg[ct_hostname]}")" ;;
+      5) cfg[network_cidr]="$(tui_input_with_default "$backend" 'Network CIDR' "${cfg[network_cidr]}")" ;;
+      9)
+        if tui_confirm "$backend" "RALF Bootstrap" "Mit diesen Werten fortfahren?" 0; then
+          return
+        fi
+        ;;
+      0)
+        if tui_confirm "$backend" "RALF Bootstrap" "Bootstrap wirklich abbrechen?" 1; then
+          TUI_CANCELLED=1
+          return
+        fi
+        ;;
+      *)
+        # No-op for invalid selection in prompt fallback.
+        ;;
+    esac
+  done
+}
+
 TUI_CANCELLED=0
 tui_backend="none"
 if [[ "${cfg[tui]}" == "1" && "${cfg[non_interactive]}" != "1" && "$is_tty" == "1" ]]; then
   tui_backend="$(tui_backend_detect)"
-  local_info=$'Gefundene lokale Secrets: '"${probe_local_secrets_dir:-<keine>}"$'\n'"Erkannte Domain: ${cfg[base_domain]:-<leer>}"$'\n'"Erkannter Benutzername: ${cfg[owner_name]:-<leer>}"$'\n'"Erkannter RALF-Name: ${cfg[ralf_name]:-ralf}"$'\n\nWerte bestaetigen oder anpassen.'
+  local_info=$(cat <<EOF
+Gefundene lokale Secrets: ${probe_local_secrets_dir:-<keine>}
+Erkannte Domain: ${cfg[base_domain]:-<leer>}
+Erkannter Benutzername: ${cfg[owner_name]:-<leer>}
+Erkannter RALF-Name: ${cfg[ralf_name]:-ralf}
+
+Werte bestaetigen oder anpassen.
+EOF
+)
   tui_show_info "$tui_backend" "RALF Bootstrap TUI" "$local_info"
-  cfg[base_domain]="$(tui_input_with_default "$tui_backend" 'Lab DNS / Base-Domain' "${cfg[base_domain]}")"
-  cfg[owner_name]="$(tui_input_with_default "$tui_backend" 'Dein Name (Primary User)' "${cfg[owner_name]}")"
-  cfg[ralf_name]="$(tui_input_with_default "$tui_backend" 'RALF Name' "${cfg[ralf_name]}")"
-  [[ -n "${cfg[ct_hostname]}" ]] || cfg[ct_hostname]="ralf-bootstrap"
+  tui_run_wizard "$tui_backend"
 fi
 
 # Phase 3: Policy / Gatekeeping

--- a/bootstrap/runner.sh
+++ b/bootstrap/runner.sh
@@ -281,13 +281,17 @@ for s in "${stacks[@]}"; do
 
   elif [[ -f "playbook.yml" || -f "playbook.yaml" ]]; then
     inv="$RALF_REPO/inventory/hosts.ini"
+    playbook_file="playbook.yml"
+    if [[ -f "playbook.yaml" ]]; then
+      playbook_file="playbook.yaml"
+    fi
     [[ -f "$inv" ]] || { echo "ERROR: missing inventory: $inv" >&2; exit 1; }
 
     if [[ "$AUTO_APPLY" == "1" ]]; then
       play_output=""
       played=0
       for attempt in $(seq 1 12); do
-        if play_output="$(ansible-playbook -i "$inv" playbook.yml 2>&1)"; then
+        if play_output="$(ansible-playbook -i "$inv" "$playbook_file" 2>&1)"; then
           printf '%s\n' "$play_output"
           played=1
           break
@@ -303,7 +307,7 @@ for s in "${stacks[@]}"; do
       [[ "$played" == "1" ]] || exit 1
     else
       echo "[runner] AUTO_APPLY=0 → ansible remote run skipped; running syntax-check only"
-      ansible-playbook -i "$inv" --syntax-check playbook.yml
+      ansible-playbook -i "$inv" --syntax-check "$playbook_file"
     fi
 
   else


### PR DESCRIPTION
### Motivation

- Provide an interactive text UI to review and adjust bootstrap configuration values and add confirm dialogs to avoid accidental cancellation. 
- Make the bootstrap runner resilient to either `playbook.yml` or `playbook.yaml` being present so Ansible invocations do not hardcode a single filename.

### Description

- Added `tui_confirm`, `tui_render_summary`, and `tui_run_wizard` functions to `bin/ralf` to render a summary menu, allow editing of common bootstrap values, and confirm actions.  
- Replaced the previous inline info string assembly with a heredoc-backed `local_info` and swapped direct sequential `tui_input_with_default` calls for the new `tui_run_wizard` flow.  
- Added `playbook_file` detection in `bootstrap/runner.sh` to choose `playbook.yml` or `playbook.yaml` and used that variable for `ansible-playbook` calls (both apply/retry and `--syntax-check`).  
- Minor control-flow additions to propagate TUI cancellation state (`TUI_CANCELLED`) when the wizard is aborted.

### Testing

- Ran `bash -n` syntax checks and `shellcheck` on the modified scripts and found no syntax errors. (passed)
- Executed an automated smoke run of `bootstrap/runner.sh` in a CI-like environment that simulates presence of both `playbook.yml` and `playbook.yaml` to verify the runner selects the existing file and invokes `ansible-playbook --syntax-check` against the detected name. (passed)
- Verified non-interactive invocation paths of `bin/ralf` via automated script-based runs to ensure the new TUI code does not break non-TTY flows. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ec677e8bc833389200edc8fe34224)