### PR TITLE
governance: automate issue labeling and enforce foundation merge gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: RALF Governance Hinweise
+    url: https://github.com/default82/RALF/blob/main/agents.md
+    about: Bitte erst Rollenmodell, Gate-Logik und Foundation-Reihenfolge pruefen.

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,32 @@
+name: Epic
+description: Sammelthema mit Child-Issues und klaren Gates
+title: "Epic: "
+labels:
+  - epic
+  - governance
+  - gate:required
+body:
+  - type: textarea
+    id: ziel
+    attributes:
+      label: Ziel
+      description: Was wird durch das Epic erreicht?
+    validations:
+      required: true
+  - type: textarea
+    id: arbeitspakete
+    attributes:
+      label: Enthaltene Arbeitspakete
+      description: Liste mit referenzierten Issues
+      placeholder: |
+        - [ ] #14 ...
+        - [ ] #18 ...
+    validations:
+      required: true
+  - type: textarea
+    id: dod
+    attributes:
+      label: Definition of Done
+      description: Welche Bedingungen muessen fuer Abschluss erfuellt sein?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/extension-task.yml
+++ b/.github/ISSUE_TEMPLATE/extension-task.yml
@@ -1,0 +1,50 @@
+name: Extension Task
+description: Erweiterungsdienst fuer RALF nach Foundation-Validierung
+title: "Extension: "
+labels:
+  - extension
+  - priority:medium
+  - gate:required
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Erweiterungen werden erst nach Foundation-OK umgesetzt.
+  - type: textarea
+    id: ziel
+    attributes:
+      label: Ziel
+      description: Was soll der Dienst leisten?
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Betroffene Hooks/Services/Pfade
+    validations:
+      required: true
+  - type: textarea
+    id: akzeptanz
+    attributes:
+      label: Akzeptanzkriterien
+      description: Messbare Kriterien inkl. Nachweis
+      placeholder: |
+        - Service intern erreichbar
+        - validate/smoke dokumentiert
+    validations:
+      required: true
+  - type: textarea
+    id: abhaengigkeiten
+    attributes:
+      label: Abhaengigkeiten
+      description: Foundation-Tickets/Services, die vorher abgeschlossen sein muessen
+    validations:
+      required: true
+  - type: textarea
+    id: risiko
+    attributes:
+      label: Risiko
+      description: Hauptrisiko und Rollback-Ansatz
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/foundation-task.yml
+++ b/.github/ISSUE_TEMPLATE/foundation-task.yml
@@ -1,0 +1,51 @@
+name: Foundation Task
+description: Foundation-Core oder Foundation-Service Arbeitspaket fuer RALF
+title: "Foundation: "
+labels:
+  - foundation
+  - priority:high
+  - gate:required
+  - governance
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Bitte dieses Formular fuer Foundation-Themen nutzen.
+  - type: textarea
+    id: ziel
+    attributes:
+      label: Ziel
+      description: Was soll erreicht werden?
+      placeholder: Kurze, klare Zielbeschreibung.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Welche Komponenten/Pfade sind betroffen?
+      placeholder: bootstrap/hooks/..., bootstrap/lib/..., docs/...
+    validations:
+      required: true
+  - type: textarea
+    id: akzeptanz
+    attributes:
+      label: Akzeptanzkriterien
+      description: Messbare Definition of Done
+      placeholder: |
+        - idempotent in plan/apply
+        - validate/smoke nachweis vorhanden
+    validations:
+      required: true
+  - type: textarea
+    id: abhaengigkeiten
+    attributes:
+      label: Abhaengigkeiten
+      description: Vorbedingungen gemaess Foundation-Reihenfolge
+  - type: textarea
+    id: risiko
+    attributes:
+      label: Risiko
+      description: Wichtigstes Risiko und geplanter Rollback
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Proposal
+Beschreibe kurz, was geaendert wird und warum.
+
+## Gate-Status
+Gate-Status: `OK`
+
+## Nachweis
+- [ ] `bash -n bootstrap/start.sh bootstrap/bootrunner.sh bootstrap/validate.sh`
+- [ ] Falls Hooks/Services geaendert: `bash bootstrap/validate.sh --config bootstrap/bootstrap.env`
+- [ ] Keine Klartext-Secrets im Diff
+
+## Risikoanalyse
+- Risiko: 
+- Rollback: 
+
+## Alternativen
+- Betrachtete Alternative(n): 
+
+## Entscheidung
+- Warum diese Umsetzung: 
+
+## Auswirkungen
+- Betroffene Pfade/Komponenten: 
+- Foundation-Reihenfolge eingehalten: `ja/nein`

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,52 @@
+name: issue-labeler
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  label-by-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply default labels by title prefix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = (context.payload.issue.title || "").toLowerCase();
+            const issueNumber = context.issue.number;
+            const labels = new Set();
+
+            if (title.startsWith("foundation:")) {
+              labels.add("foundation");
+              labels.add("priority:high");
+              labels.add("gate:required");
+              labels.add("governance");
+            }
+
+            if (title.startsWith("extension:")) {
+              labels.add("extension");
+              labels.add("priority:medium");
+              labels.add("gate:required");
+            }
+
+            if (title.startsWith("epic:")) {
+              labels.add("epic");
+              labels.add("gate:required");
+              labels.add("governance");
+            }
+
+            if (labels.size === 0) {
+              core.info("No matching title prefix; no labels added.");
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              labels: Array.from(labels),
+            });
+            core.info(`Labels applied to issue #${issueNumber}: ${Array.from(labels).join(", ")}`);

--- a/.github/workflows/merge-gate.yml
+++ b/.github/workflows/merge-gate.yml
@@ -1,0 +1,121 @@
+name: merge-gate
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  pr-governance:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Gate-Status in PR body
+        run: |
+          set -euo pipefail
+          body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+
+          if ! grep -Eq 'Gate-Status:[[:space:]]*`?(OK|Warnung|Blocker)`?' <<<"$body"; then
+            echo "Missing or invalid 'Gate-Status'. Expected: OK|Warnung|Blocker."
+            exit 1
+          fi
+
+          if ! grep -Eq '##[[:space:]]+Nachweis|Nachweis' <<<"$body"; then
+            echo "PR body must contain a Nachweis section."
+            exit 1
+          fi
+
+  shell-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bash syntax check
+        run: |
+          set -euo pipefail
+          if [ -d bootstrap ]; then
+            find bootstrap -type f -name '*.sh' -print0 | xargs -0 -r bash -n
+          fi
+
+  secret-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        id: changed
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
+          cat /tmp/changed_files.txt
+
+      - name: Block credential files in repo
+        run: |
+          set -euo pipefail
+          if grep -E '(^|/)bootstrap\.env$|credentials\.env$|postgresql-credentials\.env$' /tmp/changed_files.txt; then
+            echo "Credential or local env file detected in diff."
+            exit 1
+          fi
+
+      - name: Block obvious inline secrets
+        run: |
+          set -euo pipefail
+          files="$(tr '\n' ' ' < /tmp/changed_files.txt)"
+          [ -z "$files" ] && exit 0
+
+          # Basic deny-list for hard-coded sensitive variables with non-empty values.
+          if grep -RInE 'PROXMOX_API_TOKEN_SECRET="[^"]+"|PROXMOX_API_TOKEN_ID="[^"]+"|POSTGRES_MASTER_PASS="[^"]+"|GITEA_ADMIN[12]_PASS="[^"]+"|SEMAPHORE_ADMIN[12]_PASS="[^"]+"|MINIO_ROOT_PASSWORD="[^"]+"' $files; then
+            echo "Potential hard-coded secret detected."
+            exit 1
+          fi
+
+  foundation-order:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed files
+        run: |
+          set -euo pipefail
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git diff --name-only "origin/${{ github.base_ref }}"...HEAD > /tmp/changed_files.txt
+          cat /tmp/changed_files.txt
+
+      - name: Enforce foundation before extension
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if ! grep -Eq '^bootstrap/hooks/(070-n8n|080-ki|085-matrix|090-semaphore-first)\.sh$|^bootstrap/create-(n8n|matrix|mail|exo)\.sh$' /tmp/changed_files.txt; then
+            echo "No extension deploy paths changed."
+            exit 0
+          fi
+
+          echo "Extension deploy paths detected; verifying foundation issue status..."
+          required_foundation_issues=(14 18 15 20)
+
+          for issue_id in "${required_foundation_issues[@]}"; do
+            state="$(curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${issue_id}" | jq -r '.state')"
+
+            echo "Issue #${issue_id} state=${state}"
+            if [[ "${state}" != "closed" ]]; then
+              echo "Foundation order violation: Issue #${issue_id} is not closed."
+              exit 1
+            fi
+          done
+
+          echo "Foundation order check passed."

--- a/README.md
+++ b/README.md
@@ -101,3 +101,31 @@ Ergebnisse werden in `$RUNTIME_DIR/smoke-results.jsonl` abgelegt.
 - Jede relevante Änderung folgt Entscheidungsweg + Gate-Status.
 - Jede Phase gilt erst als abgeschlossen mit Nachweis/Artefakten.
 - Ab stabiler Foundation: `Semaphore-first` für wiederholbare Ausführung.
+
+## Merge-Gate
+
+Für Pull Requests gilt ein verbindliches Merge-Gate über:
+
+- `.github/pull_request_template.md`
+- `.github/workflows/merge-gate.yml`
+- `.github/workflows/issue-labeler.yml`
+
+Für neue Tickets stehen strukturierte Issue-Formulare bereit unter:
+
+- `.github/ISSUE_TEMPLATE/foundation-task.yml`
+- `.github/ISSUE_TEMPLATE/extension-task.yml`
+- `.github/ISSUE_TEMPLATE/epic.yml`
+
+Aktive Pflichtprüfungen:
+
+- PR-Body enthält `Gate-Status: OK|Warnung|Blocker`
+- PR-Body enthält einen Nachweis-Abschnitt
+- Bash-Syntaxcheck für `bootstrap/**/*.sh`
+- Secret-Guard gegen versehentlich committed Credentials
+- Foundation-vor-Extension Regel bei PRs mit Erweiterungs-Deploypfaden
+
+Empfohlene lokale Vorprüfung:
+
+```bash
+bash -n bootstrap/start.sh bootstrap/bootrunner.sh bootstrap/validate.sh
+```


### PR DESCRIPTION
## Proposal
Automatisiert Governance fuer neue Issues und Pull Requests:
- strukturierte Issue-Formulare mit Default-Labels
- Label-Automation per Workflow
- erweitertes Merge-Gate inkl. Foundation-vor-Extension Pruefung

## Gate-Status
Gate-Status: `OK`

## Nachweis
- [x] `bash -n bootstrap/start.sh bootstrap/bootrunner.sh bootstrap/validate.sh`
- [x] Workflow-/Template-Dateien ohne Probleme erstellt
- [x] Keine Klartext-Secrets im Diff

## Risikoanalyse
- Risiko: Foundation-Order-Check blockiert Extension-PRs, solange Foundation-Issues offen sind.
- Rollback: PR nicht mergen oder Workflow-Datei revertieren.

## Alternativen
- Nur manuelle Review-Regeln ohne Automation

## Entscheidung
- Automatisierung reduziert Drift und erzwingt Governance konsistent.

## Auswirkungen
- Betroffene Pfade/Komponenten: `.github/**`, `README.md`
- Foundation-Reihenfolge eingehalten: `ja`