### PR TITLE
ci: add validate dry-run checkrun and labeler dispatch mode

### DIFF
--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -3,6 +3,7 @@ name: issue-labeler
 on:
   issues:
     types: [opened, edited, reopened]
+  workflow_dispatch:
 
 permissions:
   issues: write
@@ -15,38 +16,61 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const title = (context.payload.issue.title || "").toLowerCase();
-            const issueNumber = context.issue.number;
-            const labels = new Set();
+            function labelsForTitle(rawTitle) {
+              const title = (rawTitle || "").toLowerCase();
+              const labels = new Set();
 
-            if (title.startsWith("foundation:")) {
-              labels.add("foundation");
-              labels.add("priority:high");
-              labels.add("gate:required");
-              labels.add("governance");
+              if (title.startsWith("foundation:")) {
+                labels.add("foundation");
+                labels.add("priority:high");
+                labels.add("gate:required");
+                labels.add("governance");
+              }
+
+              if (title.startsWith("extension:")) {
+                labels.add("extension");
+                labels.add("priority:medium");
+                labels.add("gate:required");
+              }
+
+              if (title.startsWith("epic:")) {
+                labels.add("epic");
+                labels.add("gate:required");
+                labels.add("governance");
+              }
+
+              return Array.from(labels);
             }
 
-            if (title.startsWith("extension:")) {
-              labels.add("extension");
-              labels.add("priority:medium");
-              labels.add("gate:required");
+            async function applyForIssue(issue) {
+              const labels = labelsForTitle(issue.title);
+              if (labels.length === 0) {
+                core.info(`No matching prefix for issue #${issue.number}.`);
+                return;
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels,
+              });
+              core.info(`Labels applied to issue #${issue.number}: ${labels.join(", ")}`);
             }
 
-            if (title.startsWith("epic:")) {
-              labels.add("epic");
-              labels.add("gate:required");
-              labels.add("governance");
-            }
+            if (context.eventName === "workflow_dispatch") {
+              const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: "open",
+                per_page: 100,
+              });
 
-            if (labels.size === 0) {
-              core.info("No matching title prefix; no labels added.");
+              for (const issue of openIssues) {
+                // Skip pull requests listed by the Issues API.
+                if (issue.pull_request) continue;
+                await applyForIssue(issue);
+              }
               return;
             }
 
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              labels: Array.from(labels),
-            });
-            core.info(`Labels applied to issue #${issueNumber}: ${Array.from(labels).join(", ")}`);
+            await applyForIssue(context.payload.issue);

--- a/.github/workflows/validate-ci.yml
+++ b/.github/workflows/validate-ci.yml
@@ -1,0 +1,32 @@
+name: validate-ci
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bash syntax for validate script
+        run: |
+          set -euo pipefail
+          bash -n bootstrap/validate.sh
+
+      - name: Run validate.sh in dry-run mode
+        run: |
+          set -euo pipefail
+          bash bootstrap/validate.sh --dry-run --runtime-dir /tmp/ralf-runtime
+
+      - name: Assert dry-run output exists
+        run: |
+          set -euo pipefail
+          test -f /tmp/ralf-runtime/smoke-results.jsonl
+          test "$(wc -l < /tmp/ralf-runtime/smoke-results.jsonl)" -ge 9

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Für Pull Requests gilt ein verbindliches Merge-Gate über:
 - `.github/pull_request_template.md`
 - `.github/workflows/merge-gate.yml`
 - `.github/workflows/issue-labeler.yml`
+- `.github/workflows/validate-ci.yml`
 
 Für neue Tickets stehen strukturierte Issue-Formulare bereit unter:
 
@@ -123,9 +124,11 @@ Aktive Pflichtprüfungen:
 - Bash-Syntaxcheck für `bootstrap/**/*.sh`
 - Secret-Guard gegen versehentlich committed Credentials
 - Foundation-vor-Extension Regel bei PRs mit Erweiterungs-Deploypfaden
+- Dry-Run Checkrun fuer `bootstrap/validate.sh`
 
 Empfohlene lokale Vorprüfung:
 
 ```bash
 bash -n bootstrap/start.sh bootstrap/bootrunner.sh bootstrap/validate.sh
+bash bootstrap/validate.sh --dry-run --runtime-dir /tmp/ralf-runtime
 ```

--- a/bootstrap/validate.sh
+++ b/bootstrap/validate.sh
@@ -13,17 +13,22 @@ source "$REPO_ROOT/bootstrap/lib/smoke_check.sh"
 
 CONFIG_FILE=""
 RUNTIME_DIR="/opt/ralf/runtime"
+DRY_RUN=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --config) CONFIG_FILE="${2:-}"; shift 2 ;;
     --runtime-dir) RUNTIME_DIR="${2:-}"; shift 2 ;;
+    --dry-run|--mock) DRY_RUN=1; shift ;;
     -h|--help)
       cat <<'EOF'
-Usage: bootstrap/validate.sh [--config FILE] [--runtime-dir DIR]
+Usage: bootstrap/validate.sh [--config FILE] [--runtime-dir DIR] [--dry-run|--mock]
 
 Runs smoke checks for all deployed RALF services.
 Requires a Proxmox host with pct available.
+
+Options:
+  --dry-run, --mock   Simuliert die Pruefung ohne Proxmox-Abhaengigkeit.
 EOF
       exit 0
       ;;
@@ -58,6 +63,12 @@ check_service() {
   local vmid_key="${service}_ctid"
   local service_name="$2"
   local port="${3:-}"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "DRY-RUN: pruefe ${service} (service=${service_name}, port=${port:-n/a})"
+    write_result "$service" "DRY-RUN"
+    return 0
+  fi
 
   if ! smoke_state_file "$state_file" "$service"; then
     write_result "$service" "no-state"
@@ -103,6 +114,10 @@ run_check() {
 }
 
 log "RALF Smoke-Validierung startet..."
+
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "Modus: DRY-RUN (Mock)"
+fi
 
 run_check "minio"        check_service "minio"       "minio"          "9000"
 run_check "postgresql"   check_service "postgresql"  "postgresql"     "5432"


### PR DESCRIPTION
## Proposal
Ergaenzt CI-Checkruns fuer `bootstrap/validate.sh` im Dry-Run/Mock-Modus und erweitert den Issue-Labeler um `workflow_dispatch` fuer manuelle Verifikation.

## Gate-Status
Gate-Status: `OK`

## Nachweis
- [x] `bash -n bootstrap/validate.sh`
- [x] `bash bootstrap/validate.sh --dry-run --runtime-dir /tmp/ralf-runtime`
- [x] Dry-Run schreibt 9 Ergebniszeilen in `smoke-results.jsonl`

## Risikoanalyse
- Risiko: Dispatch-Modus labelt offene Issues anhand Titelpraefix neu (idempotent).
- Rollback: PR revertieren oder Workflows deaktivieren.

## Alternativen
- Labeler nur event-basiert ohne manuelle Ausloesung
- validate.sh nur lokal statt als CI-Checkrun

## Entscheidung
- Dry-Run ermoeglicht reproduzierbare CI-Pruefung ohne Proxmox-Abhaengigkeit.

## Auswirkungen
- Betroffene Pfade/Komponenten: `bootstrap/validate.sh`, `.github/workflows/*`, `README.md`
- Foundation-Reihenfolge eingehalten: `ja`