### PR TITLE
Ergebnisprotokoll verbindlich einführen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,14 @@ Vor Abschluss einer Aufgabe:
 4. `ZIELBILD.md` aktualisieren, wenn sich Ziel, Anweisung, Entscheidung oder Status geändert hat.
 5. Offen gebliebene Punkte klar benennen.
 
+## Laufprotokoll und Veröffentlichung
+
+- Nach jedem Arbeitsdurchlauf ist `Ergebnis.md` um einen neuen datierten Eintrag zu erweitern. Bestehende Einträge werden nicht überschrieben.
+- Jeder Eintrag nennt mindestens die bearbeiteten Zielbild-IDs, Ergebnis oder Fehler, geänderte Dateien, tatsächlich ausgeführte Prüfungen, nicht ausgeführte Prüfungen mit Begründung, offene Risiken oder Blocker und den nächsten sinnvollen Zielbild-Eintrag.
+- Das Laufprotokoll wird auch dann gepflegt, wenn die eigentliche Umsetzung fehlschlägt oder ohne Änderung abgebrochen werden muss.
+- Zu jedem Arbeitsdurchlauf gehören ein gezielter Commit der zugehörigen Repository-Dateien und ein Push auf den vorgesehenen Remote-Branch. Lokale Geheimnisse und nicht zum Arbeitsdurchlauf gehörende Dateien werden nicht aufgenommen.
+- Schlägt Commit oder Push technisch fehl, wird der konkrete Fehler im nächsten möglichen Eintrag festgehalten; ein fehlgeschlagener Push darf nicht als erfolgreich gemeldet werden.
+
 ## Aktuelle Definition of Done
 
 Der erste Standalone-Meilenstein ist abgeschlossen, wenn ein reproduzierbarer Installationsweg auf Proxmox einen unprivilegierten LXC mit Modell, Modelllaufzeit und kleiner Weboberfläche erzeugt und anschließend nachweist, dass:

--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -1,0 +1,14 @@
+# Ergebnisprotokoll
+
+Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge bleiben unverändert.
+
+## 2026-07-28 – Laufprotokoll verbindlich eingeführt
+
+- Bearbeitete Zielbild-ID: P-001
+- Ergebnis: Ein append-only Ergebnisprotokoll sowie die Pflicht zu gezieltem Commit und Push nach jedem Arbeitsdurchlauf wurden als dauerhafte Arbeitsregel eingeführt.
+- Geänderte Dateien: `AGENTS.md`, `ZIELBILD.md`, `README.md`, `Ergebnis.md`
+- Ausgeführte Prüfungen: Pflichtdokumente vollständig gelesen; Git-Status und Remote geprüft; Dokumentationsdiff und Geheimnisausschluss werden vor dem Commit geprüft.
+- Nicht ausgeführte Prüfungen: Keine Code-, Installations- oder Infrastrukturtests, da ausschließlich Projektdokumentation geändert wurde.
+- Risiken oder Blocker: Die fachliche Implementierung von RALF bleibt durch O-001 bis O-006 blockiert.
+- Nächster sinnvoller Zielbild-Eintrag: O-001
+- Veröffentlichung: Dieser Eintrag wird gemeinsam mit den zugehörigen Änderungen committed und auf einen Remote-Branch gepusht.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 RALF ist ein frühes, gemeinschaftlich entwickeltes Projekt für einen anpassbaren lokalen KI-Assistenten. Das Projekt beginnt bewusst klein und praktisch: Zuerst soll eine reproduzierbare Standalone-Installation entstehen, die auf der vorhandenen Infrastruktur tatsächlich läuft. Die spätere Architektur wird aus den dabei gewonnenen Erfahrungen entwickelt und nicht vorab vollständig festgelegt.
 
+RALF entsteht transparent durch Vibe Coding: Menschen geben Zielbild, Entscheidungen und Grenzen vor, während Coding-Agenten die Umsetzung in kleinen, überprüfbaren Schritten unterstützen.
+
 ## Aktueller Meilenstein
 
 Der erste Meilenstein ist eine feste Referenzinstallation für Proxmox:
@@ -33,6 +35,7 @@ Diese Punkte sind Zielrichtung, nicht bereits implementierte Architektur.
 
 - [`AGENTS.md`](AGENTS.md) enthält verbindliche Arbeitsregeln für Codex CLI und andere Coding-Agenten.
 - [`ZIELBILD.md`](ZIELBILD.md) ist die fortlaufend gepflegte Quelle für Ziele, Anweisungen, Entscheidungen und deren Status.
+- [`Ergebnis.md`](Ergebnis.md) protokolliert die Ergebnisse und Fehler der einzelnen Arbeitsdurchläufe.
 - [`LICENSE`](LICENSE) enthält die Projektlizenz.
 
 ## Arbeiten mit Codex CLI

--- a/ZIELBILD.md
+++ b/ZIELBILD.md
@@ -95,3 +95,9 @@ Diese Entscheidungen sind als Nächstes notwendig, bevor der Installer implement
 | A-003 | ABGESCHLOSSEN | Der erste praktische Schritt wurde von einer vollständigen Plattformarchitektur auf eine feste Proxmox-Standalone-Installation reduziert. |
 | A-004 | ABGESCHLOSSEN | Eine endgültige Definition des RALF-Kerns wurde bewusst auf einen späteren Zeitpunkt verschoben. |
 | A-005 | ABGESCHLOSSEN | Das Projekt wurde zunächst unter die Apache License 2.0 gestellt. |
+
+# 5. Verbindlicher Entwicklungsprozess
+
+| ID | Status | Anweisung |
+|---|---|---|
+| P-001 | AKTIV | Nach jedem Arbeitsdurchlauf wird `Ergebnis.md` append-only um Ergebnis oder Fehler, Änderungen, Prüfungen, Blocker und nächsten Zielbild-Schritt ergänzt. Die zugehörigen Repository-Änderungen werden gezielt committed und auf den vorgesehenen Remote-Branch gepusht; technische Commit- oder Pushfehler werden wahrheitsgemäß nachgetragen. |


### PR DESCRIPTION
## Änderungen

- führt `Ergebnis.md` als append-only Laufprotokoll ein
- verankert Pflege, gezielten Commit und Push nach jedem Lauf in `AGENTS.md`
- ergänzt P-001 als verbindliche Zielbild-Regel
- dokumentiert die neue Projektdatei und die Vibe-Coding-Herkunft in der README

## Zweck

Auch fehlgeschlagene oder blockierte Arbeitsdurchläufe sollen nachvollziehbar dokumentiert und veröffentlicht werden, ohne lokale Geheimnisse aufzunehmen.

## Prüfungen

- `git diff --check`
- Pflichtdateien und neue Ergebnisdatei vorhanden
- P-001 und Dokumentationsverweise per `rg` geprüft
- keine Dateien unter `secrets/` getrackt oder gestaged
- staged diff gezielt auf vier Dateien begrenzt