### PR TITLE
Offene Installer-Entscheidungen protokollieren

### DIFF
--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -23,3 +23,14 @@ Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge ble
 - Risiken oder Blocker: Die fachliche Implementierung von RALF bleibt durch O-001 bis O-006 blockiert.
 - Nächster sinnvoller Zielbild-Eintrag: O-001
 - Veröffentlichung: Der Merge erzeugte Commit `4583b3950a0ed10acf250b1cd54811375a87e754`; dieser Protokolleintrag wird separat auf `main` gepusht.
+
+## 2026-07-28 – Entwicklung durch offene Entscheidungen blockiert
+
+- Bearbeitete Zielbild-ID: P-001
+- Ergebnis: Kein Implementierungsschritt wurde begonnen, weil die für den Installer ausdrücklich vorausgesetzten Entscheidungen O-001 bis O-006 weiterhin `OFFEN` sind und nicht eigenmächtig getroffen werden dürfen.
+- Geänderte Dateien: `Ergebnis.md`
+- Ausgeführte Prüfungen: `AGENTS.md`, `ZIELBILD.md` und `README.md` vollständig gelesen; Git-Status und Repository-Dateien geprüft; Status und Abhängigkeit von O-001 bis O-006 gegen den aktuellen Meilenstein abgeglichen.
+- Nicht ausgeführte Prüfungen: Keine Syntax-, Unit-, Integrations- oder Infrastrukturtests, da keine Implementierung zulässig war.
+- Risiken oder Blocker: O-001 blockiert die Containergrundlage; O-002 die Modelllaufzeit; O-003 Modellinstallation und Funktionstest; O-004 Weboberfläche und Bedienpfad; O-005 Aufbau des Installers; O-006 Containerkonfiguration und Persistenz.
+- Nächster sinnvoller Zielbild-Eintrag: O-001
+- Veröffentlichung: Dieser Blocker-Eintrag wird committed, gepusht und nach `main` gemergt.


### PR DESCRIPTION
Geschlossen, weil `main` parallel fortgeschritten ist und O-001 bis O-006 inzwischen vollständig entschieden wurden. Der enthaltene Blocker-Eintrag ist daher veraltet und wird nicht gemergt.