### PR TITLE
Read-only Bootstrap-Preflight ergänzen

### DIFF
--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -111,3 +111,14 @@ Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge ble
 - Risiken oder Blocker: Die tatsächlichen Datenpfade von Ollama und Open WebUI müssen bei der Implementierung gezielt auf die festgelegten RALF-Pfade konfiguriert oder nachvollziehbar dorthin gebunden werden.
 - Nächster sinnvoller Zielbild-Eintrag: Implementierung des Bootstrap-Skripts für RALF Standalone 0.0.1.
 - Veröffentlichung: Die Dokumentationsänderungen wurden direkt auf `main` committed.
+
+## 2026-07-28 – Read-only Bootstrap-Preflight implementiert
+
+- Bearbeitete Zielbild-IDs: M-001, M-010, M-011, M-012, M-013, M-017, P-001
+- Ergebnis: Das Host-Bootstrap-Skript besitzt einen ausschließlich lesenden `--check`-Modus. Er prüft Root-Ausführung, erforderliche Proxmox-Befehle, die Proxmox-Versionsabfrage, die Verfügbarkeit eines Ubuntu-26.04-LXC-Templates und eine Namenskollision mit `ralf-standalone`.
+- Geänderte Dateien: `scripts/ralf-standalone-bootstrap.sh`, `tests/bootstrap-preflight.sh`, `README.md`, `Ergebnis.md`
+- Ausgeführte Prüfungen: `bash -n` und ShellCheck ohne Befund; simulierte Tests für Erfolgsfall, fehlendes Template und bestehenden Containername erfolgreich; read-only Preflight auf dem realen Proxmox-Host erfolgreich; `git diff --check` ohne Befund.
+- Nicht ausgeführte Prüfungen: Kein Test gegen eine reale Container-Erstellung oder Softwareinstallation, weil dieser Schritt ausschließlich den read-only Preflight implementiert und Live-Infrastruktur nicht verändert werden darf.
+- Risiken oder Blocker: VMID, Storage, Netzwerk-Bridge und feste Ressourcenwerte sind für den Erzeugungsschritt noch nicht implementiert. Der Template-Abgleich setzt voraus, dass der Proxmox-Katalog einen Namen mit `ubuntu-26.04-standard` enthält.
+- Nächster sinnvoller Zielbild-Eintrag: M-017 – sichere, explizit konfigurierte Erstellung des unprivilegierten LXC ergänzen.
+- Veröffentlichung: Die Änderungen werden gemeinsam committed, gepusht und nach `main` gemergt.

--- a/README.md
+++ b/README.md
@@ -42,9 +42,19 @@ Diese Punkte sind Zielrichtung, nicht bereits implementierte Architektur.
 
 Codex soll vor jeder Änderung zuerst `AGENTS.md` und `ZIELBILD.md` lesen. Änderungen, die Ziele, Grenzen, Entscheidungen oder den Stand eines Meilensteins verändern, müssen gleichzeitig in `ZIELBILD.md` nachgeführt werden. Codex verwendet dafür die konventionelle Projektdatei `AGENTS.md`, wie sie auch vom Codex-Initialisierungsworkflow erzeugt wird.
 
+## Bootstrap-Preflight
+
+Der erste ungefährliche Teil des Proxmox-Bootstraps prüft ausschließlich die Voraussetzungen und verändert keine Container oder Hostkonfigurationen:
+
+```bash
+sudo ./scripts/ralf-standalone-bootstrap.sh --check
+```
+
+Der Preflight erwartet einen Proxmox-Host, prüft die benötigten Proxmox-Befehle, sucht im Templatekatalog nach Ubuntu 26.04 und bricht ab, falls bereits ein LXC namens `ralf-standalone` existiert. Die eigentliche Container-Erstellung ist noch nicht implementiert.
+
 ## Status
 
-Das Repository befindet sich in der Initialisierung. Es existiert noch keine Implementierung und es wurde noch kein Modell, keine Laufzeit und keine Weboberfläche verbindlich ausgewählt.
+Das Repository befindet sich in der Initialisierung. Die Referenzkomponenten sind im Zielbild festgelegt; implementiert ist bislang nur der read-only Bootstrap-Preflight, noch keine Container-Erstellung oder Softwareinstallation.
 
 ## Lizenz
 

--- a/scripts/ralf-standalone-bootstrap.sh
+++ b/scripts/ralf-standalone-bootstrap.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly CONTAINER_NAME="ralf-standalone"
+readonly TEMPLATE_PATTERN='ubuntu-26\.04-standard'
+
+fail() {
+  printf 'Fehler: %s\n' "$*" >&2
+  exit 1
+}
+
+usage() {
+  printf 'Aufruf: %s --check\n' "${0##*/}" >&2
+  exit 2
+}
+
+check_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "Benötigter Befehl fehlt: $1"
+}
+
+run_preflight() {
+  local templates
+  local containers
+
+  (( EUID == 0 )) || fail "Der Proxmox-Preflight muss als root ausgeführt werden."
+
+  check_command pveversion
+  check_command pveam
+  check_command pct
+
+  pveversion >/dev/null 2>&1 ||
+    fail "Die Proxmox-Version konnte nicht abgefragt werden."
+
+  templates=$(pveam available --section system) ||
+    fail "Der Proxmox-Templatekatalog konnte nicht gelesen werden."
+  grep -Eq "$TEMPLATE_PATTERN" <<<"$templates" ||
+    fail "Kein Ubuntu-26.04-LXC-Template im Proxmox-Katalog gefunden."
+
+  containers=$(pct list) ||
+    fail "Die vorhandenen LXC-Container konnten nicht gelesen werden."
+  if awk -v name="$CONTAINER_NAME" 'NR > 1 && $NF == name { found = 1 } END { exit !found }' <<<"$containers"; then
+    fail "Ein LXC mit dem Namen ${CONTAINER_NAME} existiert bereits."
+  fi
+
+  printf 'Preflight erfolgreich: Proxmox ist bereit und der Name %s ist frei.\n' "$CONTAINER_NAME"
+}
+
+[[ $# == 1 && $1 == "--check" ]] || usage
+run_preflight

--- a/tests/bootstrap-preflight.sh
+++ b/tests/bootstrap-preflight.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+readonly PROJECT_ROOT
+readonly SCRIPT="${PROJECT_ROOT}/scripts/ralf-standalone-bootstrap.sh"
+TEST_ROOT=$(mktemp -d)
+readonly TEST_ROOT
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+make_stub() {
+  local directory=$1
+  local name=$2
+  local body=$3
+
+  mkdir -p "$directory"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -Eeuo pipefail\n'
+    printf '%s\n' "$body"
+  } >"${directory}/${name}"
+  chmod +x "${directory}/${name}"
+}
+
+run_case() {
+  local name=$1
+  local expected_status=$2
+  local expected_text=$3
+  local stub_dir="${TEST_ROOT}/${name}"
+  local output
+  local status
+
+  make_stub "$stub_dir" pveversion 'printf "pve-manager/9.2.4\\n"'
+  make_stub "$stub_dir" pveam 'printf "system local:vztmpl/ubuntu-26.04-standard_26.04-1_amd64.tar.zst\\n"'
+  make_stub "$stub_dir" pct 'printf "VMID Status Lock Name\\n"'
+
+  case "$name" in
+    missing-template)
+      make_stub "$stub_dir" pveam 'printf "system local:vztmpl/debian-13-standard_13.0-1_amd64.tar.zst\\n"'
+      ;;
+    existing-container)
+      make_stub "$stub_dir" pct 'printf "VMID Status Lock Name\\n2200 stopped - ralf-standalone\\n"'
+      ;;
+  esac
+
+  set +e
+  output=$(PATH="${stub_dir}:/usr/bin:/bin" "$SCRIPT" --check 2>&1)
+  status=$?
+  set -e
+
+  [[ $status == "$expected_status" ]] ||
+    printf 'FAIL %s: Status %s statt %s\n%s\n' "$name" "$status" "$expected_status" "$output" >&2
+  [[ $status == "$expected_status" ]] || return 1
+
+  grep -Fq "$expected_text" <<<"$output" ||
+    printf 'FAIL %s: Ausgabe enthält nicht: %s\n%s\n' "$name" "$expected_text" "$output" >&2
+  grep -Fq "$expected_text" <<<"$output" || return 1
+
+  printf 'PASS %s\n' "$name"
+}
+
+run_case success 0 'Preflight erfolgreich'
+run_case missing-template 1 'Kein Ubuntu-26.04-LXC-Template'
+run_case existing-container 1 'existiert bereits'


### PR DESCRIPTION
## Änderungen

- ergänzt einen ausschließlich lesenden `--check`-Modus für den Proxmox-Host
- prüft Proxmox-Werkzeuge, Versionsabfrage, Ubuntu-26.04-Template und Namenskollision
- ergänzt fokussierte Shell-Tests für Erfolg und zwei Fehlerpfade
- dokumentiert Aufruf, Grenzen und Laufergebnis

## Sicherheit

Der Preflight erstellt oder verändert keine Container, Storages, Netzwerke oder Hostkonfigurationen. `secrets/` ist nicht Bestandteil des Commits.

## Prüfungen

- `bash -n`
- ShellCheck ohne Befund
- simulierter Erfolgsfall
- Fehlerpfad bei fehlendem Template
- Fehlerpfad bei bestehendem Containername
- erfolgreicher read-only Preflight auf dem realen Proxmox-Host
- `git diff --check`