### PR TITLE
Offene LXC-Ressourcenkonfiguration erfassen

### DIFF
--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -133,3 +133,14 @@ Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge ble
 - Risiken oder Blocker: Die GitHub-Schreibvorgänge erzeugten mehrere aufeinanderfolgende Commits statt eines einzelnen atomaren Commits. Der Bootstrap ist weiterhin nur als ungefährlicher Preflight teilweise implementiert; Container-Erstellung und Softwareinstallation stehen aus.
 - Nächster sinnvoller Zielbild-Eintrag: M-017 – sichere, explizit konfigurierte Erstellung des unprivilegierten LXC gemäß `GOAL.md` fortsetzen.
 - Veröffentlichung: Alle Änderungen wurden durch GitHub-Schreibvorgänge direkt auf `main` committed und auf das Remote-Repository veröffentlicht; dieser Protokolleintrag bildet den abschließenden Commit des Arbeitsdurchlaufs.
+
+## 2026-07-28 – Fehlende LXC-Ressourcenkonfiguration formalisiert
+
+- Bearbeitete Zielbild-IDs: M-002, M-007, M-010, M-011, M-017, O-007, P-001
+- Ergebnis: O-007 erfasst VMID, Ziel-Storage, Netzwerk-Bridge, CPU, RAM, Root-Disk-Größe und deren verbindliche Eingabeform als noch offene, vor der LXC-Erstellung notwendige Entscheidung. Es wurden keine Werte erfunden und keine Live-Ressourcen verändert.
+- Geänderte Dateien: `ZIELBILD.md`, `Ergebnis.md`
+- Ausgeführte Prüfungen: Pflichtdokumente und jüngste relevante Ergebnisse gelesen; Abhängigkeit zur sicheren LXC-Erstellung geprüft; Zielbild-ID und Tabellenstruktur kontrolliert; `git diff --check` wird vor dem Commit ausgeführt.
+- Nicht ausgeführte Prüfungen: Keine Shell-, Installations- oder Infrastrukturtests, da ausschließlich ein Implementierungsblocker dokumentiert wurde und die bestehende Preflight-Implementierung unverändert blieb.
+- Risiken oder Blocker: M-017 und D-001 bleiben bis zur Entscheidung O-007 blockiert.
+- Nächster sinnvoller Zielbild-Eintrag: O-007
+- Veröffentlichung: Die Dokumentationsänderungen werden gemeinsam committed, gepusht und nach `main` gemergt.

--- a/ZIELBILD.md
+++ b/ZIELBILD.md
@@ -93,6 +93,7 @@ Diese Entscheidungen sind als Nächstes notwendig, bevor der Installer implement
 | O-004 | ABGESCHLOSSEN | Open WebUI ist als kleine Weboberfläche für RALF Standalone 0.0.1 festgelegt. |
 | O-005 | ABGESCHLOSSEN | Die Installation erfolgt durch ein vom Proxmox-Host gestartetes Bootstrap-Skript, das den LXC erstellt, konfiguriert und die Installation im Container anstößt. |
 | O-006 | ABGESCHLOSSEN | Hostname und Proxmox-Bezeichnung lauten `ralf-standalone`. Die Netzwerkkonfiguration erfolgt per DHCP ohne vorausgesetzte Reservierung. Persistente Daten verbleiben ohne separate Proxmox-Mountpoints im Root-Dateisystem unter `/etc/ralf/`, `/var/lib/ralf/ollama/`, `/var/lib/ralf/webui/` und `/var/log/ralf/`; die Sicherung erfolgt zunächst über Proxmox-Backups des LXC. |
+| O-007 | OFFEN | Vor der LXC-Erstellung sind VMID, Ziel-Storage, Netzwerk-Bridge, CPU-Anzahl, RAM und Root-Disk-Größe sowie die verbindliche Eingabeform dieser Werte festzulegen. |
 
 # 4. Abgeschlossene Anweisungen und Entscheidungen
 


### PR DESCRIPTION
## Ergebnis

O-007 erfasst die vor der sicheren LXC-Erstellung noch notwendigen Entscheidungen zu VMID, Storage, Bridge, CPU, RAM, Root-Disk und Eingabeform. Es werden keine Werte vorweggenommen und keine Live-Ressourcen verändert.

## Prüfungen

- Pflichtdokumente und jüngste Ergebnisse gelesen
- Zielbild-ID und Tabellenstruktur geprüft
- `git diff --check`
- Commit auf `ZIELBILD.md` und `Ergebnis.md` begrenzt
- `secrets/` ausgeschlossen