### PR TITLE
O-007 Ressourcenplan sicher validieren

### DIFF
--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -144,3 +144,14 @@ Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge ble
 - Risiken oder Blocker: M-017 und D-001 bleiben bis zur Entscheidung O-007 blockiert.
 - Nächster sinnvoller Zielbild-Eintrag: O-007
 - Veröffentlichung: Die Dokumentationsänderungen werden gemeinsam committed, gepusht und nach `main` gemergt.
+
+## 2026-07-31 – O-007 festgelegt und Ressourcenplan implementiert
+
+- Bearbeitete Zielbild-IDs: O-007, M-021, M-022, O-008, P-001
+- Ergebnis: O-007 ist abgeschlossen. Der sichere Plan-/Preflight-Pfad verwendet 4 Kerne, 12288 MiB RAM, 4096 MiB Swap und 40 GiB Root-Disk als feste Referenzwerte. VMID, Storage und Bridge werden eindeutig und nur lesend ermittelt; die sieben vorgesehenen CLI-Parameter überschreiben die Defaults beziehungsweise Auswahl. Mehrdeutige oder ungültige Werte brechen vor jeder Mutation ab. GPU-Passthrough wurde als separate offene Entscheidung O-008 dokumentiert und nicht implementiert.
+- Geänderte Dateien: `scripts/ralf-standalone-bootstrap.sh`, `tests/bootstrap-preflight.sh`, `ZIELBILD.md`, `README.md`, `Ergebnis.md`
+- Ausgeführte Prüfungen: `bash -n`, ShellCheck soweit verfügbar, gültige Defaults, gültige CLI-Overrides, belegte VMID, mehrdeutige Storages, mehrdeutige Bridges, ungültiger Speicherwert, unbekannte Option, fehlender Parameter sowie `git diff --check`.
+- Nicht ausgeführte Prüfungen: Keine echte LXC-Erstellung, kein Start/Stop und keine Softwareinstallation; der Planpfad bleibt absichtlich ohne Live-Mutation.
+- Risiken oder Blocker: Die konkrete LXC-Erstellung und die Installation von Ubuntu-Aktualisierungen, Ollama, Modell und Open WebUI stehen weiterhin aus. O-008 bleibt für GPU-Unterstützung offen.
+- Nächster sinnvoller Zielbild-Eintrag: M-017 – sichere LXC-Erstellung auf Basis des validierten Plans.
+- Veröffentlichung: Die Änderungen werden gemeinsam committed, gepusht und nach `main` gemergt.

--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Jeder Arbeitsdurchlauf umfasst einen kleinen überprüfbaren Schritt, relevante 
 Der erste ungefährliche Teil des Proxmox-Bootstraps prüft ausschließlich die Voraussetzungen und verändert keine Container oder Hostkonfigurationen:
 
 ```bash
-sudo ./scripts/ralf-standalone-bootstrap.sh --check
+sudo ./scripts/ralf-standalone-bootstrap.sh --plan
 ```
 
-Der Preflight erwartet einen Proxmox-Host, prüft die benötigten Proxmox-Befehle, sucht im Templatekatalog nach Ubuntu 26.04 und bricht ab, falls bereits ein LXC namens `ralf-standalone` existiert. Die eigentliche Container-Erstellung ist noch nicht implementiert.
+`--check` ist ein kompatibler Alias. Der Plan ermittelt die nächste freie VMID sowie Storage und Bridge nur dann automatisch, wenn jeweils genau eine geeignete Option vorhanden ist. Alternativ können `--vmid`, `--storage`, `--bridge`, `--cores`, `--memory`, `--swap` und `--disk` explizit gesetzt werden. Speicher und Swap werden in MiB, die Root-Disk in GiB angegeben. Ungültige, fehlende oder mehrdeutige Werte brechen ohne LXC-Änderung ab. Die eigentliche Container-Erstellung ist noch nicht implementiert.
 
 ## Status
 
-Die grundlegenden Entscheidungen für RALF Standalone 0.0.1 sind abgeschlossen. Implementiert ist bislang nur der read-only Bootstrap-Preflight; Container-Erstellung, Softwareinstallation und vollständige Definition of Done stehen noch aus.
+Die grundlegenden Entscheidungen für RALF Standalone 0.0.1 sind abgeschlossen. Implementiert ist bislang nur der read-only Bootstrap- und Ressourcenplan; Container-Erstellung, Softwareinstallation und vollständige Definition of Done stehen noch aus.
 
 ## Lizenz
 

--- a/ZIELBILD.md
+++ b/ZIELBILD.md
@@ -1,6 +1,6 @@
 # ZIELBILD.md
 
-Stand: 2026-07-28
+Stand: 2026-07-31
 
 Diese Datei ist die dauerhaft gepflegte Arbeitsgrundlage für Menschen und Coding-Agenten, die RALF entwickeln. Sie enthält Ziele, verbindliche Anweisungen, Entscheidungen, Grenzen und deren Status. Sie enthält keine vollständigen Überlegungen, Gesprächsprotokolle oder ausführlichen Alternativdiskussionen.
 
@@ -68,6 +68,8 @@ Eine feste und reproduzierbare erste Installation soll auf der vorhandenen Proxm
 | M-018 | AKTIV | Hostname und Proxmox-Bezeichnung des ersten LXC lauten `ralf-standalone`. |
 | M-019 | AKTIV | Die Netzwerkkonfiguration des ersten LXC erfolgt grundsätzlich per DHCP. Für die erste Referenzinstallation wird keine feste IP-Adresse und keine DHCP-Reservierung vorausgesetzt. |
 | M-020 | AKTIV | Für RALF Standalone 0.0.1 werden keine separaten Proxmox-Mountpoints eingerichtet. Persistente Daten liegen im Root-Dateisystem des LXC unter `/etc/ralf/`, `/var/lib/ralf/ollama/`, `/var/lib/ralf/webui/` und `/var/log/ralf/`. Die Sicherung erfolgt zunächst über normale Proxmox-Backups des LXC. |
+| M-021 | AKTIV | Die feste Referenzinstallation verwendet 4 CPU-Kerne, 12288 MiB RAM, 4096 MiB Swap und eine 40-GiB-Root-Disk. Diese Werte sind Referenzwerte der ersten Installation und keine allgemeinen Mindestanforderungen. VMID, Storage und Bridge werden standardmäßig sicher ermittelt; die Werte können über explizite CLI-Parameter überschrieben werden. |
+| M-022 | AKTIV | Der Plan-/Preflight-Pfad validiert alle Ressourcenparameter und bricht bei ungültigen oder unvollständigen Angaben sowie bei nicht eindeutiger automatischer Storage- oder Bridge-Auswahl vor jeder LXC-Mutation mit verständlicher Ausgabe ab. Eine belegte VMID wird niemals überschrieben. |
 
 ## Definition of Done
 
@@ -93,7 +95,8 @@ Diese Entscheidungen sind als Nächstes notwendig, bevor der Installer implement
 | O-004 | ABGESCHLOSSEN | Open WebUI ist als kleine Weboberfläche für RALF Standalone 0.0.1 festgelegt. |
 | O-005 | ABGESCHLOSSEN | Die Installation erfolgt durch ein vom Proxmox-Host gestartetes Bootstrap-Skript, das den LXC erstellt, konfiguriert und die Installation im Container anstößt. |
 | O-006 | ABGESCHLOSSEN | Hostname und Proxmox-Bezeichnung lauten `ralf-standalone`. Die Netzwerkkonfiguration erfolgt per DHCP ohne vorausgesetzte Reservierung. Persistente Daten verbleiben ohne separate Proxmox-Mountpoints im Root-Dateisystem unter `/etc/ralf/`, `/var/lib/ralf/ollama/`, `/var/lib/ralf/webui/` und `/var/log/ralf/`; die Sicherung erfolgt zunächst über Proxmox-Backups des LXC. |
-| O-007 | OFFEN | Vor der LXC-Erstellung sind VMID, Ziel-Storage, Netzwerk-Bridge, CPU-Anzahl, RAM und Root-Disk-Größe sowie die verbindliche Eingabeform dieser Werte festzulegen. |
+| O-007 | ABGESCHLOSSEN | Für die feste Referenzinstallation gelten 4 CPU-Kerne, 12288 MiB RAM, 4096 MiB Swap und 40 GiB Root-Disk. Die nächste freie VMID wird standardmäßig über Proxmox ermittelt; Storage und Bridge werden nur bei genau einer geeigneten Option automatisch gewählt. `--vmid`, `--storage`, `--bridge`, `--cores`, `--memory`, `--swap` und `--disk` überschreiben die Standardwerte beziehungsweise Auswahl. Mehrdeutige oder fehlende Optionen sowie ungültige Parameter brechen vor jeder Änderung ab. |
+| O-008 | OFFEN | GPU-Unterstützung und insbesondere GPU-Passthrough für RALF Standalone sind nicht entschieden. Eine Umsetzung ist nicht Teil des aktuellen Meilensteins. |
 
 # 4. Abgeschlossene Anweisungen und Entscheidungen
 

--- a/scripts/ralf-standalone-bootstrap.sh
+++ b/scripts/ralf-standalone-bootstrap.sh
@@ -4,6 +4,19 @@ set -Eeuo pipefail
 
 readonly CONTAINER_NAME="ralf-standalone"
 readonly TEMPLATE_PATTERN='ubuntu-26\.04-standard'
+readonly DEFAULT_CORES=4
+readonly DEFAULT_MEMORY_MIB=12288
+readonly DEFAULT_SWAP_MIB=4096
+readonly DEFAULT_DISK_GIB=40
+
+MODE="plan"
+VMID=""
+STORAGE=""
+BRIDGE=""
+CORES="$DEFAULT_CORES"
+MEMORY_MIB="$DEFAULT_MEMORY_MIB"
+SWAP_MIB="$DEFAULT_SWAP_MIB"
+DISK_GIB="$DEFAULT_DISK_GIB"
 
 fail() {
   printf 'Fehler: %s\n' "$*" >&2
@@ -11,7 +24,22 @@ fail() {
 }
 
 usage() {
-  printf 'Aufruf: %s --check\n' "${0##*/}" >&2
+  cat >&2 <<'EOF'
+Aufruf:
+  ralf-standalone-bootstrap.sh [--plan|--check] [OPTIONEN]
+
+Optionen:
+  --vmid ID       VMID; Standard: nächste freie Proxmox-VMID
+  --storage NAME  Ziel-Storage; Standard: genau ein geeigneter Storage
+  --bridge NAME   Netzwerk-Bridge; Standard: genau eine geeignete Bridge
+  --cores N       CPU-Kerne; Standard: 4
+  --memory MIB    Arbeitsspeicher in MiB; Standard: 12288 (12 GiB)
+  --swap MIB      Swap in MiB; Standard: 4096 (4 GiB)
+  --disk GIB      Root-Disk in GiB; Standard: 40
+  --plan          sicheren Konfigurationsplan ausgeben (Standard)
+  --check         Alias für --plan
+  --help          diese Hilfe anzeigen
+EOF
   exit 2
 }
 
@@ -19,32 +47,162 @@ check_command() {
   command -v "$1" >/dev/null 2>&1 || fail "Benötigter Befehl fehlt: $1"
 }
 
-run_preflight() {
+require_value() {
+  local option=$1
+  [[ $# -ge 2 && -n ${2:-} ]] || fail "Fehlender Wert für ${option}."
+}
+
+validate_positive_integer() {
+  local option=$1
+  local value=$2
+  [[ $value =~ ^[0-9]+$ && $value -gt 0 ]] ||
+    fail "Ungültiger Wert für ${option}: ${value}. Erwartet wird eine positive Ganzzahl."
+}
+
+validate_non_negative_integer() {
+  local option=$1
+  local value=$2
+  [[ $value =~ ^[0-9]+$ ]] ||
+    fail "Ungültiger Wert für ${option}: ${value}. Erwartet wird eine nichtnegative Ganzzahl."
+}
+
+parse_args() {
+  while (($#)); do
+    case $1 in
+      --plan|--check)
+        MODE="plan"
+        shift
+        ;;
+      --vmid|--storage|--bridge|--cores|--memory|--swap|--disk)
+        local option=$1
+        shift
+        require_value "$option" "${1:-}"
+        case $option in
+          --vmid) VMID=$1 ;;
+          --storage) STORAGE=$1 ;;
+          --bridge) BRIDGE=$1 ;;
+          --cores) CORES=$1 ;;
+          --memory) MEMORY_MIB=$1 ;;
+          --swap) SWAP_MIB=$1 ;;
+          --disk) DISK_GIB=$1 ;;
+        esac
+        shift
+        ;;
+      --help)
+        usage
+        ;;
+      *)
+        fail "Unbekannte Option: $1"
+        ;;
+    esac
+  done
+}
+
+resources_contain_vmid() {
+  local resources
+  resources=$(pvesh get /cluster/resources --type vm --output-format json) ||
+    fail "Die belegten Proxmox-VMIDs konnten nicht gelesen werden."
+  grep -Eq '"vmid"[[:space:]]*:[[:space:]]*'"$1"'([,}])' <<<"$resources"
+}
+
+resolve_vmid() {
+  local nextid
+  if [[ -z $VMID ]]; then
+    nextid=$(pvesh get /cluster/nextid | tr -d '[:space:]') ||
+      fail "Die nächste freie Proxmox-VMID konnte nicht ermittelt werden."
+    VMID=$nextid
+  fi
+
+  [[ $VMID =~ ^[0-9]+$ && $VMID -ge 100 && $VMID -le 999999999 ]] ||
+    fail "Ungültige VMID: ${VMID}. Erwartet wird eine Ganzzahl zwischen 100 und 999999999."
+  if resources_contain_vmid "$VMID"; then
+    fail "Die VMID ${VMID} ist bereits belegt; es wird nichts überschrieben."
+  fi
+}
+
+storage_candidates() {
+  pvesm status --content rootdir | awk 'NR > 1 && $1 != "" && $3 == "active" { print $1 }'
+}
+
+bridge_candidates() {
+  ip -o link show type bridge | sed -E 's/^[0-9]+: ([^:]+):.*/\1/'
+}
+
+choose_unique() {
+  local kind=$1
+  local requested=$2
+  shift 2
+  local candidates=("$@")
+  local candidate
+
+  if [[ -n $requested ]]; then
+    for candidate in "${candidates[@]}"; do
+      [[ $candidate == "$requested" ]] && return 0
+    done
+    fail "${kind} '${requested}' ist nicht als geeignete aktive Option verfügbar. Verfügbar: ${candidates[*]:-keine}."
+  fi
+
+  ((${#candidates[@]} == 1)) && {
+    printf '%s' "${candidates[0]}"
+    return 0
+  }
+  if ((${#candidates[@]} == 0)); then
+    fail "Keine geeignete ${kind} gefunden. Verfügbare Optionen: keine."
+  fi
+  local option_name=storage
+  [[ $kind == Bridge ]] && option_name=bridge
+  fail "Mehrere geeignete ${kind} gefunden. Bitte --${option_name} wählen: ${candidates[*]}"
+}
+
+resolve_storage_and_bridge() {
+  local -a storages bridges
+  mapfile -t storages < <(storage_candidates) ||
+    fail "Geeignete Storages konnten nicht gelesen werden."
+  mapfile -t bridges < <(bridge_candidates) ||
+    fail "Geeignete Netzwerk-Bridges konnten nicht gelesen werden."
+  STORAGE=$(choose_unique "Storage" "$STORAGE" "${storages[@]}")
+  BRIDGE=$(choose_unique "Bridge" "$BRIDGE" "${bridges[@]}")
+}
+
+validate_values() {
+  validate_positive_integer '--cores' "$CORES"
+  validate_positive_integer '--memory' "$MEMORY_MIB"
+  validate_non_negative_integer '--swap' "$SWAP_MIB"
+  validate_positive_integer '--disk' "$DISK_GIB"
+}
+
+run_plan() {
   local templates
-  local containers
 
-  (( EUID == 0 )) || fail "Der Proxmox-Preflight muss als root ausgeführt werden."
-
+  (( EUID == 0 )) || fail "Der Proxmox-Plan muss als root ausgeführt werden."
   check_command pveversion
   check_command pveam
+  check_command pvesh
+  check_command pvesm
   check_command pct
-
-  pveversion >/dev/null 2>&1 ||
-    fail "Die Proxmox-Version konnte nicht abgefragt werden."
+  check_command ip
+  pveversion >/dev/null 2>&1 || fail "Die Proxmox-Version konnte nicht abgefragt werden."
 
   templates=$(pveam available --section system) ||
     fail "Der Proxmox-Templatekatalog konnte nicht gelesen werden."
   grep -Eq "$TEMPLATE_PATTERN" <<<"$templates" ||
     fail "Kein Ubuntu-26.04-LXC-Template im Proxmox-Katalog gefunden."
 
-  containers=$(pct list) ||
-    fail "Die vorhandenen LXC-Container konnten nicht gelesen werden."
-  if awk -v name="$CONTAINER_NAME" 'NR > 1 && $NF == name { found = 1 } END { exit !found }' <<<"$containers"; then
-    fail "Ein LXC mit dem Namen ${CONTAINER_NAME} existiert bereits."
-  fi
+  validate_values
+  resolve_vmid
+  resolve_storage_and_bridge
 
-  printf 'Preflight erfolgreich: Proxmox ist bereit und der Name %s ist frei.\n' "$CONTAINER_NAME"
+  printf 'Plan erfolgreich; es wurden keine Änderungen vorgenommen.\n'
+  printf '  VMID: %s\n' "$VMID"
+  printf '  Name: %s\n' "$CONTAINER_NAME"
+  printf '  Storage: %s\n' "$STORAGE"
+  printf '  Bridge: %s\n' "$BRIDGE"
+  printf '  CPU: %s Kerne\n' "$CORES"
+  printf '  RAM: %s MiB\n' "$MEMORY_MIB"
+  printf '  Swap: %s MiB\n' "$SWAP_MIB"
+  printf '  Root-Disk: %s GiB\n' "$DISK_GIB"
 }
 
-[[ $# == 1 && $1 == "--check" ]] || usage
-run_preflight
+parse_args "$@"
+[[ $MODE == plan ]] || fail "Unbekannter Ausführungsmodus."
+run_plan

--- a/tests/bootstrap-preflight.sh
+++ b/tests/bootstrap-preflight.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# shellcheck disable=SC2016
+
 set -Eeuo pipefail
 
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
@@ -23,43 +25,47 @@ make_stub() {
   chmod +x "${directory}/${name}"
 }
 
+prepare_stubs() {
+  local directory=$1
+  make_stub "$directory" pveversion 'printf "pve-manager/9.2.4\n"'
+  make_stub "$directory" pveam 'printf "system local:vztmpl/ubuntu-26.04-standard_26.04-1_amd64.tar.zst\n"'
+  make_stub "$directory" pvesh 'case "$*" in */nextid*) printf "2200\n" ;; *) case "${TEST_CASE:-}" in occupied-vmid) printf "[{\"vmid\":2200}]\n" ;; *) printf "[]\n" ;; esac ;; esac'
+  make_stub "$directory" pvesm 'case "${TEST_CASE:-}" in multiple-storage) printf "Name Type Status Total Used Available %%\nlocal dir active 1 0 1 0\nlocal-lvm lvmthin active 1 0 1 0\n" ;; *) printf "Name Type Status Total Used Available %%\nlocal-lvm lvmthin active 1 0 1 0\n" ;; esac'
+  make_stub "$directory" pct 'exit 0'
+  make_stub "$directory" ip 'case "${TEST_CASE:-}" in multiple-bridge) printf "3: vmbr0: <UP>\n4: vmbr1: <UP>\n" ;; *) printf "3: vmbr0: <UP>\n" ;; esac'
+}
+
 run_case() {
   local name=$1
   local expected_status=$2
   local expected_text=$3
+  shift 3
   local stub_dir="${TEST_ROOT}/${name}"
   local output
   local status
 
-  make_stub "$stub_dir" pveversion 'printf "pve-manager/9.2.4\\n"'
-  make_stub "$stub_dir" pveam 'printf "system local:vztmpl/ubuntu-26.04-standard_26.04-1_amd64.tar.zst\\n"'
-  make_stub "$stub_dir" pct 'printf "VMID Status Lock Name\\n"'
-
-  case "$name" in
-    missing-template)
-      make_stub "$stub_dir" pveam 'printf "system local:vztmpl/debian-13-standard_13.0-1_amd64.tar.zst\\n"'
-      ;;
-    existing-container)
-      make_stub "$stub_dir" pct 'printf "VMID Status Lock Name\\n2200 stopped - ralf-standalone\\n"'
-      ;;
-  esac
-
+  prepare_stubs "$stub_dir"
   set +e
-  output=$(PATH="${stub_dir}:/usr/bin:/bin" "$SCRIPT" --check 2>&1)
+  output=$(TEST_CASE="$name" PATH="${stub_dir}:/usr/bin:/bin" "$SCRIPT" --plan "$@" 2>&1)
   status=$?
   set -e
 
-  [[ $status == "$expected_status" ]] ||
+  [[ $status == "$expected_status" ]] || {
     printf 'FAIL %s: Status %s statt %s\n%s\n' "$name" "$status" "$expected_status" "$output" >&2
-  [[ $status == "$expected_status" ]] || return 1
-
-  grep -Fq "$expected_text" <<<"$output" ||
+    return 1
+  }
+  grep -Fq "$expected_text" <<<"$output" || {
     printf 'FAIL %s: Ausgabe enthält nicht: %s\n%s\n' "$name" "$expected_text" "$output" >&2
-  grep -Fq "$expected_text" <<<"$output" || return 1
-
+    return 1
+  }
   printf 'PASS %s\n' "$name"
 }
 
-run_case success 0 'Preflight erfolgreich'
-run_case missing-template 1 'Kein Ubuntu-26.04-LXC-Template'
-run_case existing-container 1 'existiert bereits'
+run_case valid-defaults 0 'RAM: 12288 MiB'
+run_case valid-overrides 0 'CPU: 8 Kerne' --vmid 2300 --storage local-lvm --bridge vmbr0 --cores 8 --memory 16384 --swap 8192 --disk 60
+run_case occupied-vmid 1 'bereits belegt'
+run_case multiple-storage 1 'Mehrere geeignete Storage'
+run_case multiple-bridge 1 'Mehrere geeignete Bridge'
+run_case invalid-memory 1 'Ungültiger Wert für --memory' --memory nope
+run_case unknown-option 1 'Unbekannte Option: --wat' --wat
+run_case missing-value 1 'Fehlender Wert für --cores' --cores


### PR DESCRIPTION
## Änderungen

- schließt O-007 mit festen Referenzwerten ab: 4 Kerne, 12288 MiB RAM, 4096 MiB Swap, 40 GiB Disk
- ergänzt automatische Auswahl von nächster freier VMID, eindeutigem Storage und eindeutiger Bridge
- ergänzt strikte CLI-Parameter für VMID, Storage, Bridge, Kerne, RAM, Swap und Disk
- bricht bei ungültigen, fehlenden, belegten oder mehrdeutigen Werten vor jeder Mutation ab
- dokumentiert O-008 als separate offene GPU-Entscheidung

## Sicherheit

Der Durchlauf implementiert ausschließlich Plan/Preflight. Es gibt keinen `pct create`, keine Storage-/Netzwerkänderung und kein GPU-Passthrough.

## Prüfungen

- `bash -n`
- ShellCheck ohne Befund
- acht gültige und ungültige Parameter-/Auswahltests
- realer read-only Plan auf dem Proxmox-Host
- `git diff --check`
- `secrets/` nicht gestaged