### PR TITLE
Sicheren LXC-Apply-Pfad ergänzen

### DIFF
--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -155,3 +155,14 @@ Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge ble
 - Risiken oder Blocker: Die konkrete LXC-Erstellung und die Installation von Ubuntu-Aktualisierungen, Ollama, Modell und Open WebUI stehen weiterhin aus. O-008 bleibt für GPU-Unterstützung offen.
 - Nächster sinnvoller Zielbild-Eintrag: M-017 – sichere LXC-Erstellung auf Basis des validierten Plans.
 - Veröffentlichung: Die Änderungen werden gemeinsam committed, gepusht und nach `main` gemergt.
+
+## 2026-07-31 – Sicheren Apply-Pfad für LXC-Erstellung implementiert
+
+- Bearbeitete Zielbild-IDs: M-017, M-023, D-001, P-001
+- Ergebnis: `--apply` wiederholt den vollständigen Preflight, vergleicht den unmittelbaren Plan und ruft anschließend genau einmal `pct create` mit unprivilegiertem LXC, DHCP, Referenzressourcen, Root-Disk und ohne Mountpoints oder GPU-Features auf. Die erzeugte Konfiguration und der gestoppte Status werden read-only geprüft. Bei Create- oder Prüfungsfehlern erfolgt kein automatisches Rollback; der Zustand wird eindeutig ausgegeben.
+- Geänderte Dateien: `scripts/ralf-standalone-bootstrap.sh`, `tests/bootstrap-apply.sh`, `tests/bootstrap-preflight.sh`, `README.md`, `ZIELBILD.md`, `Ergebnis.md`
+- Ausgeführte Prüfungen: `bash -n`, ShellCheck, bestehende Preflight-Tests, Apply-Mocktests für Plan/Check ohne Create, exakte Overrides, belegte VMID, vorhandenen Namen, fehlendes Template, ungültigen Storage, ungültige Bridge, `pct create`-Fehler, erfolgreiche Create-Konfigurationsprüfung, unbekannte und widersprüchliche Optionen sowie `git diff --check`.
+- Nicht ausgeführte Prüfungen: Kein realer `--apply`-Lauf und kein realer LXC wurden erstellt, gestartet, gestoppt oder gelöscht; dies war ausdrücklich ausgeschlossen.
+- Risiken oder Blocker: D-001 bleibt `AKTIV`, bis ein realer LXC erfolgreich erstellt und geprüft wurde. Softwareinstallation und O-008 GPU-Entscheidung bleiben offen. Bei einem fehlgeschlagenen `pct create` wird kein automatisches Rollback versucht.
+- Nächster sinnvoller Zielbild-Eintrag: Ein ausdrücklich beauftragter realer `--apply`-Validierungslauf für D-001.
+- Veröffentlichung: Die Änderungen werden gemeinsam committed, gepusht und nach `main` gemergt.

--- a/README.md
+++ b/README.md
@@ -65,11 +65,19 @@ Der erste ungefährliche Teil des Proxmox-Bootstraps prüft ausschließlich die 
 sudo ./scripts/ralf-standalone-bootstrap.sh --plan
 ```
 
-`--check` ist ein kompatibler Alias. Der Plan ermittelt die nächste freie VMID sowie Storage und Bridge nur dann automatisch, wenn jeweils genau eine geeignete Option vorhanden ist. Alternativ können `--vmid`, `--storage`, `--bridge`, `--cores`, `--memory`, `--swap` und `--disk` explizit gesetzt werden. Speicher und Swap werden in MiB, die Root-Disk in GiB angegeben. Ungültige, fehlende oder mehrdeutige Werte brechen ohne LXC-Änderung ab. Die eigentliche Container-Erstellung ist noch nicht implementiert.
+`--check` ist ein kompatibler Alias. Der Plan ermittelt die nächste freie VMID sowie Storage und Bridge nur dann automatisch, wenn jeweils genau eine geeignete Option vorhanden ist. Alternativ können `--vmid`, `--storage`, `--bridge`, `--cores`, `--memory`, `--swap` und `--disk` explizit gesetzt werden. Speicher und Swap werden in MiB, die Root-Disk in GiB angegeben. Ungültige, fehlende oder mehrdeutige Werte brechen ohne LXC-Änderung ab.
+
+Die ausdrückliche Erstellung erfolgt erst mit `--apply`:
+
+```bash
+sudo ./scripts/ralf-standalone-bootstrap.sh --apply
+```
+
+`--apply` wiederholt den vollständigen Plan unmittelbar vor der Mutation, ruft genau einmal `pct create` auf und prüft die erzeugte LXC-Konfiguration anschließend read-only. Der Container bleibt gestoppt; Softwareinstallation, GPU-Passthrough und automatisches Rollback sind nicht Bestandteil dieses Schritts. Ein realer `--apply`-Lauf ist bisher nicht ausgeführt.
 
 ## Status
 
-Die grundlegenden Entscheidungen für RALF Standalone 0.0.1 sind abgeschlossen. Implementiert ist bislang nur der read-only Bootstrap- und Ressourcenplan; Container-Erstellung, Softwareinstallation und vollständige Definition of Done stehen noch aus.
+Die grundlegenden Entscheidungen für RALF Standalone 0.0.1 sind abgeschlossen. Implementiert sind der read-only Bootstrap-/Ressourcenplan und der ausdrückliche, noch nicht real ausgeführte Apply-Pfad; Softwareinstallation und vollständige Definition of Done stehen noch aus.
 
 ## Lizenz
 

--- a/ZIELBILD.md
+++ b/ZIELBILD.md
@@ -70,6 +70,7 @@ Eine feste und reproduzierbare erste Installation soll auf der vorhandenen Proxm
 | M-020 | AKTIV | Für RALF Standalone 0.0.1 werden keine separaten Proxmox-Mountpoints eingerichtet. Persistente Daten liegen im Root-Dateisystem des LXC unter `/etc/ralf/`, `/var/lib/ralf/ollama/`, `/var/lib/ralf/webui/` und `/var/log/ralf/`. Die Sicherung erfolgt zunächst über normale Proxmox-Backups des LXC. |
 | M-021 | AKTIV | Die feste Referenzinstallation verwendet 4 CPU-Kerne, 12288 MiB RAM, 4096 MiB Swap und eine 40-GiB-Root-Disk. Diese Werte sind Referenzwerte der ersten Installation und keine allgemeinen Mindestanforderungen. VMID, Storage und Bridge werden standardmäßig sicher ermittelt; die Werte können über explizite CLI-Parameter überschrieben werden. |
 | M-022 | AKTIV | Der Plan-/Preflight-Pfad validiert alle Ressourcenparameter und bricht bei ungültigen oder unvollständigen Angaben sowie bei nicht eindeutiger automatischer Storage- oder Bridge-Auswahl vor jeder LXC-Mutation mit verständlicher Ausgabe ab. Eine belegte VMID wird niemals überschrieben. |
+| M-023 | AKTIV | `--apply` wiederholt den vollständigen Plan unmittelbar vor der Mutation, ruft genau einmal `pct create` für den unprivilegierten `ralf-standalone`-LXC auf und prüft die resultierende Konfiguration read-only. Der Container bleibt gestoppt; Softwareinstallation, GPU-Passthrough und automatisches Rollback sind nicht Bestandteil dieses Schritts. |
 
 ## Definition of Done
 

--- a/scripts/ralf-standalone-bootstrap.sh
+++ b/scripts/ralf-standalone-bootstrap.sh
@@ -9,7 +9,7 @@ readonly DEFAULT_MEMORY_MIB=12288
 readonly DEFAULT_SWAP_MIB=4096
 readonly DEFAULT_DISK_GIB=40
 
-MODE="plan"
+MODE=""
 VMID=""
 STORAGE=""
 BRIDGE=""
@@ -17,16 +17,34 @@ CORES="$DEFAULT_CORES"
 MEMORY_MIB="$DEFAULT_MEMORY_MIB"
 SWAP_MIB="$DEFAULT_SWAP_MIB"
 DISK_GIB="$DEFAULT_DISK_GIB"
+TEMPLATE=""
+PCT_CREATE_ATTEMPTED=0
 
 fail() {
   printf 'Fehler: %s\n' "$*" >&2
+  if [[ $MODE == apply ]]; then
+    if ((PCT_CREATE_ATTEMPTED == 0)); then
+      printf 'Container erstellt: nein; kein pct create wurde ausgeführt.\n' >&2
+      printf '  VMID: %s\n' "${VMID:-nicht ermittelt}" >&2
+      printf '  Zustand: nicht gestartet; keine Infrastrukturmutation erfolgt.\n' >&2
+      printf '  Nächster manueller Schritt: Fehler beheben und den Apply-Plan erneut prüfen.\n' >&2
+    else
+      printf 'Container erstellt: unbekannt; ein Fehler trat nach dem pct create-Aufruf auf.\n' >&2
+      printf '  VMID: %s\n  Zustand: nicht sicher validiert\n  Rollback: nicht automatisch ausgeführt.\n' "$VMID" >&2
+    fi
+  fi
   exit 1
 }
 
 usage() {
   cat >&2 <<'EOF'
 Aufruf:
-  ralf-standalone-bootstrap.sh [--plan|--check] [OPTIONEN]
+  ralf-standalone-bootstrap.sh (--plan|--check|--apply) [OPTIONEN]
+
+Modi:
+  --plan          sicheren Konfigurationsplan ausgeben (read-only)
+  --check         Alias für --plan
+  --apply         nach erneutem Preflight genau einen LXC erstellen
 
 Optionen:
   --vmid ID       VMID; Standard: nächste freie Proxmox-VMID
@@ -36,11 +54,21 @@ Optionen:
   --memory MIB    Arbeitsspeicher in MiB; Standard: 12288 (12 GiB)
   --swap MIB      Swap in MiB; Standard: 4096 (4 GiB)
   --disk GIB      Root-Disk in GiB; Standard: 40
-  --plan          sicheren Konfigurationsplan ausgeben (Standard)
-  --check         Alias für --plan
   --help          diese Hilfe anzeigen
 EOF
   exit 2
+}
+
+fail_mode_conflict() {
+  fail "Widersprüchliche Ausführungsmodi: --${1} und --${2} dürfen nicht gemeinsam verwendet werden."
+}
+
+select_mode() {
+  local requested=$1
+  if [[ -n $MODE && $MODE != "$requested" ]]; then
+    fail_mode_conflict "$MODE" "$requested"
+  fi
+  MODE=$requested
 }
 
 check_command() {
@@ -69,10 +97,9 @@ validate_non_negative_integer() {
 parse_args() {
   while (($#)); do
     case $1 in
-      --plan|--check)
-        MODE="plan"
-        shift
-        ;;
+      --plan) select_mode plan; shift ;;
+      --check) select_mode plan; shift ;;
+      --apply) select_mode apply; shift ;;
       --vmid|--storage|--bridge|--cores|--memory|--swap|--disk)
         local option=$1
         shift
@@ -88,14 +115,11 @@ parse_args() {
         esac
         shift
         ;;
-      --help)
-        usage
-        ;;
-      *)
-        fail "Unbekannte Option: $1"
-        ;;
+      --help) usage ;;
+      *) fail "Unbekannte Option: $1" ;;
     esac
   done
+  [[ -n $MODE ]] || MODE=plan
 }
 
 resources_contain_vmid() {
@@ -103,6 +127,12 @@ resources_contain_vmid() {
   resources=$(pvesh get /cluster/resources --type vm --output-format json) ||
     fail "Die belegten Proxmox-VMIDs konnten nicht gelesen werden."
   grep -Eq '"vmid"[[:space:]]*:[[:space:]]*'"$1"'([,}])' <<<"$resources"
+}
+
+name_is_in_use() {
+  local containers
+  containers=$(pct list) || fail "Die vorhandenen LXC-Container konnten nicht gelesen werden."
+  awk -v name="$CONTAINER_NAME" 'NR > 1 && $NF == name { found = 1 } END { exit !found }' <<<"$containers"
 }
 
 resolve_vmid() {
@@ -117,6 +147,9 @@ resolve_vmid() {
     fail "Ungültige VMID: ${VMID}. Erwartet wird eine Ganzzahl zwischen 100 und 999999999."
   if resources_contain_vmid "$VMID"; then
     fail "Die VMID ${VMID} ist bereits belegt; es wird nichts überschrieben."
+  fi
+  if name_is_in_use; then
+    fail "Ein LXC namens ${CONTAINER_NAME} existiert bereits; es wird nichts überschrieben."
   fi
 }
 
@@ -137,7 +170,10 @@ choose_unique() {
 
   if [[ -n $requested ]]; then
     for candidate in "${candidates[@]}"; do
-      [[ $candidate == "$requested" ]] && return 0
+      if [[ $candidate == "$requested" ]]; then
+        printf '%s' "$requested"
+        return 0
+      fi
     done
     fail "${kind} '${requested}' ist nicht als geeignete aktive Option verfügbar. Verfügbar: ${candidates[*]:-keine}."
   fi
@@ -164,6 +200,26 @@ resolve_storage_and_bridge() {
   BRIDGE=$(choose_unique "Bridge" "$BRIDGE" "${bridges[@]}")
 }
 
+resolve_template() {
+  local catalog
+  local storage
+  local template
+  local -a template_storages templates
+  catalog=$(pveam available --section system) ||
+    fail "Der Proxmox-Templatekatalog konnte nicht gelesen werden."
+  grep -Eq "$TEMPLATE_PATTERN" <<<"$catalog" ||
+    fail "Kein Ubuntu-26.04-LXC-Template im Proxmox-Katalog gefunden."
+  mapfile -t template_storages < <(pvesm status --content vztmpl | awk 'NR > 1 && $1 != "" && $3 == "active" { print $1 }')
+  for storage in "${template_storages[@]}"; do
+    while IFS= read -r template; do
+      [[ -n $template ]] && templates+=("$template")
+    done < <(pveam list "$storage" | awk -v pattern="$TEMPLATE_PATTERN" '$1 ~ pattern { print $1 }')
+  done
+  ((${#templates[@]} > 0)) ||
+    fail "Kein Ubuntu-26.04-LXC-Template in einem aktiven Template-Storage gefunden."
+  TEMPLATE=$(printf '%s\n' "${templates[@]}" | sort -V | tail -n1)
+}
+
 validate_values() {
   validate_positive_integer '--cores' "$CORES"
   validate_positive_integer '--memory' "$MEMORY_MIB"
@@ -171,9 +227,7 @@ validate_values() {
   validate_positive_integer '--disk' "$DISK_GIB"
 }
 
-run_plan() {
-  local templates
-
+validate_plan() {
   (( EUID == 0 )) || fail "Der Proxmox-Plan muss als root ausgeführt werden."
   check_command pveversion
   check_command pveam
@@ -182,19 +236,18 @@ run_plan() {
   check_command pct
   check_command ip
   pveversion >/dev/null 2>&1 || fail "Die Proxmox-Version konnte nicht abgefragt werden."
-
-  templates=$(pveam available --section system) ||
-    fail "Der Proxmox-Templatekatalog konnte nicht gelesen werden."
-  grep -Eq "$TEMPLATE_PATTERN" <<<"$templates" ||
-    fail "Kein Ubuntu-26.04-LXC-Template im Proxmox-Katalog gefunden."
-
+  resolve_template
   validate_values
   resolve_vmid
   resolve_storage_and_bridge
+}
 
-  printf 'Plan erfolgreich; es wurden keine Änderungen vorgenommen.\n'
+print_plan() {
+  local prefix=$1
+  printf '%s\n' "$prefix"
   printf '  VMID: %s\n' "$VMID"
   printf '  Name: %s\n' "$CONTAINER_NAME"
+  printf '  Template: %s\n' "$TEMPLATE"
   printf '  Storage: %s\n' "$STORAGE"
   printf '  Bridge: %s\n' "$BRIDGE"
   printf '  CPU: %s Kerne\n' "$CORES"
@@ -203,6 +256,122 @@ run_plan() {
   printf '  Root-Disk: %s GiB\n' "$DISK_GIB"
 }
 
+verify_created_config() {
+  local config=$1
+  if ! grep -Eq '^unprivileged: 1$' <<<"$config"; then
+    printf 'Fehler: Erzeugte Konfiguration ist nicht unprivilegiert.\n' >&2
+    return 1
+  fi
+  if ! grep -Eq "^hostname: ${CONTAINER_NAME}$" <<<"$config"; then
+    printf 'Fehler: Hostname der erzeugten Konfiguration stimmt nicht.\n' >&2
+    return 1
+  fi
+  if ! grep -Eq "^cores: ${CORES}$" <<<"$config"; then
+    printf 'Fehler: CPU-Konfiguration stimmt nicht.\n' >&2
+    return 1
+  fi
+  if ! grep -Eq "^memory: ${MEMORY_MIB}$" <<<"$config"; then
+    printf 'Fehler: RAM-Konfiguration stimmt nicht.\n' >&2
+    return 1
+  fi
+  if ! grep -Eq "^swap: ${SWAP_MIB}$" <<<"$config"; then
+    printf 'Fehler: Swap-Konfiguration stimmt nicht.\n' >&2
+    return 1
+  fi
+  if ! grep -Eq "^rootfs: ${STORAGE}:.*size=${DISK_GIB}G([,[:space:]]|$)" <<<"$config"; then
+    printf 'Fehler: Root-Disk-Konfiguration stimmt nicht.\n' >&2
+    return 1
+  fi
+  if ! grep -Eq "^net0: .*bridge=${BRIDGE}(,|$).*ip=dhcp(,|$)" <<<"$config"; then
+    printf 'Fehler: DHCP-Bridge-Konfiguration stimmt nicht.\n' >&2
+    return 1
+  fi
+  if grep -Eq '^mp[0-9]+:' <<<"$config"; then
+    printf 'Fehler: Die erzeugte Konfiguration enthält unerwartete Mountpoints.\n' >&2
+    return 1
+  fi
+  if grep -Eq '^features:.*(keyctl|nesting|fuse|mount|mknod)' <<<"$config"; then
+    printf 'Fehler: Die erzeugte Konfiguration enthält unnötige privilegierte Features.\n' >&2
+    return 1
+  fi
+}
+
+report_failed_create() {
+  local state="nicht in pct config sichtbar"
+  if pct config "$VMID" >/dev/null 2>&1; then
+    state="in pct config registriert; mögliche Teilressource"
+  fi
+  printf 'Container erstellt: nein bestätigt; pct create ist fehlgeschlagen.\n' >&2
+  printf '  VMID: %s\n' "$VMID" >&2
+  printf '  Zustand: %s\n' "$state" >&2
+  printf '  Rollback: nicht automatisch ausgeführt.\n' >&2
+  printf '  Nächster manueller Schritt: Zustand und Proxmox-Storage prüfen.\n' >&2
+}
+
+run_plan() {
+  validate_plan
+  print_plan 'Plan erfolgreich; es wurden keine Änderungen vorgenommen.'
+}
+
+run_apply() {
+  local first_vmid first_storage first_bridge first_template
+  local create_output config status_output
+  validate_plan
+  first_vmid=$VMID
+  first_storage=$STORAGE
+  first_bridge=$BRIDGE
+  first_template=$TEMPLATE
+
+  validate_plan
+  [[ $VMID == "$first_vmid" && $STORAGE == "$first_storage" &&
+    $BRIDGE == "$first_bridge" && $TEMPLATE == "$first_template" ]] ||
+    fail "Der unmittelbare Preflight lieferte einen geänderten Plan (zuvor VMID=${first_vmid}, Storage=${first_storage}, Bridge=${first_bridge}, Template=${first_template}; jetzt VMID=${VMID}, Storage=${STORAGE}, Bridge=${BRIDGE}, Template=${TEMPLATE}); es wurde nichts erstellt."
+  print_plan 'Unmittelbarer Preflight erfolgreich; genau ein LXC wird erstellt.'
+
+  PCT_CREATE_ATTEMPTED=1
+  if ! create_output=$(pct create "$VMID" "$TEMPLATE" \
+    --hostname "$CONTAINER_NAME" \
+    --unprivileged 1 \
+    --cores "$CORES" \
+    --memory "$MEMORY_MIB" \
+    --swap "$SWAP_MIB" \
+    --rootfs "${STORAGE}:${DISK_GIB}" \
+    --net0 "name=eth0,bridge=${BRIDGE},ip=dhcp,type=veth" \
+    --ostype ubuntu 2>&1); then
+    printf '%s\n' "$create_output" >&2
+    report_failed_create
+    return 1
+  fi
+
+  if ! config=$(pct config "$VMID"); then
+    printf 'Container erstellt: ja; read-only Konfigurationsprüfung konnte nicht gelesen werden.\n' >&2
+    printf '  VMID: %s\n  Zustand: erstellt, aber nicht validiert\n  Rollback: nicht automatisch ausgeführt.\n' "$VMID" >&2
+    return 1
+  fi
+  if ! verify_created_config "$config"; then
+    printf 'Container erstellt: ja; Konfigurationsprüfung fehlgeschlagen.\n' >&2
+    printf '  VMID: %s\n  Zustand: erstellt, aber nicht validiert\n  Rollback: nicht automatisch ausgeführt.\n' "$VMID" >&2
+    return 1
+  fi
+  if ! status_output=$(pct status "$VMID"); then
+    printf 'Container erstellt: ja; Status konnte nicht read-only gelesen werden.\n' >&2
+    printf '  VMID: %s\n  Zustand: erstellt, aber nicht validiert\n  Rollback: nicht automatisch ausgeführt.\n' "$VMID" >&2
+    return 1
+  fi
+  if ! grep -Eq 'status: stopped$' <<<"$status_output"; then
+    printf 'Container erstellt: ja; Container ist nicht erwartungsgemäß gestoppt.\n' >&2
+    printf '  VMID: %s\n  Zustand: gestartet oder unbekannt\n  Rollback: nicht automatisch ausgeführt.\n' "$VMID" >&2
+    return 1
+  fi
+  printf 'Container erstellt: ja\n'
+  printf '  VMID: %s\n' "$VMID"
+  printf '  Zustand: gestoppt (kein automatischer Start)\n'
+  printf '  Nächster manueller Schritt: Softwareinstallation in einem separaten Arbeitsdurchlauf.\n'
+}
+
 parse_args "$@"
-[[ $MODE == plan ]] || fail "Unbekannter Ausführungsmodus."
-run_plan
+if [[ $MODE == apply ]]; then
+  run_apply
+else
+  run_plan
+fi

--- a/tests/bootstrap-apply.sh
+++ b/tests/bootstrap-apply.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2016
+
+set -Eeuo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+readonly PROJECT_ROOT
+readonly SCRIPT="${PROJECT_ROOT}/scripts/ralf-standalone-bootstrap.sh"
+TEST_ROOT=$(mktemp -d)
+readonly TEST_ROOT
+trap 'rm -rf -- "$TEST_ROOT"' EXIT
+
+make_stub() {
+  local directory=$1
+  local name=$2
+  local body=$3
+
+  mkdir -p "$directory"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'set -Eeuo pipefail\n'
+    printf '%s\n' "$body"
+  } >"${directory}/${name}"
+  chmod +x "${directory}/${name}"
+}
+
+prepare_stubs() {
+  local directory=$1
+  make_stub "$directory" pveversion 'printf "pve-manager/9.2.4\n"'
+  make_stub "$directory" pveam 'case "$1" in available) case "${TEST_CASE:-}" in missing-template) printf "system debian-13-standard_13.6-1_amd64.tar.zst\n" ;; *) printf "system ubuntu-26.04-standard_26.04-1_amd64.tar.zst\n" ;; esac ;; list) printf "NAME SIZE\nlocal:vztmpl/ubuntu-26.04-standard_26.04-1_amd64.tar.zst 151\n" ;; esac'
+  make_stub "$directory" pvesh 'printf "pvesh %s\n" "$*" >> "$CALL_LOG"; case "$*" in */nextid*) printf "2200\n" ;; *) case "${TEST_CASE:-}" in occupied-vmid) printf "[{\"vmid\":2200}]\n" ;; *) printf "[]\n" ;; esac ;; esac'
+  make_stub "$directory" pvesm 'case "$*" in *vztmpl*) printf "Name Type Status Total Used Available %%\nlocal dir active 1 0 1 0\n" ;; *) printf "Name Type Status Total Used Available %%\nlocal-lvm lvmthin active 1 0 1 0\n" ;; esac'
+  make_stub "$directory" ip 'case "${TEST_CASE:-}" in multiple-bridge) printf "3: vmbr0: <UP>\n4: vmbr1: <UP>\n" ;; *) printf "3: vmbr0: <UP>\n" ;; esac'
+  make_stub "$directory" pct 'printf "%s\n" "$*" >> "$PCT_LOG"; case "$1" in list) case "${TEST_CASE:-}" in existing-name) printf "VMID Status Lock Name\n2300 stopped - ralf-standalone\n" ;; *) printf "VMID Status Lock Name\n" ;; esac ;; config) [[ -e "$CREATED" ]] || exit 1; printf "unprivileged: 1\nhostname: ralf-standalone\ncores: %s\nmemory: %s\nswap: %s\nrootfs: %s:vm-2200-disk-0,size=%sG\nnet0: name=eth0,bridge=%s,ip=dhcp,type=veth\n" "$EXPECT_CORES" "$EXPECT_MEMORY" "$EXPECT_SWAP" "$EXPECT_STORAGE" "$EXPECT_DISK" "$EXPECT_BRIDGE" ;; status) [[ -e "$CREATED" ]] || exit 1; printf "status: stopped\n" ;; create) case "${TEST_CASE:-}" in create-failure) printf "mock pct create failed\n" >&2; exit 7 ;; *) touch "$CREATED"; printf "mock pct create succeeded\n" ;; esac ;; *) exit 1 ;; esac'
+}
+
+run_case() {
+  local name=$1
+  local expected_status=$2
+  local expected_text=$3
+  shift 3
+  local stub_dir="${TEST_ROOT}/${name}"
+  local pct_log="${stub_dir}/pct.log"
+  local call_log="${stub_dir}/calls.log"
+  local created="${stub_dir}/created"
+  local output
+  local status
+
+  prepare_stubs "$stub_dir"
+  set +e
+  output=$(TEST_CASE="$name" PCT_LOG="$pct_log" CALL_LOG="$call_log" CREATED="$created" \
+    EXPECT_CORES="${EXPECT_CORES:-4}" EXPECT_MEMORY="${EXPECT_MEMORY:-12288}" \
+    EXPECT_SWAP="${EXPECT_SWAP:-4096}" EXPECT_STORAGE="${EXPECT_STORAGE:-local-lvm}" \
+    EXPECT_DISK="${EXPECT_DISK:-40}" EXPECT_BRIDGE="${EXPECT_BRIDGE:-vmbr0}" \
+    PATH="${stub_dir}:/usr/bin:/bin" "$SCRIPT" "$@" 2>&1)
+  status=$?
+  set -e
+
+  [[ $status == "$expected_status" ]] || {
+    printf 'FAIL %s: Status %s statt %s\n%s\n' "$name" "$status" "$expected_status" "$output" >&2
+    return 1
+  }
+  grep -Fq "$expected_text" <<<"$output" || {
+    printf 'FAIL %s: Ausgabe enthält nicht: %s\n%s\n' "$name" "$expected_text" "$output" >&2
+    return 1
+  }
+  printf 'PASS %s\n' "$name"
+
+  case "$name" in
+    plan-no-create|check-no-create|occupied-vmid|existing-name|missing-template|invalid-storage|invalid-bridge|unknown-option)
+      if [[ -f $pct_log ]] && grep -Eq '^create ' "$pct_log"; then
+        printf 'FAIL %s: pct create wurde aufgerufen\n' "$name" >&2
+        return 1
+      fi
+      ;;
+    apply-success)
+      [[ $(grep -Ec '^create ' "$pct_log") == 1 ]] || { printf 'FAIL %s: nicht genau ein pct create\n' "$name" >&2; return 1; }
+      grep -Fq 'create 2200 local:vztmpl/ubuntu-26.04-standard' "$pct_log" || { printf 'FAIL %s: VMID/Template fehlen\n' "$name" >&2; return 1; }
+      grep -Fq -- '--unprivileged 1 --cores 8 --memory 16384 --swap 8192 --rootfs local-lvm:60 --net0 name=eth0,bridge=vmbr0,ip=dhcp,type=veth' "$pct_log" || { printf 'FAIL %s: Ressourcenwerte fehlen\n' "$name" >&2; return 1; }
+      ;;
+    create-failure)
+      [[ $(grep -Ec '^create ' "$pct_log") == 1 ]] || { printf 'FAIL %s: pct create nicht genau einmal aufgerufen\n' "$name" >&2; return 1; }
+      ;;
+  esac
+}
+
+run_case plan-no-create 0 'Plan erfolgreich' --plan
+run_case check-no-create 0 'Plan erfolgreich' --check
+EXPECT_CORES=8 EXPECT_MEMORY=16384 EXPECT_SWAP=8192 EXPECT_STORAGE=local-lvm EXPECT_DISK=60 EXPECT_BRIDGE=vmbr0 \
+  run_case apply-success 0 'Container erstellt: ja' --apply --vmid 2200 --storage local-lvm --bridge vmbr0 --cores 8 --memory 16384 --swap 8192 --disk 60
+run_case occupied-vmid 1 'bereits belegt' --apply --vmid 2200
+run_case existing-name 1 'existiert bereits' --apply
+run_case missing-template 1 'Kein Ubuntu-26.04-LXC-Template' --apply
+run_case invalid-storage 1 'nicht als geeignete aktive Option' --apply --storage missing
+run_case invalid-bridge 1 'nicht als geeignete aktive Option' --apply --bridge vmbr9
+run_case create-failure 1 'Container erstellt: nein bestätigt' --apply
+run_case unknown-option 1 'Unbekannte Option: --wat' --apply --wat
+run_case conflicting-mode 1 'Widersprüchliche Ausführungsmodi' --plan --apply

--- a/tests/bootstrap-preflight.sh
+++ b/tests/bootstrap-preflight.sh
@@ -28,9 +28,9 @@ make_stub() {
 prepare_stubs() {
   local directory=$1
   make_stub "$directory" pveversion 'printf "pve-manager/9.2.4\n"'
-  make_stub "$directory" pveam 'printf "system local:vztmpl/ubuntu-26.04-standard_26.04-1_amd64.tar.zst\n"'
+  make_stub "$directory" pveam 'case "$1" in available) printf "system ubuntu-26.04-standard_26.04-1_amd64.tar.zst\n" ;; list) printf "NAME SIZE\nlocal:vztmpl/ubuntu-26.04-standard_26.04-1_amd64.tar.zst 151\n" ;; esac'
   make_stub "$directory" pvesh 'case "$*" in */nextid*) printf "2200\n" ;; *) case "${TEST_CASE:-}" in occupied-vmid) printf "[{\"vmid\":2200}]\n" ;; *) printf "[]\n" ;; esac ;; esac'
-  make_stub "$directory" pvesm 'case "${TEST_CASE:-}" in multiple-storage) printf "Name Type Status Total Used Available %%\nlocal dir active 1 0 1 0\nlocal-lvm lvmthin active 1 0 1 0\n" ;; *) printf "Name Type Status Total Used Available %%\nlocal-lvm lvmthin active 1 0 1 0\n" ;; esac'
+  make_stub "$directory" pvesm 'case "$*" in *vztmpl*) printf "Name Type Status Total Used Available %%\nlocal dir active 1 0 1 0\n" ;; *) case "${TEST_CASE:-}" in multiple-storage) printf "Name Type Status Total Used Available %%\nlocal dir active 1 0 1 0\nlocal-lvm lvmthin active 1 0 1 0\n" ;; *) printf "Name Type Status Total Used Available %%\nlocal-lvm lvmthin active 1 0 1 0\n" ;; esac ;; esac'
   make_stub "$directory" pct 'exit 0'
   make_stub "$directory" ip 'case "${TEST_CASE:-}" in multiple-bridge) printf "3: vmbr0: <UP>\n4: vmbr1: <UP>\n" ;; *) printf "3: vmbr0: <UP>\n" ;; esac'
 }


### PR DESCRIPTION
## Änderungen

- ergänzt `--apply` neben `--plan` und `--check`
- wiederholt den vollständigen Preflight unmittelbar vor `pct create`
- ruft genau einmal `pct create` mit unprivilegiertem LXC, DHCP, Ressourcenwerten und ohne Mountpoints/GPU-Features auf
- prüft die erzeugte Konfiguration und den gestoppten Status read-only
- gibt bei Vorab- oder Create-Fehlern Zustand und fehlendes Rollback eindeutig aus
- ergänzt Mocktests und trennt Plan-/Apply-Dokumentation

## Grenzen

Kein realer `--apply`-Lauf, keine Softwareinstallation, kein Start/Stop/Destroy und kein GPU-Passthrough.

## Prüfungen

- `bash -n`
- ShellCheck ohne Befund
- bestehende Preflight-Tests
- Apply-Mocktests für alle geforderten Fehler- und Erfolgsfälle
- realer read-only `--plan`
- `git diff --check`
- `secrets/` nicht gestaged