### PR TITLE
D-001 reale LXC-Erstellung dokumentieren

### DIFF
--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -166,3 +166,14 @@ Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge ble
 - Risiken oder Blocker: D-001 bleibt `AKTIV`, bis ein realer LXC erfolgreich erstellt und geprüft wurde. Softwareinstallation und O-008 GPU-Entscheidung bleiben offen. Bei einem fehlgeschlagenen `pct create` wird kein automatisches Rollback versucht.
 - Nächster sinnvoller Zielbild-Eintrag: Ein ausdrücklich beauftragter realer `--apply`-Validierungslauf für D-001.
 - Veröffentlichung: Die Änderungen werden gemeinsam committed, gepusht und nach `main` gemergt.
+
+## 2026-07-31 – D-001 real validiert
+
+- Bearbeitete Zielbild-IDs: M-017, M-023, D-001, P-001
+- Ergebnis: Der bestätigte Plan wurde genau einmal mit `sudo ./scripts/ralf-standalone-bootstrap.sh --apply` ausgeführt. VMID 100 wurde als unprivilegierter LXC `ralf-standalone` erstellt. Die anschließenden read-only Aufrufe `pct config 100` und `pct status 100` bestätigten die Zielkonfiguration und den Status `stopped`.
+- Geänderte Dateien: `ZIELBILD.md`, `README.md`, `Ergebnis.md`
+- Ausgeführte Prüfungen: Plan vor Apply; VMID-, Name-, Storage-, Bridge- und Template-Prüfung im Plan; genau ein realer Apply; read-only `pct config 100`; read-only `pct status 100`; Prüfung auf `unprivileged: 1`, 4 Kerne, 12288 MiB RAM, 4096 MiB Swap, 40-GiB-Root-Disk, DHCP über `vmbr0`, keine Mountpoints und keine GPU-Features.
+- Nicht ausgeführte Prüfungen: Keine Softwareinstallation, kein Containerstart, kein Stop nach der Erstellung, kein Rollback, kein zweiter Apply-Versuch und keine weiteren Proxmox-Mutationen.
+- Risiken oder Blocker: Der Container ist leer und gestoppt. Ubuntu-Paketupdates, Ollama, `qwen2.5-coder:7b`, Open WebUI und GPU-Unterstützung bleiben offen. O-008 bleibt als GPU-Entscheidung offen.
+- Nächster sinnvoller Zielbild-Eintrag: Kontrolliertes Starten und Vorbereiten des leeren Ubuntu-LXC ohne RALF-Softwareinstallation.
+- Veröffentlichung: Ausschließlich diese Dokumentationsänderungen werden committed, gepusht und nach `main` gemergt.

--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ Die ausdrückliche Erstellung erfolgt erst mit `--apply`:
 sudo ./scripts/ralf-standalone-bootstrap.sh --apply
 ```
 
-`--apply` wiederholt den vollständigen Plan unmittelbar vor der Mutation, ruft genau einmal `pct create` auf und prüft die erzeugte LXC-Konfiguration anschließend read-only. Der Container bleibt gestoppt; Softwareinstallation, GPU-Passthrough und automatisches Rollback sind nicht Bestandteil dieses Schritts. Ein realer `--apply`-Lauf ist bisher nicht ausgeführt.
+`--apply` wiederholt den vollständigen Plan unmittelbar vor der Mutation, ruft genau einmal `pct create` auf und prüft die erzeugte LXC-Konfiguration anschließend read-only. Der Container bleibt gestoppt; Softwareinstallation, GPU-Passthrough und automatisches Rollback sind nicht Bestandteil dieses Schritts.
 
 ## Status
 
-Die grundlegenden Entscheidungen für RALF Standalone 0.0.1 sind abgeschlossen. Implementiert sind der read-only Bootstrap-/Ressourcenplan und der ausdrückliche, noch nicht real ausgeführte Apply-Pfad; Softwareinstallation und vollständige Definition of Done stehen noch aus.
+Die grundlegenden Entscheidungen für RALF Standalone 0.0.1 sind abgeschlossen. Der reale unprivilegierte LXC `ralf-standalone` (VMID 100) wurde erstellt und read-only geprüft; er ist aktuell gestoppt und enthält noch keine RALF-Software. Softwareinstallation und die übrigen Definition-of-Done-Punkte stehen noch aus.
 
 ## Lizenz
 

--- a/ZIELBILD.md
+++ b/ZIELBILD.md
@@ -76,7 +76,7 @@ Eine feste und reproduzierbare erste Installation soll auf der vorhandenen Proxm
 
 | ID | Status | Prüfkriterium |
 |---|---|---|
-| D-001 | AKTIV | Der Installationsweg erstellt den vorgesehenen unprivilegierten LXC auf Proxmox. |
+| D-001 | ABGESCHLOSSEN | Der Installationsweg erstellte den vorgesehenen unprivilegierten LXC auf Proxmox als VMID 100 und die read-only Prüfung bestätigte die Zielkonfiguration. |
 | D-002 | AKTIV | Die kleine Weboberfläche ist nach der Installation erreichbar. |
 | D-003 | AKTIV | Das installierte Modell beantwortet über die Weboberfläche eine Testanfrage. |
 | D-004 | AKTIV | Notwendige Daten und Konfiguration überleben einen Container-Neustart. |
@@ -117,6 +117,7 @@ Diese Entscheidungen sind als Nächstes notwendig, bevor der Installer implement
 | A-012 | ABGESCHLOSSEN | DHCP ohne vorausgesetzte Reservierung wurde als Netzwerkkonfiguration des ersten RALF-Standalone-LXC festgelegt. |
 | A-013 | ABGESCHLOSSEN | Die persistenten Verzeichnisse des ersten LXC wurden festgelegt; separate Proxmox-Mountpoints werden in RALF Standalone 0.0.1 nicht verwendet. |
 | A-014 | ABGESCHLOSSEN | `GOAL.md` wurde als allgemeingültiger, wiederverwendbarer Arbeitsauftrag für Codex CLI angelegt und in den Projektdokumenten verankert. |
+| A-015 | ABGESCHLOSSEN | Der erste reale `ralf-standalone`-LXC wurde am 2026-07-31 als VMID 100 erstellt und read-only geprüft. Er ist gestoppt und enthält noch keine RALF-Software. |
 
 # 5. Verbindlicher Entwicklungsprozess
 


### PR DESCRIPTION
## Ergebnis

- dokumentiert die einmalige reale Erstellung von VMID 100
- setzt D-001 nach erfolgreicher read-only Prüfung auf `ABGESCHLOSSEN`
- hält fest, dass `ralf-standalone` gestoppt und noch ohne RALF-Software ist
- aktualisiert README und append-only Ergebnisprotokoll

## Validierung

- bestätigter read-only Plan
- genau ein realer `--apply`
- `pct config 100`
- `pct status 100`
- Zielbild-ID- und Geheimnisausschlussprüfung
- `git diff --check`

Keine weitere Proxmox-Mutation, kein Start, kein Rollback, keine Softwareinstallation.