### PR TITLE
Tighten recoverable resume state

### DIFF
--- a/Ergebnis.md
+++ b/Ergebnis.md
@@ -413,3 +413,13 @@ Diese Datei wird nach jedem Arbeitsdurchlauf erweitert. Bestehende Einträge ble
 - Nicht ausgeführte Prüfungen oder Änderungen: Kein Resume-Apply, keine Paketinstallation, keine Entfernung des temporären Venvs und keine Proxmox-/Containeränderung.
 - Risiken oder Blocker: VMID 100 bleibt im dokumentierten `recoverable_venv_failure`; eine neue ausdrückliche Freigabe ist vor dem realen Resume-Apply erforderlich.
 - Nächster sinnvoller Zielbild-Eintrag: M-027 – read-only Resume-Plan und genau ein freigegebener Resume-Apply-Lauf.
+
+## 2026-08-01 – Resume-Zustand gegen zusätzliche Bootstrap-Einträge abgesichert
+
+- Bearbeitete Zielbild-IDs: M-031, P-001
+- Ergebnis: Der bereinigbare Teilzustand akzeptiert nun ausschließlich das eine validierte `.venv-build.*`-Verzeichnis als direkten Inhalt des Bootstrap-Basisverzeichnisses. Zusätzliche Dateien oder Verzeichnisse verhindern den Resume-Pfad auf Host- und Gastseite.
+- Geänderte Dateien: `scripts/ralf-bootstrap-status-install.sh`, `scripts/ralf-bootstrap-status-deploy.sh`, `Ergebnis.md`.
+- Ausgeführte Prüfungen: `bash -n`, ShellCheck, sämtliche bestehenden und neuen Shelltests sowie `git diff --check`.
+- Nicht ausgeführte Prüfungen oder Änderungen: Kein realer Resume-Apply, keine Paketinstallation, keine Entfernung des temporären Venvs und keine weitere VMID-100-Mutation.
+- Risiken oder Blocker: VMID 100 bleibt im exakt dokumentierten `recoverable_venv_failure`; vor einer Mutation ist eine neue ausdrückliche Freigabe erforderlich.
+- Nächster sinnvoller Zielbild-Eintrag: M-027 – read-only Resume-Plan, Freigabe und genau ein Resume-Apply-Lauf.

--- a/scripts/ralf-bootstrap-status-deploy.sh
+++ b/scripts/ralf-bootstrap-status-deploy.sh
@@ -119,6 +119,7 @@ else:
         root_stat = root.stat()
         temps = sorted(root.glob(".venv-build.*"))
         app_temps = list(root.glob(".app-build.*"))
+        direct_entries = list(root.iterdir())
         service_absent = not Path("/etc/systemd/system/ralf-bootstrap.service").exists()
         service_inactive = all(subprocess.run(["systemctl", action, "ralf-bootstrap.service"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode != 0 for action in ("is-enabled", "is-active"))
         sock = socket.socket()
@@ -132,7 +133,7 @@ else:
         recoverable = (
             root.is_dir() and root_stat.st_uid == pwd.getpwnam("root").pw_uid and root_stat.st_gid == group.gr_gid and stat.S_IMODE(root_stat.st_mode) == 0o750
             and user.pw_gid == group.gr_gid and user.pw_dir == "/nonexistent" and user.pw_shell == "/usr/sbin/nologin"
-            and len(temps) == 1 and not app_temps and all(not path.exists() for path in final) and not state_db.exists()
+            and len(temps) == 1 and direct_entries == temps and not app_temps and all(not path.exists() for path in final) and not state_db.exists()
             and service_absent and service_inactive and port_free
         )
     except (KeyError, OSError):

--- a/scripts/ralf-bootstrap-status-install.sh
+++ b/scripts/ralf-bootstrap-status-install.sh
@@ -278,6 +278,9 @@ check_recoverable_shape() {
   [[ -n $(getent passwd "$EXPECTED_USER" || true) && -n $(getent group "$EXPECTED_GROUP" || true) ]] || return 1
   check_user_group
   find_recoverable_temp || return 1
+  while IFS= read -r actual; do
+    [[ $actual == "$RECOVERABLE_TEMP_VENV" ]] || return 1
+  done < <(find "$bootstrap_root" -mindepth 1 -maxdepth 1 -print)
   ! find "$bootstrap_root" -mindepth 1 -maxdepth 1 -type d -name '.app-build.*' -print -quit | grep -q . || return 1
   for path in "$app_dir" "$venv_dir" "$version_file" "$config_dir" "$state_dir" "$unit_file" "$(target_path '/var/lib/ralf/bootstrap/state.db')"; do
     [[ ! -e $path ]] || return 1


### PR DESCRIPTION
## Änderung

Der exakt bereinigbare Resume-Zustand akzeptiert keine zusätzlichen direkten Einträge im Bootstrap-Basisverzeichnis. Host- und Gastprüfung bleiben damit auf den nachgewiesenen Teilzustand begrenzt.

## Prüfungen

- bash -n und ShellCheck
- vollständige Bootstrap-Status-Mocktests
- git diff --check

VMID 100 blieb unverändert.
