### PR TITLE
Specify Database Service 001 architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ RALF entsteht von innen nach außen. Der erste Baustein ist ein eigenständiger 
 
 PostgreSQL ist die erste Referenzimplementierung des Database Service. Ausschlaggebend sind ACID-Eigenschaften, umfassende SQL-Unterstützung, klare Rollenverwaltung sowie etablierte Möglichkeiten für Backup und Replikation. Weitere Datenbanksysteme sollen später über denselben fachlichen Dienstvertrag unterstützt werden; PostgreSQL ist keine dauerhafte Produktbindung des Gesamtprojekts.
 
-Der nächste Schritt ist ausschließlich die gemeinsame Spezifikation des Database Service:
+Die erste fachliche Spezifikation trennt den fähigkeitsorientierten RALF-Vertrag ausdrücklich vom konkreten PostgreSQL-Provider:
 
-- Aufgaben und Verantwortlichkeiten,
-- Schnittstellen und Konfiguration,
-- Lebenszyklus,
-- Backup und Wiederherstellung,
-- Health Checks,
-- Vertrag zwischen RALF und dem Datenbankdienst.
+- [Architektur des Database Service](docs/architecture/database-service.md)
+- [RALF Database Contract 0.1](docs/contracts/database-service-v0.1.md)
+- [ADR-0001: providerneutrale Datenbankfähigkeit](docs/decisions/ADR-0001-database-service.md)
 
 Es gibt derzeit noch keine Implementierung. Insbesondere existieren noch kein Installer, Controller, Webinterface, Provider, Connector, Datenmodell, ORM, REST-Endpunkt, `pgvector`, Modellruntime oder Reverse Proxy.
+
+Der nächste kleine Schritt ist die fachliche Entscheidung, welche Daten zuerst gespeichert werden und welche RALF-Komponente der erste Datenbankkunde wird. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
 
 RALF entsteht transparent durch Vibe Coding: Menschen bestimmen Ziele, Entscheidungen und Grenzen; Coding-Agenten unterstützen die Umsetzung in kleinen, überprüfbaren Schritten.

--- a/docs/architecture/database-service.md
+++ b/docs/architecture/database-service.md
@@ -1,0 +1,183 @@
+# Dienst 001: Database Service – Architektur
+
+## Zweck
+
+Der Database Service ist die stabile persistente Datenschnittstelle von RALF. Er stellt strukturierte, transaktionale Datenhaltung als eigenständige RALF-Fähigkeit bereit und verantwortet deren Lebenszyklus. PostgreSQL ist die erste Referenzimplementierung, aber kein Bestandteil des öffentlichen RALF-Vertrags.
+
+Andere RALF-Komponenten dürfen deshalb keine PostgreSQL-Verbindungsparameter, Systemtabellen, Erweiterungen, SQL-Dialekte, Fehlermeldungen oder Rollen voraussetzen. Das gilt ausdrücklich auch für `psql`, `pg_dump`, `pg_restore` und `pgvector`. PostgreSQL-spezifische Details bleiben im PostgreSQL-Provider sowie dessen Betriebs- und Administrationsschicht.
+
+## Architekturmodell
+
+```text
+RALF-Komponenten
+       │
+       ▼
+RALF Database Contract
+       │
+       ▼
+Database Service
+       │
+       ▼
+Provider
+       │
+       └── PostgreSQL
+```
+
+Der **RALF Database Contract** beschreibt benötigte Fähigkeiten, providerneutrale Zustände und Fehler, Lebenszyklusoperationen, Schema- und Migrationsregeln sowie Sicherheits-, Backup- und Restore-Anforderungen.
+
+Der **Database Service** verantwortet die persistente strukturierte Datenhaltung, die Einhaltung des Vertrags, die Auswahl genau eines aktiven Providers, Fähigkeits- und Statusmeldungen, kontrollierte Schemaentwicklung und die Verträge für Sicherung und Wiederherstellung.
+
+Ein **Provider** bildet diesen Vertrag auf ein konkretes Datenbanksystem ab. Der erste Provider ist PostgreSQL. Spätere Provider wie MariaDB, Microsoft SQL Server, SQLite oder andere relationale Datenbanken sind architektonisch möglich, aber nicht zugesichert. Sie sind nur kompatibel, wenn sie die für das jeweilige RALF-Profil erforderlichen Fähigkeiten nachweislich erfüllen.
+
+## Providerprinzip und Abstraktionsgrenze
+
+RALF abstrahiert Datenbankprodukte nicht um jeden Preis auf den kleinsten gemeinsamen Nenner. Der Vertrag ist fähigkeitsorientiert:
+
+- Ein Provider deklariert die Fähigkeiten, die er tatsächlich und sicher bereitstellt.
+- RALF-Komponenten beziehungsweise Betriebsprofile deklarieren erforderliche und optionale Fähigkeiten.
+- Fehlt eine erforderliche Fähigkeit, wird die Kombination verständlich als inkompatibel oder eingeschränkt bewertet.
+- Zusätzliche Providerfähigkeiten werden nicht automatisch Bestandteil des allgemeinen Vertrags.
+- Providerdetails dürfen intern für Betrieb und Diagnose genutzt werden, aber nicht in den öffentlichen Vertrag durchsickern.
+
+### Entscheidung zur Datenzugriffsgrenze
+
+Der Database Service wird als **Betriebs- und Vertragsdienst** gestaltet. Er verwaltet Provider, Verbindungsfähigkeit, Fähigkeiten, Schema, Migrationen, Health, Readiness, Backup und Restore. Fachliche Datenoperationen gehören in domänenspezifische Repository- oder Datenschnittstellen der jeweils verantwortlichen RALF-Komponente.
+
+Damit wird keine universelle RALF-Datenbanksprache geschaffen. Die im Vertrag genannten Datenoperationen sind vorläufige fachliche Begriffe zur Beschreibung notwendiger Transaktionseigenschaften, keine zentrale technische CRUD-API. Die genaue Kommunikation zwischen Domänen und Database Service bleibt offen.
+
+Diese Grenze vermeidet eine künstliche Universal-API und hält fachliche Modelle bei ihren Eigentümern. Dafür müssen spätere Domänenverträge Providerneutralität und benötigte Fähigkeiten ausdrücklich berücksichtigen.
+
+## Umfang von Database Service 0.1
+
+Version 0.1 umfasst bewusst:
+
+- genau einen aktiven Datenbankprovider,
+- PostgreSQL als Referenzprovider,
+- eine RALF-Datenbankinstanz,
+- eine logische RALF-Datenbank,
+- getrennte technische Rollen,
+- transaktionale Datenoperationen,
+- ein versioniertes Schema,
+- kontrollierte Schemamigrationen,
+- getrennte Health- und Readiness-Prüfungen,
+- einen Backup- und Restore-Vertrag,
+- providerneutrale Zustände und Fehler.
+
+Nicht Bestandteil von 0.1 sind Vektorsuche und `pgvector`, Hochverfügbarkeit, Replikation, automatisches Failover, Sharding, Multi-Master, externe Mandanten, ein allgemeiner Datenbankdienst für fremde Anwendungen, Datenbank-Webadministration, automatische Performanceoptimierung, autonome Datenlöschung oder -reparatur sowie Cloud-Datenbankintegration.
+
+## Fähigkeitsmodell
+
+| Fähigkeit | Bedeutung | Einordnung für 0.1 |
+| --- | --- | --- |
+| `relational_storage` | Dauerhafte strukturierte Speicherung mit relationalen Beziehungen. | erforderlich |
+| `transactions` | Atomare, konsistente Transaktionsgrenzen für zusammengehörige Operationen. | erforderlich |
+| `schema_migrations` | Versionierte, geordnete und kontrolliert ausführbare Schemaänderungen. | erforderlich |
+| `constraints` | Datenbankseitige Durchsetzung definierter Integritätsregeln. | erforderlich |
+| `indexes` | Definierte Zugriffsstrukturen für vorhersehbare Abfragen. | erforderlich |
+| `json_documents` | Speicherung und gezielte Abfrage strukturierter JSON-Dokumente. | optional nutzbar |
+| `full_text_search` | Datenbankgestützte Volltextsuche. | optional nutzbar |
+| `advisory_locks` | Kooperative, anwendungsdefinierte Sperren für koordinierte Abläufe. | optional nutzbar |
+| `vector_search` | Ähnlichkeitssuche über Vektorrepräsentationen. | später |
+| `backup` | Kontrollierte Erzeugung einer sicherungsfähigen Datenrepräsentation. | erforderlich |
+| `restore` | Kontrollierte Wiederherstellung aus einer geprüften Sicherung. | erforderlich |
+| `point_in_time_recovery` | Wiederherstellung auf einen bestimmten Zeitpunkt. | später |
+| `replication` | Bereitstellung replizierter Datenbankkopien. | später |
+| `high_availability` | Betrieb mit definierten Verfügbarkeits- und Ausfallzielen. | später |
+
+Die Einordnung ist der Architekturvorschlag für Vertrag 0.1. Ob `json_documents` oder `full_text_search` bereits verpflichtend werden, hängt von den zuerst festgelegten fachlichen Daten und Datenbankkunden ab.
+
+## Verantwortlichkeiten
+
+### Persistenz
+
+- strukturierte RALF-Daten dauerhaft speichern,
+- konsistente Lese- und Schreibvorgänge ermöglichen,
+- Transaktionsgrenzen unterstützen,
+- relationale Integrität ermöglichen.
+
+### Schema
+
+- aktuelle und angestrebte Schemaversion kennen,
+- Migrationen geordnet, versioniert und nachvollziehbar behandeln,
+- inkompatible oder unbekannte Schemaversionen erkennen,
+- Downgrades und Migrationserfolge nicht vortäuschen.
+
+### Fähigkeiten
+
+- unterstützte Fähigkeiten melden,
+- fehlende erforderliche Fähigkeiten als Inkompatibilität ausweisen,
+- Provider und Providerversion intern kennen,
+- keine providerspezifischen Details zum allgemeinen Vertrag erklären.
+
+### Betrieb
+
+- Health und Readiness getrennt bewerten,
+- Start-, Stopp-, Wartungs-, Migrations-, Backup- und Restore-Zustände melden,
+- Verbindungs-, Speicher- und Providerprobleme neutral klassifizieren,
+- kontrollierte Sicherungs- und Wiederherstellungsvorgänge ermöglichen.
+
+### Sicherheit
+
+- technische Rollen und ihre Aufgaben trennen,
+- normale Anwendungen nie mit administrativer Superuserrolle betreiben,
+- minimale Rechte verwenden,
+- Geheimnisse vom Repository und von nicht geheimer Konfiguration fernhalten,
+- Verbindungen und Identitäten als deployment-spezifische Konfiguration behandeln.
+
+### Auditierbarkeit
+
+- Migrationen sowie Backup- und Restorevorgänge nachvollziehbar machen,
+- Statusänderungen und Fehlerursachen verständlich klassifizieren,
+- keine Geheimnisse oder vollständigen Zugangsdaten protokollieren.
+
+## Nicht-Verantwortlichkeiten
+
+Der Database Service ist kein Datei- oder Objekt-Storage, Cache, Message Queue, Event Bus, Suchdienst, allgemeiner Vektorspeicher oder Secrets-Dienst. Er verantwortet weder Modellinferenz und Modellverwaltung noch Benutzeroberfläche, Reverse Proxy, Netzwerk-, Container-, Proxmox- oder OPNsense-Verwaltung. Er ist außerdem kein allgemeiner Datenbankverwaltungsdienst für Anwendungen außerhalb von RALF.
+
+## Fachliches Rollenmodell
+
+| Rolle | Sicherheitsziel |
+| --- | --- |
+| `database_owner` | Besitzt die logische Datenbank beziehungsweise zentrale Objekte und wird nie für normale RALF-Anwendungszugriffe verwendet. |
+| `migration_role` | Darf ausschließlich während eines freigegebenen Migrationsvorgangs kontrollierte Schemaänderungen ausführen. |
+| `application_role` | Besitzt nur die für den normalen fachlichen Betrieb erforderlichen Lese- und Schreibrechte und keine administrativen Rechte. |
+| `backup_role` | Besitzt nur die für geplante Sicherung und Wiederherstellung notwendigen Rechte. |
+| `monitoring_role` | Darf ausschließlich die für Status, Health, Readiness und Diagnose erforderlichen Informationen lesen. |
+
+Ein Provider darf diese Rollen technisch anders abbilden, muss aber dieselbe Trennung und dieselben Sicherheitsziele nachweisbar erfüllen.
+
+## Konfigurationsvertrag
+
+Die spätere nicht geheime Konfiguration wird in folgende Kategorien gegliedert:
+
+- **Provider:** `provider_id`, `provider_version`
+- **Verbindung:** `host`, `port`, `database_name`, `connection_security`, `connection_timeout`
+- **Rollenreferenzen:** `application_identity`, `migration_identity`, `backup_identity`, `monitoring_identity`
+- **Betrieb:** `health_timeout`, `migration_policy`, `backup_policy`, `retention_policy`
+- **Fähigkeiten:** `required_capabilities`, `optional_capabilities`
+
+Diese Namen definieren Kategorien, noch kein Dateiformat und keine öffentliche Programmierschnittstelle. Kennwörter, private Schlüssel, API-Tokens, vollständige Connection Strings mit Zugangsdaten, Cloud-Credentials und Backup-Verschlüsselungsschlüssel gehören niemals in normale Konfigurationsdateien. Ein eigener Secrets-Vertrag wird später benötigt und ist nicht Teil dieser Spezifikation.
+
+## Lebenszyklus
+
+Der providerneutrale Lebenszyklus unterscheidet `unknown`, `unconfigured`, `configured`, `starting`, `ready`, `degraded`, `maintenance`, `migration_required`, `migrating`, `backup_running`, `restore_running`, `failed` und `stopped`. Nur `ready` erlaubt reguläre Lese- und Schreibzugriffe. Eingeschränkte Zugriffe in `degraded` oder `backup_running` benötigen eine ausdrücklich belegte Providerzusage; Migration, Restore und Fehlerzustände sperren den normalen Datenzugriff.
+
+Die genaue Bedeutung und die Zugriffsgrenzen jedes Zustands sind im [Vertrag 0.1](../contracts/database-service-v0.1.md#lebenszykluszustände) definiert. Administrative Aktionen bedeuten dort ausschließlich ausdrücklich geplante, autorisierte Lebenszyklusvorgänge; sie sind keine allgemeine Administrationsfreigabe.
+
+## Sicherheitsgrenzen
+
+- Andere RALF-Komponenten sehen keine PostgreSQL-spezifischen Zugangsdaten oder Werkzeuge.
+- Normale Anwendungsidentitäten besitzen keine Owner-, Migrations- oder Backuprechte.
+- Migration, Backup und Restore sind getrennte, geplante Vorgänge mit eigener Freigabe.
+- Fehlerantworten enthalten keine Geheimnisse und keine providerspezifischen Interna als Vertragsbestandteil.
+- Restore, Datenlöschung und Reparatur erfolgen niemals automatisch.
+
+## PostgreSQL als Referenzprovider
+
+Der PostgreSQL-Provider soll später Version und Verfügbarkeit erkennen, Verbindungen aufbauen, das Rollenmodell abbilden, die logische Datenbank anlegen und verwalten, providerspezifische Migrationen ausführen, Health und Readiness prüfen, logische Backups und Restore umsetzen, Fehler in RALF-Fehlerklassen übersetzen und seine Fähigkeiten deklarieren.
+
+Noch nicht entschieden sind Referenzversion, Paketquelle, Betriebsform, Netzwerkfreigaben, Serverkonfiguration, Zugriffsregeln, Datenverzeichnis, Backupziel und Zugangsdaten. Diese Punkte gehören in spätere getrennte Entscheidungen.
+
+## SQLite-Abgrenzung
+
+SQLite kann später einen Minimal- oder Einzelprozessprovider bilden. Es ist nicht automatisch gleichwertig mit PostgreSQL und darf nur Fähigkeiten deklarieren, die es im gewählten Betriebsprofil sicher erfüllt. Eine möglicherweise eingebettete SQLite-Datenbank einer anderen RALF-Komponente wäre nicht automatisch der RALF Database Service.

--- a/docs/contracts/database-service-v0.1.md
+++ b/docs/contracts/database-service-v0.1.md
@@ -1,0 +1,215 @@
+# RALF Database Contract 0.1
+
+## Status und Zweck
+
+Dieses Dokument definiert die fachliche Vertragsoberfläche des Database Service in Version 0.1. Es legt weder REST, RPC, MCP, Python-Signaturen noch ein SQL- oder Dateiformat fest. PostgreSQL ist der erste Referenzprovider, bleibt jedoch außerhalb des öffentlichen Vertrags.
+
+## Vertragsumfang 0.1
+
+Der Vertrag gilt für genau einen aktiven Provider, eine RALF-Datenbankinstanz und eine logische RALF-Datenbank. Er beschreibt Fähigkeiten, Provider- und Schemazustand, kontrollierte Migrationen, Health, Readiness, Backup, Restore, Rollenanforderungen und providerneutrale Fehler.
+
+Er definiert keine fachlichen Tabellen, Datenmodelle, Queries oder allgemeine Datenbankverwaltung für fremde Anwendungen.
+
+## Fähigkeiten
+
+### Erforderlich
+
+- `relational_storage`
+- `transactions`
+- `schema_migrations`
+- `constraints`
+- `indexes`
+- `backup`
+- `restore`
+
+Ohne eine dieser Fähigkeiten ist ein Provider für Database Service 0.1 nicht kompatibel.
+
+### Optional nutzbar
+
+- `json_documents`
+- `full_text_search`
+- `advisory_locks`
+
+Eine RALF-Domäne darf eine optionale Fähigkeit für ihr eigenes Profil zur Voraussetzung machen. Dadurch wird sie nicht automatisch für alle Database-Service-Nutzer verpflichtend.
+
+### Später
+
+- `vector_search`
+- `point_in_time_recovery`
+- `replication`
+- `high_availability`
+
+Diese Fähigkeiten sind ausdrücklich nicht Teil der Mindestzusage von 0.1.
+
+## Fachliche Vertragsoperationen
+
+Die folgenden Namen gliedern Verantwortungen. Sie sind Platzhalter und keine öffentlichen Funktionssignaturen.
+
+### Status
+
+- `get_service_status`
+- `get_provider_information`
+- `get_capabilities`
+- `get_schema_status`
+
+### Datenoperationen
+
+- `begin_transaction`
+- `commit_transaction`
+- `rollback_transaction`
+- `execute_read`
+- `execute_write`
+
+Diese Begriffe beschreiben die benötigten Transaktions- und Datenzugriffseigenschaften. Gemäß ADR‑0001 werden fachliche Lese- und Schreiboperationen später in domänenspezifischen Repository-Verträgen konkretisiert, nicht als universelle Database-Service-API.
+
+### Schema
+
+- `get_current_schema_version`
+- `get_target_schema_version`
+- `plan_migrations`
+- `apply_migrations`
+
+### Sicherung
+
+- `plan_backup`
+- `create_backup`
+- `verify_backup`
+- `plan_restore`
+- `restore_backup`
+
+### Diagnose
+
+- `health_check`
+- `readiness_check`
+- `diagnose`
+
+## Lebenszykluszustände
+
+„Administrativ“ bedeutet eine ausdrücklich geplante und autorisierte Lebenszyklusaktion. Diagnose ist in jedem Zustand lesend zulässig, soweit der Provider erreichbar ist.
+
+| Zustand | Bedeutung | Lesen | Schreiben | Administrative Aktionen |
+| --- | --- | --- | --- | --- |
+| `unknown` | Zustand wurde noch nicht zuverlässig ermittelt. | nein | nein | nur Diagnose und sichere Bestandsaufnahme |
+| `unconfigured` | Provider oder logische Datenbank ist noch nicht vollständig konfiguriert. | nein | nein | Konfiguration darf geplant werden |
+| `configured` | Konfiguration ist vorhanden, Betriebsbereitschaft aber noch nicht bestätigt. | nein | nein | Start und Prüfung dürfen geplant werden |
+| `starting` | Provider startet oder stellt Verbindungen her. | nein | nein | Statusprüfung, kein paralleler Lebenszykluswechsel |
+| `ready` | Alle Pflichtfähigkeiten, Schema- und Sicherheitsprüfungen sind erfüllt. | ja | ja | geplante Standardaktionen zulässig |
+| `degraded` | Betrieb ist eingeschränkt; Umfang ist diagnostiziert. | nur wenn ausdrücklich als sicher bewertet | nur wenn ausdrücklich als sicher bewertet | Diagnose und freigegebene Korrekturplanung |
+| `maintenance` | Geplanter Wartungsmodus. | standardmäßig nein | nein | ausschließlich freigegebene Wartungsaktionen |
+| `migration_required` | Provider ist gesund, aber das Schema ist nicht zur Zielversion kompatibel. | höchstens ausdrücklich kompatible Reads | nein | Migrationsplanung zulässig |
+| `migrating` | Eine freigegebene Migration läuft. | nein, sofern Migration nichts anderes garantiert | nein | nur der laufende Migrationsvorgang |
+| `backup_running` | Eine Sicherung läuft. | ja, wenn der Provider konsistente Reads garantiert | nur wenn die Backupmethode Konsistenz garantiert | nur Backupüberwachung oder Abbruch nach eigener Regel |
+| `restore_running` | Eine Wiederherstellung läuft. | nein | nein | nur der laufende Restorevorgang |
+| `failed` | Ein kritischer Fehler verhindert sicheren Betrieb. | nein | nein | Diagnose und ausdrücklich geplante Wiederherstellung |
+| `stopped` | Provider ist kontrolliert gestoppt. | nein | nein | Start, Diagnose oder Restoreplanung zulässig |
+
+Zugriffe in `degraded` oder `backup_running` benötigen später eine konkrete, providerseitig belegte Zusage. Ohne diese Zusage gilt „nicht zulässig“.
+
+## Health und Readiness
+
+**Health** beantwortet, ob Provider beziehungsweise Datenbankprozess grundsätzlich funktionieren. Mögliche Kriterien sind Erreichbarkeit, Verbindungsaufbau und eine einfache interne Prüfung.
+
+**Readiness** beantwortet, ob RALF die Datenbank aktuell sicher verwenden darf. Zusätzlich müssen mindestens gelten:
+
+- alle erforderlichen Fähigkeiten sind vorhanden,
+- die richtige logische Datenbank ist erreichbar,
+- die Schemaversion ist bekannt und kompatibel,
+- keine notwendige Migration und kein Restore steht im Weg,
+- kein kritischer Speicherzustand liegt vor,
+- die Anwendungsidentität besitzt genau die erforderlichen minimalen Rechte.
+
+Health und Readiness sind unabhängig. Ein laufender, erreichbarer PostgreSQL-Provider kann gesund, aber wegen einer fehlenden RALF-Schemamigration nicht bereit sein.
+
+## Schema- und Migrationsvertrag
+
+- Migrationen sind versioniert und eindeutig geordnet.
+- Der aktuelle Schemawert wird in der Datenbank selbst gespeichert.
+- Jede Migration besitzt eine stabile ID.
+- Vor jeder Migration wird ein nachvollziehbarer Plan angezeigt.
+- Jede Migration benötigt eine eigene ausdrückliche Freigabe.
+- Ein normaler Dienststart führt keine unbekannte oder stillschweigende Migration aus.
+- Eine fehlgeschlagene Migration wird niemals als erfolgreich markiert.
+- Rollbackfähigkeit wird für jede Migration einzeln dokumentiert; Rückwärtsausführung ist keine allgemeine Zusage.
+- Struktur- und Datenmigrationen werden unterscheidbar dokumentiert.
+- Unbekannte neuere oder inkompatible Schemaversionen führen zu `schema_mismatch` statt zu einem vorgetäuschten Downgrade.
+- Providerspezifische Migrationsartefakte und SQL-Dateien gehören ausschließlich zum jeweiligen Provider.
+
+Die technische Paketierung von Migrationen bleibt offen.
+
+## Backupvertrag
+
+Ein Backupdatensatz beschreibt mindestens:
+
+| Feld | Bedeutung |
+| --- | --- |
+| `backup_id` | Stabile Identität der Sicherung. |
+| `provider_id` | Provider, der die Sicherung erzeugt hat. |
+| `created_at` | Nachvollziehbarer Erstellungszeitpunkt. |
+| `schema_version` | Gesicherte RALF-Schemaversion. |
+| `database_identity` | Nicht geheime Identität der gesicherten logischen Datenbank. |
+| `backup_type` | Art der Sicherung. |
+| `integrity_status` | Ergebnis der technischen Überprüfbarkeit. |
+| `encryption_status` | Deklarierter Verschlüsselungszustand ohne Schlüsselmaterial. |
+| `storage_reference` | Deployment-spezifischer Verweis auf den Speicherort. |
+
+Zulässige fachliche Typen sind zunächst `logical`, `physical` und `snapshot`. Für 0.1 wird `logical` bevorzugt; die konkrete Umsetzung ist noch nicht entschieden.
+
+Eine Sicherung ist erst erfolgreich, wenn ihre Erzeugung technisch abgeschlossen und ihre Überprüfbarkeit bestätigt ist. Eine vorhandene Datei allein gilt nicht als verifiziertes Backup. Der Vertrag enthält keine Kennwörter oder Schlüssel. Speicherort, Aufbewahrung und Verschlüsselung bleiben deployment-spezifisch. Automatische Löschung alter Sicherungen gehört nicht zu 0.1.
+
+## Restorevertrag
+
+Jeder Restore ist ein eigener geplanter Vorgang und benötigt mindestens:
+
+1. Auswahl eines verifizierten Backups,
+2. sichtbare Angabe von Quelle und Ziel,
+3. Prüfung von Schemaversion und Zielzustand,
+4. ausdrückliche Bestätigung,
+5. kontrollierte einmalige Ausführung,
+6. anschließende Integritäts-, Health- und Readiness-Prüfung.
+
+Es gibt keinen automatischen Restore und kein stillschweigendes Überschreiben einer produktiven Datenbank.
+
+## Providerneutrale Fehlerklassen
+
+| Kategorie | Bedeutung |
+| --- | --- |
+| `configuration_error` | Nicht geheime Konfiguration ist ungültig oder unvollständig. |
+| `connection_error` | Verbindung konnte nicht hergestellt oder gehalten werden. |
+| `authentication_error` | Identität konnte nicht erfolgreich nachgewiesen werden. |
+| `authorization_error` | Identität besitzt nicht die erforderlichen minimalen Rechte. |
+| `capability_missing` | Eine erforderliche Fähigkeit fehlt. |
+| `schema_mismatch` | Datenbankschema ist unbekannt oder inkompatibel. |
+| `migration_required` | Eine bekannte Migration ist vor sicherem Betrieb erforderlich. |
+| `migration_failed` | Eine freigegebene Migration ist fehlgeschlagen. |
+| `transaction_failed` | Eine Transaktion konnte nicht erfolgreich abgeschlossen werden. |
+| `constraint_violation` | Eine deklarierte Integritätsbedingung wurde verletzt. |
+| `storage_exhausted` | Verfügbarer Speicher reicht für den sicheren Vorgang nicht aus. |
+| `backup_failed` | Sicherung oder deren Verifikation ist fehlgeschlagen. |
+| `restore_failed` | Wiederherstellung oder Abschlussprüfung ist fehlgeschlagen. |
+| `provider_unavailable` | Provider ist nicht verfügbar. |
+| `provider_conflict` | Providerzustand widerspricht dem ausgewählten Vertrag. |
+| `unknown_error` | Fehler konnte keiner stabilen Kategorie zugeordnet werden. |
+
+Jeder spätere Fehlerdatensatz enthält mindestens `error_code`, `category`, `message`, `retryable`, `provider_reference` und `operation_reference`. Providerspezifische Fehlercodes dürfen intern für Diagnose und Audit erhalten bleiben, werden aber nicht Teil des allgemeinen RALF-Fehlervertrags.
+
+## Sicherheits- und Auditvertrag
+
+- Die fachlichen Rollen `database_owner`, `migration_role`, `application_role`, `backup_role` und `monitoring_role` bleiben getrennt.
+- Die Anwendung arbeitet nie mit einer administrativen Superuseridentität.
+- Geheimnisse stehen weder im Repository noch in normaler Konfiguration, Statusantworten oder Logs.
+- Migrationen, Backups und Restores sind mit Plan, Operation, Ergebnis und nicht geheimen Referenzen nachvollziehbar.
+- Providerdiagnosen werden redigiert, bevor sie eine öffentliche Vertragsgrenze überschreiten.
+
+## Offene Vertragsfragen
+
+1. **Unmittelbar nächste Entscheidung:** Welche fachlichen Daten werden zuerst gespeichert, und welche erste RALF-Komponente benötigt den Database Service?
+2. Wie sehen die domänenspezifischen Repository-Verträge dieses ersten Datenbankkunden aus?
+3. Welche PostgreSQL-Version wird als Referenzversion gewählt?
+4. Wie kommunizieren RALF-Komponenten mit dem Database Service, ohne eine universelle Datenzugriffs-API zu schaffen?
+5. Wie werden Secrets sicher und deployment-spezifisch bereitgestellt?
+6. Wo liegen Daten und Backups in den ersten unterstützten Betriebsprofilen?
+7. Welche Backup-Retention wird später verlangt?
+8. Werden `json_documents` oder `full_text_search` für 0.1 nach Festlegung der ersten Fachdaten verpflichtend?
+9. Wie werden Migrationen technisch paketiert und ihrem Provider eindeutig zugeordnet?
+
+Keine dieser Fragen autorisiert bereits eine Implementierung oder Installation.

--- a/docs/decisions/ADR-0001-database-service.md
+++ b/docs/decisions/ADR-0001-database-service.md
@@ -1,0 +1,62 @@
+# ADR-0001: Database Service als providerneutrale Datenbankfähigkeit
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-02
+
+## Kontext
+
+RALF wird von innen nach außen neu entwickelt. Der erste fachliche Baustein soll strukturierte, dauerhafte Datenhaltung ermöglichen, ohne das Gesamtprojekt dauerhaft an ein bestimmtes Datenbankprodukt zu koppeln. PostgreSQL bietet eine belastbare Referenz für Transaktionen, SQL, Rollen, Backup und spätere Erweiterbarkeit. Eine direkte Kopplung anderer RALF-Komponenten an PostgreSQL würde jedoch Providerwechsel, Minimalprofile und klare Verantwortungsgrenzen erschweren.
+
+Zugleich soll die Abstraktion keine künstliche Gleichheit zwischen Datenbankprodukten behaupten. Unterschiedliche Provider besitzen unterschiedliche Fähigkeiten und Sicherheitsmerkmale.
+
+## Entscheidung
+
+Der Database Service ist die persistente Datenbankfähigkeit von RALF. PostgreSQL ist der erste Referenzprovider und bleibt hinter einem fähigkeitsorientierten RALF Database Contract verborgen.
+
+Der öffentliche Vertrag beschreibt Fähigkeiten, Zustände, Schema- und Migrationsprinzipien, Health, Readiness, Backup, Restore, Rollenanforderungen und providerneutrale Fehler. PostgreSQL-spezifische Parameter, SQL-Syntax, Systemtabellen, Erweiterungen, Werkzeuge, Rollenbezeichnungen und Fehlercodes gehören ausschließlich in den PostgreSQL-Provider beziehungsweise seine Betriebs- und Administrationsschicht.
+
+RALF abstrahiert Provider nicht auf einen behaupteten kleinsten gemeinsamen Nenner. Provider deklarieren Fähigkeiten; RALF-Profile und Domänen deklarieren ihre Anforderungen. Fehlt eine Pflichtfähigkeit, ist die Kombination inkompatibel oder eingeschränkt.
+
+Der Database Service wird als Betriebs- und Vertragsdienst ausgelegt. Fachliche Datenmodelle und Datenzugriffe verbleiben in domänenspezifischen Repository-Verträgen. Die fachlichen Begriffe `execute_read` und `execute_write` in Vertrag 0.1 sind daher keine Entscheidung für eine universelle technische Datenzugriffs-API.
+
+## Begründung
+
+- PostgreSQL ermöglicht eine praxistaugliche erste Referenz, ohne den RALF-Vertrag zu definieren.
+- Fähigkeiten machen reale Unterschiede zwischen Providern sichtbar.
+- Domänenspezifische Repositories behalten Datenmodell und Fachlogik bei der zuständigen Komponente.
+- Betriebsaufgaben wie Migration, Health, Backup und Restore erhalten eine klare zentrale Verantwortlichkeit.
+- Providerspezifische Diagnose und Werkzeuge können intern vollständig genutzt werden, ohne andere RALF-Komponenten daran zu koppeln.
+
+## Konsequenzen
+
+### Positiv
+
+- Andere Provider bleiben architektonisch möglich.
+- Providerinkompatibilität wird explizit statt durch schwache Emulation verborgen.
+- PostgreSQL-spezifische Optimierungen können kontrolliert im Provider bleiben.
+- Rollen-, Migrations-, Backup- und Restoregrenzen werden früh definiert.
+- Es entsteht keine eigene universelle RALF-Datenbanksprache.
+
+### Aufwand und Risiken
+
+- Jede RALF-Domäne muss ihre Datenzugriffsverträge sauber definieren.
+- Provider müssen Fähigkeiten und Fehler zuverlässig abbilden.
+- Der konkrete Kommunikationsweg zwischen Domänen und Database Service bleibt gesondert zu entscheiden.
+- Ein späterer Provider ist nicht automatisch kompatibel; er benötigt einen nachweisbaren Vertragsabgleich.
+
+## Verworfene beziehungsweise nicht gewählte Alternative
+
+Eine allgemeine Datenzugriffsschicht mit universellen Lese- und Schreiboperationen könnte zentrale Kontrolle und einheitliche Fehlerbehandlung vereinfachen. Sie birgt jedoch das Risiko einer künstlichen Universal-API, einer eigenen Datenbanksprache, hoher zentraler Kopplung und des Verlusts sinnvoller nativer Fähigkeiten. Deshalb ist sie nicht das Ziel von Vertrag 0.1.
+
+## Nicht entschiedene Punkte
+
+- erstes fachliches Datenmodell und erster Datenbankkunde,
+- konkrete PostgreSQL-Referenzversion und Betriebsform,
+- technischer Kommunikationsweg,
+- Secrets-Bereitstellung,
+- Daten- und Backupspeicherorte,
+- Aufbewahrungs- und Verschlüsselungsregeln,
+- technische Paketierung von Migrationen,
+- konkrete Providerimplementierung und Installation.
+
+Der nächste Schritt ist die Entscheidung, welche fachlichen Daten zuerst gespeichert werden und welche RALF-Komponente dafür als erster Datenbankkunde verantwortlich ist. Er ist ausdrücklich noch keine PostgreSQL-Installation.


### PR DESCRIPTION
## Ergebnis

- definiert Dienst 001 als providerneutrale persistente RALF-Datenbankfähigkeit
- legt PostgreSQL als ersten Referenzprovider fest, ohne PostgreSQL in den öffentlichen Vertrag aufzunehmen
- beschreibt Fähigkeits-, Rollen-, Lebenszyklus-, Health-/Readiness-, Backup-/Restore-, Migrations- und Fehlermodelle
- entscheidet die Datenzugriffsgrenze zugunsten domänenspezifischer Repository-Verträge
- dokumentiert den nächsten fachlichen Entscheidungsbedarf

## Umfang

Ausschließlich README und drei Spezifikationsdokumente. Keine Implementierung, Installation, Pakete oder Infrastrukturänderung.

## Prüfungen

- git diff --check
- Markdown-Überschriftenstruktur
- interne Dokumentlinks
- Vertragsabdeckung und PostgreSQL-Abstraktionsgrenze
- keine konkrete PostgreSQL-Version
- keine Zugangsdaten oder Beispielpasswörter
- keine Implementierungsverzeichnisse oder ausführbaren Dateien
- secrets/ weiterhin ignoriert und nicht gestaged