### PR TITLE
Define RALF Core as first native database consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ Die erste fachliche Spezifikation trennt den fähigkeitsorientierten RALF-Vertra
 - [RALF Database Contract 0.1](docs/contracts/database-service-v0.1.md)
 - [ADR-0001: providerneutrale Datenbankfähigkeit](docs/decisions/ADR-0001-database-service.md)
 
-Es gibt derzeit noch keine Implementierung. Insbesondere existieren noch kein Installer, Controller, Webinterface, Provider, Connector, Datenmodell, ORM, REST-Endpunkt, `pgvector`, Modellruntime oder Reverse Proxy.
+Der erste Datenbankkunde ist **RALF Core**. Seine erste persistente Domäne **Conversation** speichert ausschließlich Unterhaltungen und geordnete Nachrichten. Conversation bleibt zunächst eine Core-Domäne und verwendet einen fachlichen Repository-Vertrag:
 
-Der nächste kleine Schritt ist die fachliche Entscheidung, welche Daten zuerst gespeichert werden und welche RALF-Komponente der erste Datenbankkunde wird. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
+- [Architekturrahmen von RALF Core](docs/architecture/ralf-core.md)
+- [Conversation-Domäne 0.1](docs/domains/conversation.md)
+- [ConversationRepository Contract 0.1](docs/contracts/conversation-repository-v0.1.md)
+- [ADR-0002: erster Datenbankkunde](docs/decisions/ADR-0002-first-database-customer.md)
+
+Es gibt weiterhin keine Implementierung. Insbesondere existieren noch kein SQL, keine Tabellen, PostgreSQL-Installation, Programmierschnittstelle, Modellruntime, Benutzerverwaltung, Weboberfläche oder Infrastruktur.
+
+Der nächste kleine Schritt ist die fachliche Entscheidung, welche minimale Verantwortung RALF Core zwischen Benutzereingabe, ConversationRepository und einer späteren Modellruntime besitzt. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
 
 RALF entsteht transparent durch Vibe Coding: Menschen bestimmen Ziele, Entscheidungen und Grenzen; Coding-Agenten unterstützen die Umsetzung in kleinen, überprüfbaren Schritten.

--- a/README.md
+++ b/README.md
@@ -6,23 +6,27 @@ RALF entsteht von innen nach außen. Der erste Baustein ist ein eigenständiger 
 
 ## Dienst 001: Database Service
 
-PostgreSQL ist die erste Referenzimplementierung des Database Service. Ausschlaggebend sind ACID-Eigenschaften, umfassende SQL-Unterstützung, klare Rollenverwaltung sowie etablierte Möglichkeiten für Backup und Replikation. Weitere Datenbanksysteme sollen später über denselben fachlichen Dienstvertrag unterstützt werden; PostgreSQL ist keine dauerhafte Produktbindung des Gesamtprojekts.
+Der Database Service ist eine gemeinsam nutzbare Datenbankplattform. Er kann isolierte Database Allocations für RALF-eigene Komponenten und externe Anwendungen verwalten. PostgreSQL ist die erste Referenzimplementierung des Providers, aber keine dauerhafte Produktbindung des öffentlichen Vertrags.
 
 Die erste fachliche Spezifikation trennt den fähigkeitsorientierten RALF-Vertrag ausdrücklich vom konkreten PostgreSQL-Provider:
 
 - [Architektur des Database Service](docs/architecture/database-service.md)
 - [RALF Database Contract 0.1](docs/contracts/database-service-v0.1.md)
+- [Database Allocation Contract 0.1](docs/contracts/database-allocation-v0.1.md)
 - [ADR-0001: providerneutrale Datenbankfähigkeit](docs/decisions/ADR-0001-database-service.md)
+- [ADR-0003: gemeinsam nutzbare Datenbankplattform](docs/decisions/ADR-0003-shared-database-platform.md)
 
-Der erste Datenbankkunde ist **RALF Core**. Seine erste persistente Domäne **Conversation** speichert ausschließlich Unterhaltungen und geordnete Nachrichten. Conversation bleibt zunächst eine Core-Domäne und verwendet einen fachlichen Repository-Vertrag:
+Der erste spezifizierte RALF-native Database Consumer ist **RALF Core**. Seine erste persistente Domäne **Conversation** speichert ausschließlich Unterhaltungen und geordnete Nachrichten. Conversation bleibt zunächst eine Core-Domäne und verwendet nur in der RALF-Core-Allocation einen fachlichen Repository-Vertrag:
 
 - [Architekturrahmen von RALF Core](docs/architecture/ralf-core.md)
 - [Conversation-Domäne 0.1](docs/domains/conversation.md)
 - [ConversationRepository Contract 0.1](docs/contracts/conversation-repository-v0.1.md)
-- [ADR-0002: erster Datenbankkunde](docs/decisions/ADR-0002-first-database-customer.md)
+- [ADR-0002: erster RALF-nativer Consumer](docs/decisions/ADR-0002-first-database-customer.md)
+
+Externe Anwendungen wie Gitea oder optional OpenBao können eigene Allocations mit nativen Datenbankzugriffen erhalten; sie verwenden ConversationRepository nicht. Referenzstandard ist eine logische Datenbank mit eigenen Identitäten pro Consumer. Die verbindliche externe Secrets-Wurzel ist `/secrets`; im Repository stehen ausschließlich nicht geheime Referenzen, und `secrets/` bleibt ausgeschlossen.
 
 Es gibt weiterhin keine Implementierung. Insbesondere existieren noch kein SQL, keine Tabellen, PostgreSQL-Installation, Programmierschnittstelle, Modellruntime, Benutzerverwaltung, Weboberfläche oder Infrastruktur.
 
-Der nächste kleine Schritt ist die fachliche Entscheidung, welche minimale Verantwortung RALF Core zwischen Benutzereingabe, ConversationRepository und einer späteren Modellruntime besitzt. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
+Der nächste kleine Schritt ist die Spezifikation des PostgreSQL-Referenzproviders und des Allocation-Lebenszyklus. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
 
 RALF entsteht transparent durch Vibe Coding: Menschen bestimmen Ziele, Entscheidungen und Grenzen; Coding-Agenten unterstützen die Umsetzung in kleinen, überprüfbaren Schritten.

--- a/docs/architecture/database-service.md
+++ b/docs/architecture/database-service.md
@@ -2,190 +2,255 @@
 
 ## Zweck
 
-Der Database Service ist die stabile persistente Datenschnittstelle von RALF. Er stellt strukturierte, transaktionale Datenhaltung als eigenständige RALF-Fähigkeit bereit und verantwortet deren Lebenszyklus. PostgreSQL ist die erste Referenzimplementierung, aber kein Bestandteil des öffentlichen RALF-Vertrags.
+Der Database Service ist eine gemeinsam nutzbare Datenbankplattform. Er verwaltet einen oder mehrere Datenbankprovider und deren Providerinstanzen und stellt daraus voneinander isolierte Datenbankzuweisungen für RALF-eigene Komponenten, externe Anwendungen und spätere interne Plattformkomponenten bereit.
 
-Andere RALF-Komponenten dürfen deshalb keine PostgreSQL-Verbindungsparameter, Systemtabellen, Erweiterungen, SQL-Dialekte, Fehlermeldungen oder Rollen voraussetzen. Das gilt ausdrücklich auch für `psql`, `pg_dump`, `pg_restore` und `pgvector`. PostgreSQL-spezifische Details bleiben im PostgreSQL-Provider sowie dessen Betriebs- und Administrationsschicht.
+PostgreSQL ist der erste Referenzprovider, aber kein Bestandteil des öffentlichen RALF-Vertrags. Ein Consumer ist weder Eigentümer des Database Service noch automatisch Eigentümer einer Providerinstanz. RALF Core ist der erste spezifizierte RALF-native Consumer, nicht der einzige Datenbankkunde.
 
 ## Architekturmodell
 
 ```text
-RALF-Komponenten
-       │
-       ▼
-RALF Database Contract
-       │
-       ▼
-Database Service
-       │
-       ▼
-Provider
-       │
-       └── PostgreSQL
+                         Database Service
+                 ┌─────────────────────────────┐
+                 │ Verwaltungsebene            │
+                 │                             │
+                 │ Providerinstanzen           │
+                 │ Database Allocations        │
+                 │ Identitäten / Secret-Refs   │
+                 │ Fähigkeiten                 │
+                 │ Health / Readiness          │
+                 │ Backup / Restore            │
+                 └──────────────┬──────────────┘
+                                │
+                       PostgreSQL-Provider
+                                │
+          ┌─────────────────────┼─────────────────────┐
+          │                     │                     │
+          ▼                     ▼                     ▼
+  Allocation RALF Core    Allocation Gitea     Allocation OpenBao
+          │                     │                     │
+ ConversationRepository   Gitea-eigener       OpenBao-eigener
+ PostgreSQL-Adapter       Datenbankzugriff     Storage-Zugriff
 ```
 
-Der **RALF Database Contract** beschreibt benötigte Fähigkeiten, providerneutrale Zustände und Fehler, Lebenszyklusoperationen, Schema- und Migrationsregeln sowie Sicherheits-, Backup- und Restore-Anforderungen.
+Das Modell beschreibt mögliche isolierte Zuweisungen, keine bereits laufende Installation. Weder Gitea noch OpenBao noch eine konkrete Allocation werden in diesem Schritt eingerichtet.
 
-Der **Database Service** verantwortet die persistente strukturierte Datenhaltung, die Einhaltung des Vertrags, die Auswahl genau eines aktiven Providers, Fähigkeits- und Statusmeldungen, kontrollierte Schemaentwicklung und die Verträge für Sicherung und Wiederherstellung.
+## Verwaltungs- und Datenebene
 
-Ein **Provider** bildet diesen Vertrag auf ein konkretes Datenbanksystem ab. Der erste Provider ist PostgreSQL. Spätere Provider wie MariaDB, Microsoft SQL Server, SQLite oder andere relationale Datenbanken sind architektonisch möglich, aber nicht zugesichert. Sie sind nur kompatibel, wenn sie die für das jeweilige RALF-Profil erforderlichen Fähigkeiten nachweislich erfüllen.
+### Verwaltungsebene
 
-## Providerprinzip und Abstraktionsgrenze
+Der providerneutrale Database-Service-Vertrag beschreibt Providerinstanzen, Database Allocations, Fähigkeiten, Isolation, technische Identitäten, Secret-Referenzen, Lebenszyklus, Health, Readiness, Backup, Restore sowie Versions- und Kompatibilitätsstatus.
 
-RALF abstrahiert Datenbankprodukte nicht um jeden Preis auf den kleinsten gemeinsamen Nenner. Der Vertrag ist fähigkeitsorientiert:
+Diese Ebene ist für RALF steuerbar. Sie plant und bewertet Zustände, ohne Anwendungsabfragen zu übersetzen.
 
-- Ein Provider deklariert die Fähigkeiten, die er tatsächlich und sicher bereitstellt.
-- RALF-Komponenten beziehungsweise Betriebsprofile deklarieren erforderliche und optionale Fähigkeiten.
-- Fehlt eine erforderliche Fähigkeit, wird die Kombination verständlich als inkompatibel oder eingeschränkt bewertet.
-- Zusätzliche Providerfähigkeiten werden nicht automatisch Bestandteil des allgemeinen Vertrags.
-- Providerdetails dürfen intern für Betrieb und Diagnose genutzt werden, aber nicht in den öffentlichen Vertrag durchsickern.
+### Datenebene
 
-### Entscheidung zur Datenzugriffsgrenze
+Anwendungen greifen später über das native Datenbankprotokoll des ausgewählten Providers direkt auf ihre eigene Allocation zu. Für PostgreSQL ist dies das PostgreSQL Wire Protocol.
 
-Der Database Service wird als **Betriebs- und Vertragsdienst** gestaltet. Er verwaltet Provider, Verbindungsfähigkeit, Fähigkeiten, Schema, Migrationen, Health, Readiness, Backup und Restore. Fachliche Datenoperationen gehören in domänenspezifische Repository- oder Datenschnittstellen der jeweils verantwortlichen RALF-Komponente.
+Der Database Service ist kein SQL-Proxy, übersetzt keine Anwendungsabfragen und stellt keine universelle CRUD-API bereit.
 
-Damit wird keine universelle RALF-Datenbanksprache geschaffen. Die im Vertrag genannten Datenoperationen sind vorläufige fachliche Begriffe zur Beschreibung notwendiger Transaktionseigenschaften, keine zentrale technische CRUD-API. Die genaue Kommunikation zwischen Domänen und Database Service bleibt offen.
+RALF-native Consumer verwenden weiterhin domänenspezifische Repository-Verträge und einen providerbezogenen Infrastrukturadapter. Externe Anwendungen verwenden ihre eigenen Datenbanktreiber, Datenmodelle und Schemata. Der Database Service versucht insbesondere nicht, das Datenmodell von Gitea oder OpenBao in einen RALF-Domänenvertrag zu übersetzen.
 
-Diese Grenze vermeidet eine künstliche Universal-API und hält fachliche Modelle bei ihren Eigentümern. Dafür müssen spätere Domänenverträge Providerneutralität und benötigte Fähigkeiten ausdrücklich berücksichtigen.
+## Database Consumer
 
-### Erster fachlicher Kunde
+Ein **Database Consumer** ist eine Anwendung oder RALF-Komponente, die eine isolierte Datenbankzuweisung benötigt.
 
-[ADR-0002](../decisions/ADR-0002-first-database-customer.md) legt RALF Core als ersten Datenbankkunden und [Conversation](../domains/conversation.md) als erste persistente Domäne fest. Die fachliche Persistenzgrenze bildet der [ConversationRepository Contract 0.1](../contracts/conversation-repository-v0.1.md).
-
-Conversation benötigt `relational_storage`, `transactions`, `schema_migrations`, `constraints` und `indexes`. `json_documents`, `full_text_search` und `advisory_locks` werden dadurch nicht verpflichtend. Backup und Restore bleiben Pflichten des Database Service, liegen aber außerhalb des Repository-Vertrags.
-
-Das Conversation-Schema gehört fachlich RALF Core. Der Database Service besitzt weder Conversation noch Message; er plant, validiert und führt später ausschließlich freigegebene, von der Domäne verantwortete Migrationen aus.
-
-## Umfang von Database Service 0.1
-
-Version 0.1 umfasst bewusst:
-
-- genau einen aktiven Datenbankprovider,
-- PostgreSQL als Referenzprovider,
-- eine RALF-Datenbankinstanz,
-- eine logische RALF-Datenbank,
-- getrennte technische Rollen,
-- transaktionale Datenoperationen,
-- ein versioniertes Schema,
-- kontrollierte Schemamigrationen,
-- getrennte Health- und Readiness-Prüfungen,
-- einen Backup- und Restore-Vertrag,
-- providerneutrale Zustände und Fehler.
-
-Nicht Bestandteil von 0.1 sind Vektorsuche und `pgvector`, Hochverfügbarkeit, Replikation, automatisches Failover, Sharding, Multi-Master, externe Mandanten, ein allgemeiner Datenbankdienst für fremde Anwendungen, Datenbank-Webadministration, automatische Performanceoptimierung, autonome Datenlöschung oder -reparatur sowie Cloud-Datenbankintegration.
-
-## Fähigkeitsmodell
-
-| Fähigkeit | Bedeutung | Einordnung für 0.1 |
+| Consumer-Art | Bedeutung | Beispiele |
 | --- | --- | --- |
-| `relational_storage` | Dauerhafte strukturierte Speicherung mit relationalen Beziehungen. | erforderlich |
-| `transactions` | Atomare, konsistente Transaktionsgrenzen für zusammengehörige Operationen. | erforderlich |
-| `schema_migrations` | Versionierte, geordnete und kontrolliert ausführbare Schemaänderungen. | erforderlich |
-| `constraints` | Datenbankseitige Durchsetzung definierter Integritätsregeln. | erforderlich |
-| `indexes` | Definierte Zugriffsstrukturen für vorhersehbare Abfragen. | erforderlich |
-| `json_documents` | Speicherung und gezielte Abfrage strukturierter JSON-Dokumente. | optional nutzbar |
-| `full_text_search` | Datenbankgestützte Volltextsuche. | optional nutzbar |
-| `advisory_locks` | Kooperative, anwendungsdefinierte Sperren für koordinierte Abläufe. | optional nutzbar |
-| `vector_search` | Ähnlichkeitssuche über Vektorrepräsentationen. | später |
-| `backup` | Kontrollierte Erzeugung einer sicherungsfähigen Datenrepräsentation. | erforderlich |
-| `restore` | Kontrollierte Wiederherstellung aus einer geprüften Sicherung. | erforderlich |
-| `point_in_time_recovery` | Wiederherstellung auf einen bestimmten Zeitpunkt. | später |
-| `replication` | Bereitstellung replizierter Datenbankkopien. | später |
-| `high_availability` | Betrieb mit definierten Verfügbarkeits- und Ausfallzielen. | später |
+| `ralf_native` | RALF-eigene Komponente mit domänenspezifischem Repository-Vertrag. | RALF Core |
+| `external_application` | Fremde Anwendung, die den Provider nativ verwendet und ihr eigenes Schema verantwortet. | Gitea, optional OpenBao |
+| `platform_internal` | Spätere technische Plattformkomponente ohne eigene fachliche RALF-Domäne. | noch nicht festgelegt |
 
-Die Einordnung gilt für Vertrag 0.1. Der erste Datenbankkunde Conversation benötigt weder `json_documents` noch `full_text_search`; beide bleiben optional.
+Ein Consumer-Profil beschreibt Anforderungen einer Anwendung, aber keine laufende Installation.
 
-## Verantwortlichkeiten
+## Database Allocation
 
-### Persistenz
+Eine **Database Allocation** ist eine isolierte Zuweisung von Datenbankressourcen an genau einen Consumer. Der fachliche Vertrag umfasst mindestens:
 
-- strukturierte RALF-Daten dauerhaft speichern,
-- konsistente Lese- und Schreibvorgänge ermöglichen,
-- Transaktionsgrenzen unterstützen,
-- relationale Integrität ermöglichen.
+- `allocation_id`
+- `consumer_id`
+- `provider_instance_id`
+- `database_name_reference`
+- `isolation_class`
+- `schema_lifecycle`
+- `required_capabilities`
+- `optional_capabilities`
+- `identity_references`
+- `secret_references`
+- `backup_policy_reference`
+- `retention_policy_reference`
+- `status`
 
-### Schema
+Diese Namen sind Vertragsbegriffe und weder Konfigurationsschema noch Datenbankobjekte.
 
-- aktuelle und angestrebte Schemaversion kennen,
-- Migrationen geordnet, versioniert und nachvollziehbar behandeln,
-- inkompatible oder unbekannte Schemaversionen erkennen,
-- Downgrades und Migrationserfolge nicht vortäuschen.
+### Referenzisolation
 
-### Fähigkeiten
+Für den ersten PostgreSQL-Referenzstand gilt als Standard:
 
-- unterstützte Fähigkeiten melden,
-- fehlende erforderliche Fähigkeiten als Inkompatibilität ausweisen,
-- Provider und Providerversion intern kennen,
-- keine providerspezifischen Details zum allgemeinen Vertrag erklären.
+- eine logische Datenbank pro Consumer,
+- eigene technische Identitäten pro Consumer,
+- keine Rechte auf Datenbanken anderer Consumer,
+- keine gemeinsam genutzten Anwendungsschemata, insbesondere kein gemeinsames `public`-Schema.
 
-### Betrieb
+Nicht vorgesehen sind eine gemeinsame Datenbank oder ein gemeinsames Anwendungsschema für alle Consumer, eine gemeinsame Anwendungsidentität oder ein gemeinsames Kennwort.
 
-- Health und Readiness getrennt bewerten,
-- Start-, Stopp-, Wartungs-, Migrations-, Backup- und Restore-Zustände melden,
-- Verbindungs-, Speicher- und Providerprobleme neutral klassifizieren,
-- kontrollierte Sicherungs- und Wiederherstellungsvorgänge ermöglichen.
+### Isolationsklassen
 
-### Sicherheit
+| Klasse | Bedeutung |
+| --- | --- |
+| `logical_database` | Eigene logische Datenbank innerhalb einer gemeinsam betriebenen Providerinstanz. |
+| `dedicated_provider_instance` | Eigene Providerinstanz aufgrund von Sicherheits-, Verfügbarkeits- oder Kompatibilitätsanforderungen. |
+| `external_provider` | Bereits vorhandene externe Datenbankbereitstellung, die der Database Service kontrolliert referenziert oder verwaltet. |
 
-- technische Rollen und ihre Aufgaben trennen,
-- normale Anwendungen nie mit administrativer Superuserrolle betreiben,
-- minimale Rechte verwenden,
-- Geheimnisse vom Repository und von nicht geheimer Konfiguration fernhalten,
-- Verbindungen und Identitäten als deployment-spezifische Konfiguration behandeln.
+Version 0.1 darf eine gemeinsame PostgreSQL-Providerinstanz mit mehreren logischen Datenbanken als Referenzprofil beschreiben. Jede Allocation verwendet genau einen aktiven Provider; die Architektur erlaubt später die Verlagerung einzelner Allocations auf dedizierte oder externe Providerinstanzen.
 
-### Auditierbarkeit
+## Gemeinsame Fehlerdomäne und Platzierung
 
-- Migrationen sowie Backup- und Restorevorgänge nachvollziehbar machen,
-- Statusänderungen und Fehlerursachen verständlich klassifizieren,
-- keine Geheimnisse oder vollständigen Zugangsdaten protokollieren.
+Eine gemeinsame Providerinstanz reduziert Betriebsaufwand, vergrößert aber die gemeinsame Fehlerdomäne. Ein Providerausfall kann mehrere Consumer gleichzeitig betreffen.
+
+Jede Allocation muss deshalb später Anforderungen an Verfügbarkeit, Isolation, Ressourcen, Backup und Restore deklarieren können:
+
+- `availability_requirement`
+- `isolation_requirement`
+- `resource_requirement`
+- `backup_requirement`
+- `restore_requirement`
+
+Ein sicherheitskritischer Consumer darf eine dedizierte Instanz verlangen. Version 0.1 trifft keine automatische Platzierungsentscheidung.
+
+## Schemaeigentum
+
+Jede Allocation besitzt genau einen sichtbaren Schema-Lebenszyklus:
+
+| Modus | Eigentum und Ablauf |
+| --- | --- |
+| `domain_managed` | Eine RALF-Domäne besitzt fachlich Schema und Migrationen. Der Database Service plant, prüft Providerfähigkeiten und führt freigegebene Migrationspakete aus. |
+| `application_managed` | Eine externe Anwendung besitzt Schema und Migrationen und führt sie nach ihrem Betriebsmodell aus. Der Database Service beansprucht keine fachliche Eigentümerschaft. |
+| `platform_preprovisioned` | Die Plattform legt ausdrücklich vertraglich verlangte Datenbankobjekte kontrolliert vor dem Anwendungsstart an. |
+
+RALF Core mit Conversation verwendet `domain_managed`. Gitea verwendet als mögliches Profil `application_managed`. Für OpenBao bleiben `application_managed` und `platform_preprovisioned` abhängig vom später gewählten Storage-Vertrag zu prüfen.
+
+Wenn eine externe Anwendung beim Start selbst migriert, muss ihr Consumer-Vertrag sichtbar festlegen, ob eine getrennte Migrationsidentität möglich ist, wann erweiterte Rechte benötigt werden, ob Laufzeit und Migration dieselbe Identität verwenden und ob Rechte anschließend reduziert werden können. Die RALF-native Regel „Anwendungsidentität ändert kein Schema“ wird auf externe Anwendungen nicht ungeprüft übertragen.
+
+## Consumer-Profile
+
+Ein **Database Consumer Profile** beschreibt Anforderungen, ohne eine Installation oder Allocation anzulegen. Es enthält mindestens:
+
+- `consumer_profile_id`
+- `consumer_type`
+- `supported_provider_ids`
+- `required_capabilities`
+- `optional_capabilities`
+- `schema_lifecycle`
+- `identity_model`
+- `backup_expectations`
+- `health_expectations`
+- `known_constraints`
+
+### RALF Core
+
+`ralf-core` ist ein `ralf_native`-Profil mit `domain_managed`. Conversation benötigt `relational_storage`, `transactions`, `schema_migrations`, `constraints`, `indexes`, `backup` und `restore`. Der [ConversationRepository Contract](../contracts/conversation-repository-v0.1.md) gilt ausschließlich für die RALF-Core-Allocation.
+
+### Gitea
+
+Gitea ist ein möglicher `external_application`-Consumer und unterstützt PostgreSQL als Datenbankbackend. Sein Profil verwendet `application_managed` und verlangt eine eigene logische Datenbank, eigene technische Identitäten und keine Rechte auf andere Allocations. Version, Provider-Mindestversion, Konfiguration, Schema, Migrationen und Installation bleiben offen.
+
+### OpenBao
+
+OpenBao ist ein möglicher `external_application`-Consumer. Sein PostgreSQL-Backend gilt als produktions- und HA-fähige Storage-Option; für die meisten neuen Installationen bleibt das von OpenBao empfohlene Integrated Storage dennoch ein gleichwertig zu prüfender Kandidat. PostgreSQL wird nicht automatisch ausgewählt. Bei einer PostgreSQL-Allocation wären eigene logische Datenbank, eigene Identitäten und fehlende Rechte auf andere Allocations Pflicht. Die konkrete Storage-Entscheidung bleibt offen.
+
+## Identitäten und Rollen pro Allocation
+
+Rollen und Identitäten werden pro Allocation betrachtet:
+
+- `allocation_owner`
+- `migration_identity`
+- `application_identity`
+- `backup_identity`
+- `monitoring_identity`
+
+Der frühere Begriff `database_owner` bezeichnet präzisiert den Provider- oder Allocation-Eigentümer und wird nie automatisch von einer Anwendung verwendet.
+
+Jede Allocation besitzt eigene Identitäten. Gemeinsame Anwendungsidentitäten oder Kennwörter, Zugriff auf fremde Datenbanken und PostgreSQL-Superuseridentitäten für Consumer sind unzulässig. Consumer-Profile dürfen ausdrücklich erklären, dass keine getrennte Migrationsidentität unterstützt wird oder Backup beziehungsweise Monitoring zentral erfolgt; Abweichungen bleiben sichtbar.
+
+## Secrets-Vertrag
+
+Die verbindliche externe Secrets-Wurzel ist absolut:
+
+```text
+/secrets/
+└── database-service/
+    ├── providers/
+    │   └── <provider-instance-id>/
+    └── allocations/
+        └── <allocation-id>/
+```
+
+Spätere Allocation-Dateien können `owner-password`, `migration-password`, `application-password`, `backup-password` oder `monitoring-password` heißen; nicht jede Allocation benötigt jede Datei. Diese Struktur ist ein Vertrag und wird hier nicht angelegt.
+
+Normale Konfiguration enthält nur nicht geheime absolute Referenzen, beispielsweise:
+
+```text
+secret_ref = "/secrets/database-service/allocations/gitea/application-password"
+```
+
+Kennwortwerte und vollständige Verbindungs-URLs mit Zugangsdaten sind ausgeschlossen.
+
+Später erzeugte Geheimnisse werden ausschließlich unter `/secrets` atomar und mit restriktiven Rechten geschrieben. Sie erscheinen weder in stdout, Logs, Kommandozeilenargumenten noch normalen Umgebungsvariablen, gelangen nicht in Git und werden nur durch einen ausdrücklich geplanten Rotationsvorgang ersetzt.
+
+Secret-Referenzen müssen absolute Pfade innerhalb `/secrets` sein, dürfen kein `..` und keine Auflösung außerhalb der Wurzel enthalten, keine unerwarteten Symlinks nutzen und ohne bewusstes Anwendungs-Gruppenmodell weder gruppen- noch weltlesbar sein.
+
+Das Repository behält zusätzlich den Ausschluss `secrets/`. Weder `/secrets` noch ein lokales `secrets/` darf committed oder gestaged werden.
+
+OpenBao kann später als Secrets-Provider untersucht werden, ersetzt `/secrets` aber nicht automatisch. Falls OpenBao selbst eine PostgreSQL-Allocation verwendet, dürfen seine Bootstrap-Datenbankgeheimnisse nicht zirkulär aus OpenBao stammen. `/secrets` bleibt zunächst der externe Bootstrap-Vertrauensanker; eine Migration anderer Geheimnisse zu OpenBao benötigt eine eigene Entscheidung und einen eigenen Plan.
+
+## Health und Readiness
+
+Health und Readiness werden getrennt für Providerinstanz und Allocation gemeldet:
+
+- `provider_health`
+- `provider_readiness`
+- `allocation_health`
+- `allocation_readiness`
+
+Ein Zustand kann beispielsweise gleichzeitig „Provider bereit“, „Gitea-Allocation bereit“, „RALF-Core-Allocation `migration_required`“ und „OpenBao-Allocation `unconfigured`“ lauten. Ein Fehler einer Allocation wird nicht automatisch als Fehler aller Allocations dargestellt.
+
+Allocation-Readiness verlangt mindestens eine bereite Providerinstanz, vorhandene logische Datenbank, benötigte Fähigkeiten, auflösbare Secret-Referenzen, verwendbare technische Identität, erwarteten Schemazustand, einen erforderlichen Backupvertrag und den Ausschluss fremder Zugriffsrechte.
+
+## Backup und Restore
+
+Version 0.1 beschreibt Backups mindestens allocation-bezogen. Jedes Backup gehört eindeutig zu `provider_instance_id`, `allocation_id` und `consumer_id`. Fachlicher Standard ist ein logisches Backup pro Allocation.
+
+Ein Restore einer Allocation darf keine andere Allocation oder die gesamte Providerinstanz stillschweigend überschreiben. Providerweite physische Sicherungen können später zusätzlich geplant werden.
+
+Bei OpenBao hängt der Backupvertrag vom gewählten Storage-Backend ab. Integrated Storage liegt außerhalb des PostgreSQL-Database-Service-Backups; eine PostgreSQL-Allocation fällt unter den Allocation-Backupvertrag. Diese Wahl wird nicht vorweggenommen.
+
+## Providerprinzip
+
+RALF abstrahiert Datenbankprodukte nicht auf den kleinsten gemeinsamen Nenner. Provider deklarieren Fähigkeiten; Consumer-Profile und Allocations deklarieren Anforderungen. Fehlende Pflichtfähigkeiten führen nachvollziehbar zu Inkompatibilität oder Einschränkung. Zusätzliche Providerfähigkeiten werden nicht automatisch allgemeiner Vertragsbestandteil.
+
+Andere RALF-Komponenten dürfen keine PostgreSQL-Systemtabellen, Erweiterungen, SQL-Dialekte, Fehlermeldungen, Rollen oder Werkzeuge voraussetzen. Externe Anwendungen dürfen den von ihnen ausdrücklich unterstützten Provider nativ verwenden, ohne dass ihre Fachmodelle Teil des RALF-Vertrags werden.
 
 ## Nicht-Verantwortlichkeiten
 
-Der Database Service ist kein Datei- oder Objekt-Storage, Cache, Message Queue, Event Bus, Suchdienst, allgemeiner Vektorspeicher oder Secrets-Dienst. Er verantwortet weder Modellinferenz und Modellverwaltung noch Benutzeroberfläche, Reverse Proxy, Netzwerk-, Container-, Proxmox- oder OPNsense-Verwaltung. Er ist außerdem kein allgemeiner Datenbankverwaltungsdienst für Anwendungen außerhalb von RALF.
-
-## Fachliches Rollenmodell
-
-| Rolle | Sicherheitsziel |
-| --- | --- |
-| `database_owner` | Besitzt die logische Datenbank beziehungsweise zentrale Objekte und wird nie für normale RALF-Anwendungszugriffe verwendet. |
-| `migration_role` | Darf ausschließlich während eines freigegebenen Migrationsvorgangs kontrollierte Schemaänderungen ausführen. |
-| `application_role` | Besitzt nur die für den normalen fachlichen Betrieb erforderlichen Lese- und Schreibrechte und keine administrativen Rechte. |
-| `backup_role` | Besitzt nur die für geplante Sicherung und Wiederherstellung notwendigen Rechte. |
-| `monitoring_role` | Darf ausschließlich die für Status, Health, Readiness und Diagnose erforderlichen Informationen lesen. |
-
-Ein Provider darf diese Rollen technisch anders abbilden, muss aber dieselbe Trennung und dieselben Sicherheitsziele nachweisbar erfüllen.
-
-## Konfigurationsvertrag
-
-Die spätere nicht geheime Konfiguration wird in folgende Kategorien gegliedert:
-
-- **Provider:** `provider_id`, `provider_version`
-- **Verbindung:** `host`, `port`, `database_name`, `connection_security`, `connection_timeout`
-- **Rollenreferenzen:** `application_identity`, `migration_identity`, `backup_identity`, `monitoring_identity`
-- **Betrieb:** `health_timeout`, `migration_policy`, `backup_policy`, `retention_policy`
-- **Fähigkeiten:** `required_capabilities`, `optional_capabilities`
-
-Diese Namen definieren Kategorien, noch kein Dateiformat und keine öffentliche Programmierschnittstelle. Kennwörter, private Schlüssel, API-Tokens, vollständige Connection Strings mit Zugangsdaten, Cloud-Credentials und Backup-Verschlüsselungsschlüssel gehören niemals in normale Konfigurationsdateien. Ein eigener Secrets-Vertrag wird später benötigt und ist nicht Teil dieser Spezifikation.
-
-## Lebenszyklus
-
-Der providerneutrale Lebenszyklus unterscheidet `unknown`, `unconfigured`, `configured`, `starting`, `ready`, `degraded`, `maintenance`, `migration_required`, `migrating`, `backup_running`, `restore_running`, `failed` und `stopped`. Nur `ready` erlaubt reguläre Lese- und Schreibzugriffe. Eingeschränkte Zugriffe in `degraded` oder `backup_running` benötigen eine ausdrücklich belegte Providerzusage; Migration, Restore und Fehlerzustände sperren den normalen Datenzugriff.
-
-Die genaue Bedeutung und die Zugriffsgrenzen jedes Zustands sind im [Vertrag 0.1](../contracts/database-service-v0.1.md#lebenszykluszustände) definiert. Administrative Aktionen bedeuten dort ausschließlich ausdrücklich geplante, autorisierte Lebenszyklusvorgänge; sie sind keine allgemeine Administrationsfreigabe.
-
-## Sicherheitsgrenzen
-
-- Andere RALF-Komponenten sehen keine PostgreSQL-spezifischen Zugangsdaten oder Werkzeuge.
-- Normale Anwendungsidentitäten besitzen keine Owner-, Migrations- oder Backuprechte.
-- Migration, Backup und Restore sind getrennte, geplante Vorgänge mit eigener Freigabe.
-- Fehlerantworten enthalten keine Geheimnisse und keine providerspezifischen Interna als Vertragsbestandteil.
-- Restore, Datenlöschung und Reparatur erfolgen niemals automatisch.
+Der Database Service ist kein SQL-Proxy, allgemeiner CRUD-Dienst, Datei- oder Objekt-Storage, Cache, Message Queue, Event Bus, Suchdienst, Vektorspeicher oder Secrets-Provider. Er verwaltet weder fremde Anwendungsfachmodelle noch Modellinferenz, Benutzeroberflächen, Reverse Proxy, Netzwerk, Container, Proxmox oder OPNsense.
 
 ## PostgreSQL als Referenzprovider
 
-Der PostgreSQL-Provider soll später Version und Verfügbarkeit erkennen, Verbindungen aufbauen, das Rollenmodell abbilden, die logische Datenbank anlegen und verwalten, providerspezifische Migrationen ausführen, Health und Readiness prüfen, logische Backups und Restore umsetzen, Fehler in RALF-Fehlerklassen übersetzen und seine Fähigkeiten deklarieren.
+PostgreSQL ist der erste Provider. Eine konkrete Version, Paketquelle, Betriebsform, Netzwerkgrenze, Serverkonfiguration, Datenbankbezeichnung, Identität, Port, Adresse oder Zugangsdaten werden noch nicht festgelegt.
 
-Noch nicht entschieden sind Referenzversion, Paketquelle, Betriebsform, Netzwerkfreigaben, Serverkonfiguration, Zugriffsregeln, Datenverzeichnis, Backupziel und Zugangsdaten. Diese Punkte gehören in spätere getrennte Entscheidungen.
+## Offene Entscheidungen
 
-## SQLite-Abgrenzung
+1. Welche Allocations werden in der ersten realen PostgreSQL-Instanz angelegt?
+2. Beginnt die Referenzinstallation nur mit RALF Core oder zusätzlich mit Gitea?
+3. Verwendet OpenBao Integrated Storage oder PostgreSQL?
+4. Welche Consumer benötigen eine dedizierte Providerinstanz?
+5. Welche externen Anwendungen führen Migrationen selbst aus?
+6. Wie erhalten Anwendungen Zugriff auf ihre Secrets unter `/secrets`?
+7. Welche Eigentümer- und Gruppenrechte gelten unter `/secrets`?
+8. Wie erfolgt Secret-Rotation?
+9. Welche Backups erfolgen pro Allocation und welche providerweit?
+10. Wie werden Ressourcenlimits pro Allocation abgebildet?
+11. Welche Netzwerkgrenzen gelten zwischen Consumer und Provider?
+12. Welche PostgreSQL-Version wird Referenzversion?
 
-SQLite kann später einen Minimal- oder Einzelprozessprovider bilden. Es ist nicht automatisch gleichwertig mit PostgreSQL und darf nur Fähigkeiten deklarieren, die es im gewählten Betriebsprofil sicher erfüllt. Eine möglicherweise eingebettete SQLite-Datenbank einer anderen RALF-Komponente wäre nicht automatisch der RALF Database Service.
+**Nächster kleiner Schritt:** Definiere den PostgreSQL-Referenzprovider und den Allocation-Lebenszyklus, ohne PostgreSQL zu installieren.

--- a/docs/architecture/database-service.md
+++ b/docs/architecture/database-service.md
@@ -47,6 +47,14 @@ Damit wird keine universelle RALF-Datenbanksprache geschaffen. Die im Vertrag ge
 
 Diese Grenze vermeidet eine künstliche Universal-API und hält fachliche Modelle bei ihren Eigentümern. Dafür müssen spätere Domänenverträge Providerneutralität und benötigte Fähigkeiten ausdrücklich berücksichtigen.
 
+### Erster fachlicher Kunde
+
+[ADR-0002](../decisions/ADR-0002-first-database-customer.md) legt RALF Core als ersten Datenbankkunden und [Conversation](../domains/conversation.md) als erste persistente Domäne fest. Die fachliche Persistenzgrenze bildet der [ConversationRepository Contract 0.1](../contracts/conversation-repository-v0.1.md).
+
+Conversation benötigt `relational_storage`, `transactions`, `schema_migrations`, `constraints` und `indexes`. `json_documents`, `full_text_search` und `advisory_locks` werden dadurch nicht verpflichtend. Backup und Restore bleiben Pflichten des Database Service, liegen aber außerhalb des Repository-Vertrags.
+
+Das Conversation-Schema gehört fachlich RALF Core. Der Database Service besitzt weder Conversation noch Message; er plant, validiert und führt später ausschließlich freigegebene, von der Domäne verantwortete Migrationen aus.
+
 ## Umfang von Database Service 0.1
 
 Version 0.1 umfasst bewusst:
@@ -84,7 +92,7 @@ Nicht Bestandteil von 0.1 sind Vektorsuche und `pgvector`, Hochverfügbarkeit, R
 | `replication` | Bereitstellung replizierter Datenbankkopien. | später |
 | `high_availability` | Betrieb mit definierten Verfügbarkeits- und Ausfallzielen. | später |
 
-Die Einordnung ist der Architekturvorschlag für Vertrag 0.1. Ob `json_documents` oder `full_text_search` bereits verpflichtend werden, hängt von den zuerst festgelegten fachlichen Daten und Datenbankkunden ab.
+Die Einordnung gilt für Vertrag 0.1. Der erste Datenbankkunde Conversation benötigt weder `json_documents` noch `full_text_search`; beide bleiben optional.
 
 ## Verantwortlichkeiten
 

--- a/docs/architecture/ralf-core.md
+++ b/docs/architecture/ralf-core.md
@@ -2,7 +2,7 @@
 
 ## Zweck
 
-RALF Core ist die erste fachliche Komponente von RALF und der erste Kunde des Database Service. Der Core koordiniert fachliche Abläufe des Assistenten, ohne selbst Datenbankbetrieb, Providerverwaltung oder Infrastrukturinstallation zu übernehmen.
+RALF Core ist die erste fachliche Komponente von RALF und der erste spezifizierte RALF-native Database Consumer. Der Core koordiniert fachliche Abläufe des Assistenten, ohne selbst Datenbankbetrieb, Providerverwaltung oder Infrastrukturinstallation zu übernehmen. Er ist weder der einzige mögliche Consumer noch Eigentümer des Database Service oder einer Providerinstanz.
 
 Die erste persistente Domäne im Core ist **Conversation**. Sie bewahrt Unterhaltungen und deren geordnete Nachrichten. Für Version 0.1 bleibt sie ein klar abgegrenzter Bestandteil von RALF Core und wird nicht als eigenständig deploybarer Netzwerkdienst ausgelegt.
 
@@ -14,19 +14,21 @@ Benutzer
    ▼
 RALF Core
    │
-   ├── Conversation-Domäne
-   │      │
-   │      ▼
-   │   ConversationRepository
-   │      │
-   │      ▼
-   │   späterer Provideradapter
-   │
-   ▼
-Database Service
-   │
-   ▼
-PostgreSQL-Provider
+   └── Conversation-Domäne
+          │
+          ▼
+      ConversationRepository
+          │
+          ▼
+      PostgreSQL-Infrastrukturadapter
+          │
+          ▼
+      RALF-Core-Allocation
+          │
+          ▼
+      PostgreSQL-Provider
+
+Database Service ── verwaltet Provider und RALF-Core-Allocation
 ```
 
 Die Darstellung beschreibt Verantwortungsgrenzen, keine Prozess-, Netzwerk- oder Programmierschnittstelle:
@@ -34,9 +36,10 @@ Die Darstellung beschreibt Verantwortungsgrenzen, keine Prozess-, Netzwerk- oder
 - RALF Core besitzt das fachliche Conversation-Modell.
 - Der Repository-Vertrag gehört zur Conversation-Domäne.
 - Ein späterer Infrastrukturadapter übersetzt diesen Domänenvertrag in die Persistenzmechanismen des ausgewählten Providers.
-- Der Database Service verwaltet Provider, Fähigkeiten, Datenbanklebenszyklus, Schemaausführung, Health, Backup und Restore, besitzt aber nicht die fachliche Conversation-Domäne.
+- Der Database Service verwaltet die RALF-Core-Allocation, Provider, Fähigkeiten, Datenbanklebenszyklus, Schemaausführung, Health, Backup und Restore, besitzt aber nicht die fachliche Conversation-Domäne.
 - PostgreSQL-spezifische Persistenzdetails bleiben im späteren PostgreSQL-Adapter beziehungsweise Provider.
 - Andere RALF-Komponenten greifen nicht direkt auf den persistenten Conversation-Datenbestand zu.
+- Externe Database Consumer verwenden weder RALF Core noch ConversationRepository.
 
 ## Erste fachliche Verantwortung
 
@@ -59,11 +62,11 @@ Die Domänengrenze bleibt durch Modell, Invarianten und Repository-Vertrag denno
 
 ## Verhältnis zum Database Service
 
-RALF Core fordert für Conversation die Fähigkeiten `relational_storage`, `transactions`, `schema_migrations`, `constraints` und `indexes`. Backup und Restore bleiben Pflichtfähigkeiten des Database Service, werden aber nicht durch den Conversation-Repository-Vertrag aufgerufen.
+Die RALF-Core-Allocation fordert für Conversation die Fähigkeiten `relational_storage`, `transactions`, `schema_migrations`, `constraints` und `indexes`. Backup und Restore bleiben Pflichtfähigkeiten ihres Allocation-Vertrags, werden aber nicht durch ConversationRepository aufgerufen.
 
 Der fachliche Conversation-Schemastand gehört RALF Core beziehungsweise der Conversation-Domäne. Spätere Migrationspakete werden dort versioniert; der Database Service plant, validiert und führt ausschließlich freigegebene Migrationen aus. Ein Start von RALF Core löst keine stille Migration aus.
 
-Im Normalbetrieb nutzt RALF Core ausschließlich die fachliche `application_role`. Schemaänderungen bleiben der `migration_role` vorbehalten; Backup und Monitoring verwenden weiterhin ihre getrennten Rollen.
+Im Normalbetrieb nutzt RALF Core ausschließlich seine allocation-eigene `application_identity`. Schemaänderungen bleiben der `migration_identity` vorbehalten; Backup und Monitoring verwenden weiterhin getrennte Identitäten.
 
 ## Verhältnis zu einer späteren Modellruntime
 
@@ -83,7 +86,7 @@ RALF Core kann grundsätzlich gesund sein, obwohl Conversation-Persistenz nicht 
 - alle benötigten Fähigkeiten sind vorhanden,
 - das Conversation-Schema ist kompatibel,
 - keine erforderliche Migration steht aus,
-- `application_role` besitzt die minimal notwendigen Rechte,
+- die allocation-eigene `application_identity` besitzt die minimal notwendigen Rechte,
 - eine Lese- und Schreibtransaktion kann sicher ausgeführt werden.
 
 Beispiel: `healthy = true`, aber `conversation_persistence_ready = false` mit dem providerneutralen Grund `schema_migration_required`.
@@ -92,6 +95,6 @@ Beispiel: `healthy = true`, aber `conversation_persistence_ready = false` mit de
 
 RALF Core übernimmt in diesem Schritt weder Installer- oder Infrastrukturaufgaben noch Datenbankadministration. Ebenfalls nicht definiert werden Webinterface, Authentifizierung, Benutzer- oder Mandantenverwaltung, Modellruntime, Tool-Ausführung, Langzeitgedächtnis, Wissensspeicher, Streaming oder Netzwerkprotokolle.
 
-## Nächste Architekturentscheidung
+## Offene Core-Frage
 
-Als Nächstes ist zu entscheiden, welche minimale Verantwortung RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime besitzt. Diese Entscheidung ist weiterhin keine PostgreSQL-Installation und keine Implementierung.
+Für RALF Core bleibt zu entscheiden, welche minimale Verantwortung er zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime besitzt. Der nächste projektweite Schritt ist gemäß ADR-0003 zunächst die Spezifikation des PostgreSQL-Referenzproviders und des Allocation-Lebenszyklus, weiterhin ohne Installation oder Implementierung.

--- a/docs/architecture/ralf-core.md
+++ b/docs/architecture/ralf-core.md
@@ -1,0 +1,97 @@
+# RALF Core – Architekturrahmen 0.1
+
+## Zweck
+
+RALF Core ist die erste fachliche Komponente von RALF und der erste Kunde des Database Service. Der Core koordiniert fachliche Abläufe des Assistenten, ohne selbst Datenbankbetrieb, Providerverwaltung oder Infrastrukturinstallation zu übernehmen.
+
+Die erste persistente Domäne im Core ist **Conversation**. Sie bewahrt Unterhaltungen und deren geordnete Nachrichten. Für Version 0.1 bleibt sie ein klar abgegrenzter Bestandteil von RALF Core und wird nicht als eigenständig deploybarer Netzwerkdienst ausgelegt.
+
+## Architekturmodell
+
+```text
+Benutzer
+   │
+   ▼
+RALF Core
+   │
+   ├── Conversation-Domäne
+   │      │
+   │      ▼
+   │   ConversationRepository
+   │      │
+   │      ▼
+   │   späterer Provideradapter
+   │
+   ▼
+Database Service
+   │
+   ▼
+PostgreSQL-Provider
+```
+
+Die Darstellung beschreibt Verantwortungsgrenzen, keine Prozess-, Netzwerk- oder Programmierschnittstelle:
+
+- RALF Core besitzt das fachliche Conversation-Modell.
+- Der Repository-Vertrag gehört zur Conversation-Domäne.
+- Ein späterer Infrastrukturadapter übersetzt diesen Domänenvertrag in die Persistenzmechanismen des ausgewählten Providers.
+- Der Database Service verwaltet Provider, Fähigkeiten, Datenbanklebenszyklus, Schemaausführung, Health, Backup und Restore, besitzt aber nicht die fachliche Conversation-Domäne.
+- PostgreSQL-spezifische Persistenzdetails bleiben im späteren PostgreSQL-Adapter beziehungsweise Provider.
+- Andere RALF-Komponenten greifen nicht direkt auf den persistenten Conversation-Datenbestand zu.
+
+## Erste fachliche Verantwortung
+
+RALF Core soll zunächst nur die Grenze zwischen Benutzereingabe, Conversation-Domäne und einer späteren Modellruntime sauber tragen. Die minimale konkrete Orchestrierungsverantwortung ist noch zu entscheiden.
+
+Der Core ist in diesem Architekturstand verantwortlich für:
+
+- das Einhalten der fachlichen Conversation-Regeln,
+- die Verwendung des `ConversationRepository` als Persistenzgrenze,
+- die Unterscheidung von Core-Health und Conversation-Persistenz-Readiness,
+- die Trennung fachlicher Fehler von Providerrohfehlern.
+
+Nicht festgelegt werden bereits Anwendungsschnittstelle, Ausführungsmodell, Streaming, Modellaufruf oder technische Repository-Anbindung.
+
+## Conversation bleibt eine Core-Domäne
+
+Ein eigener Conversation-Microservice wird für 0.1 nicht vorgesehen. Unterhaltung ist eine zentrale Kernfunktion des Assistenten; ein zusätzlicher Netzwerkdienst würde derzeit Betriebs-, Deployment- und Schnittstellenkomplexität erzeugen, ohne dass unabhängige Skalierungs- oder Sicherheitsanforderungen bekannt sind.
+
+Die Domänengrenze bleibt durch Modell, Invarianten und Repository-Vertrag dennoch explizit. Eine spätere Auslagerung ist möglich, wenn reale Anforderungen sie rechtfertigen. Hypothetische Skalierung allein ist dafür kein Grund.
+
+## Verhältnis zum Database Service
+
+RALF Core fordert für Conversation die Fähigkeiten `relational_storage`, `transactions`, `schema_migrations`, `constraints` und `indexes`. Backup und Restore bleiben Pflichtfähigkeiten des Database Service, werden aber nicht durch den Conversation-Repository-Vertrag aufgerufen.
+
+Der fachliche Conversation-Schemastand gehört RALF Core beziehungsweise der Conversation-Domäne. Spätere Migrationspakete werden dort versioniert; der Database Service plant, validiert und führt ausschließlich freigegebene Migrationen aus. Ein Start von RALF Core löst keine stille Migration aus.
+
+Im Normalbetrieb nutzt RALF Core ausschließlich die fachliche `application_role`. Schemaänderungen bleiben der `migration_role` vorbehalten; Backup und Monitoring verwenden weiterhin ihre getrennten Rollen.
+
+## Verhältnis zu einer späteren Modellruntime
+
+Die Conversation-Domäne speichert Gesprächsverläufe, führt aber keine Modellinferenz aus. Eine spätere Core-Orchestrierung kann Benutzernachrichten persistieren, eine Assistentenantwort beginnen und eine Modellruntime ansprechen. Reihenfolge, Streaming- und Fehlerablauf dieser Koordination sind noch nicht entschieden.
+
+Conversation kennt keine Modellinstanz, Modell-ID, Provideradresse oder Provider-Credentials. Eine spätere nicht geheime Ausführungsreferenz benötigt eine eigene Entscheidung.
+
+## Health und Readiness
+
+RALF Core kann grundsätzlich gesund sein, obwohl Conversation-Persistenz nicht bereit ist.
+
+**Core healthy** bedeutet zunächst, dass der Core-Prozess grundsätzlich läuft und die Conversation-Domäne initialisierbar ist.
+
+**Conversation persistence ready** setzt zusätzlich voraus:
+
+- Database Service ist `ready`,
+- alle benötigten Fähigkeiten sind vorhanden,
+- das Conversation-Schema ist kompatibel,
+- keine erforderliche Migration steht aus,
+- `application_role` besitzt die minimal notwendigen Rechte,
+- eine Lese- und Schreibtransaktion kann sicher ausgeführt werden.
+
+Beispiel: `healthy = true`, aber `conversation_persistence_ready = false` mit dem providerneutralen Grund `schema_migration_required`.
+
+## Nicht-Verantwortlichkeiten
+
+RALF Core übernimmt in diesem Schritt weder Installer- oder Infrastrukturaufgaben noch Datenbankadministration. Ebenfalls nicht definiert werden Webinterface, Authentifizierung, Benutzer- oder Mandantenverwaltung, Modellruntime, Tool-Ausführung, Langzeitgedächtnis, Wissensspeicher, Streaming oder Netzwerkprotokolle.
+
+## Nächste Architekturentscheidung
+
+Als Nächstes ist zu entscheiden, welche minimale Verantwortung RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime besitzt. Diese Entscheidung ist weiterhin keine PostgreSQL-Installation und keine Implementierung.

--- a/docs/contracts/conversation-repository-v0.1.md
+++ b/docs/contracts/conversation-repository-v0.1.md
@@ -1,0 +1,128 @@
+# ConversationRepository Contract 0.1
+
+## Status und Zweck
+
+Dieser Vertrag beschreibt die fachliche Persistenzgrenze der Conversation-Domäne in RALF Core. `ConversationRepository` ist ein Domänenvertrag und noch keine Klasse, Bibliothek, REST-, RPC-, MCP-, Python- oder SQL-Schnittstelle.
+
+Er schützt das fachliche Modell vor Providerdetails und verhindert generische Tabellen- oder CRUD-Zugriffe. Der Database Service bleibt für Providerbetrieb, Fähigkeiten, Schemaausführung, Health, Backup und Restore verantwortlich.
+
+## Verantwortung
+
+Das Repository ermöglicht ausschließlich das konsistente Speichern und Wiederherstellen von `Conversation` und `Message` gemäß den [Domänenregeln](../domains/conversation.md). Es erzwingt beziehungsweise bewahrt fachlich relevante Invarianten, Reihenfolge, Statusübergänge, Transaktionsgrenzen und Löschzusammenhang.
+
+Es besitzt weder den Database Service noch den PostgreSQL-Provider. Eine spätere Implementierung darf Providerdetails nur hinter einem Infrastrukturadapter verwenden.
+
+## Fachliche Operationen
+
+Die Namen gliedern den Vertrag, sind aber keine Funktionssignaturen und legen keine Parameter fest.
+
+### Unterhaltungen
+
+- `create_conversation`
+- `get_conversation`
+- `list_conversations`
+- `archive_conversation`
+- `delete_conversation`
+
+### Nachrichten lesen
+
+- `list_messages`
+- `get_message`
+
+### Benutzernachrichten
+
+- `append_user_message`
+
+### Assistentenantworten
+
+- `begin_assistant_message`
+- `append_assistant_content`
+- `complete_assistant_message`
+- `fail_assistant_message`
+- `cancel_assistant_message`
+
+## Eingangs- und Ergebnisbegriffe
+
+Spätere technische Signaturen können folgende fachliche Informationen benötigen, ohne dass Form, Typ oder Transport bereits festgelegt werden:
+
+- eine stabile Conversation- oder Message-Referenz,
+- den erwarteten Conversation-Revisionsstand,
+- eine nicht bedeutungstragende fachliche Operationsreferenz zur möglichen Wiederholungserkennung,
+- Rolle, Inhaltstyp und Textinhalt einer neuen Nachricht,
+- einen kontrollierten zusätzlichen Textteil für eine laufende Assistentenantwort,
+- eine redigierte providerneutrale Fehlerzusammenfassung,
+- Listenfilter für aktive oder archivierte Unterhaltungen,
+- eine noch festzulegende Begrenzung und Fortsetzung für Listen.
+
+Ergebnisse beschreiben fachliche Snapshots von Conversation oder Message, geordnete Listen, den neuen Revisionsstand oder einen providerneutralen Fehler. Sie geben keine Datenbankzeilen, SQL-Ergebnisse, Connection-Objekte oder PostgreSQL-Fehler aus.
+
+## Verbindliche Semantik
+
+- Erzeugen, Statuswechsel und Löschung respektieren die Invarianten der Domäne.
+- Listen von Nachrichten sind fachlich nach `sequence` geordnet.
+- `append_user_message` speichert eine Benutzernachricht vollständig als `completed`.
+- `begin_assistant_message` erzeugt höchstens eine aktive Antwort pro Unterhaltung.
+- Nur `in_progress` darf durch `append_assistant_content` erweitert werden.
+- `complete_assistant_message`, `fail_assistant_message` und `cancel_assistant_message` erzeugen einen fachlich unveränderlichen Endzustand.
+- Eine archivierte Unterhaltung lehnt neue Nachrichten ab.
+- `delete_conversation` behandelt Unterhaltung und Nachrichten als eine fachliche Einheit.
+- Eine teilweise persistierte Operation wird nie als erfolgreich gemeldet.
+
+## Providerneutrale Fehlerkategorien
+
+| Kategorie | Bedeutung |
+| --- | --- |
+| `conversation_not_found` | Die referenzierte Unterhaltung existiert nicht. |
+| `conversation_archived` | Die gewünschte Schreiboperation ist für eine archivierte Unterhaltung nicht zulässig. |
+| `message_not_found` | Die referenzierte Nachricht existiert nicht in der erwarteten Unterhaltung. |
+| `invalid_message_state` | Der verlangte Übergang passt nicht zum aktuellen Nachrichtenstatus. |
+| `active_response_exists` | Es existiert bereits eine Assistentenantwort `in_progress`. |
+| `revision_conflict` | Der erwartete Conversation-Revisionsstand stimmt nicht mit dem aktuellen Stand überein. |
+| `duplicate_operation` | Eine fachlich identische oder bereits abgeschlossene Operation wurde als Wiederholung erkannt. |
+| `content_invalid` | Inhalt, Rolle oder Inhaltstyp verletzt den Conversation-Vertrag. |
+| `persistence_unavailable` | Conversation-Persistenz ist aktuell nicht bereit. |
+| `transaction_failed` | Die fachliche Operation konnte nicht atomar abgeschlossen werden. |
+| `unknown_error` | Der Fehler konnte keiner stabilen Kategorie zugeordnet werden. |
+
+Die konkrete Fehlerstruktur und die Abbildung auf Database-Service-Fehler bleiben offen. Rohfehler, Stacktraces, SQL, Zugangsdaten und vollständige Providerantworten überschreiten die Repository-Grenze nicht.
+
+## Parallelität und Idempotenz
+
+Der Vertrag verlangt keine doppelte Sequenz, keine stillschweigende doppelte Nachricht und keine zwei parallelen aktiven Assistentenantworten. Die konkrete Erkennung über erwartete Revision, Operation-ID, Idempotency-Key oder eine Kombination bleibt eine offene Entscheidung.
+
+Eine Wiederholung eines bereits erfolgreichen Abschlusses darf nicht unbemerkt einen zweiten fachlichen Effekt erzeugen. Ebenso darf ein Netzwerkfehler nicht automatisch als Begründung für eine doppelte Benutzernachricht dienen.
+
+## Benötigte Database-Service-Fähigkeiten
+
+Conversation 0.1 verlangt:
+
+- `relational_storage`
+- `transactions`
+- `schema_migrations`
+- `constraints`
+- `indexes`
+
+Nicht erforderlich sind `json_documents`, `full_text_search`, `advisory_locks`, `vector_search`, `point_in_time_recovery`, `replication` und `high_availability`.
+
+`backup` und `restore` bleiben erforderliche Fähigkeiten des Database Service, sind aber keine Operationen des ConversationRepository.
+
+## Rollen- und Schemavertrag
+
+Normale Repository-Operationen verwenden ausschließlich `application_role` mit minimalen Conversation-Lese- und Schreibrechten. Der Vertrag bietet keine Rollenverwaltung und keine Schemaänderung. Migrationspakete gehören fachlich zur Conversation-Domäne, werden aber nur über den Database Service und `migration_role` geplant und ausgeführt.
+
+Der konkrete PostgreSQL-Adapter, Objektbezeichnungen, Datentypen, Constraints und Indizes werden in diesem Vertrag nicht festgelegt.
+
+## Ausgeschlossene Funktionen
+
+Das Repository bietet kein generisches SQL, keine frei formulierbaren Abfragen, keine beliebigen Tabellenzugriffe, kein CRUD für andere Domänen und keine Provider- oder Datenbankbenutzerverwaltung. Es führt weder Backup, Restore, Modellinferenz, Promptaufbau, Streaming, semantische Suche noch Tool-Ausführung aus.
+
+## Offene Vertragsfragen
+
+- Welche Informationen sind für das Starten einer Conversation minimal erforderlich?
+- Welche Parallelitäts- und Idempotenzbegriffe werden verbindlich?
+- Wie werden Listen begrenzt und stabil fortgesetzt?
+- Wie werden „erneut senden“, Korrektur oder Supersede fachlich modelliert?
+- Welche maximale Textgröße gilt?
+- Wie wird ein späterer Infrastrukturadapter an RALF Core gebunden?
+
+Keine dieser Fragen legt bereits eine technische API oder Implementierung fest.

--- a/docs/contracts/conversation-repository-v0.1.md
+++ b/docs/contracts/conversation-repository-v0.1.md
@@ -6,6 +6,8 @@ Dieser Vertrag beschreibt die fachliche Persistenzgrenze der Conversation-Domän
 
 Er schützt das fachliche Modell vor Providerdetails und verhindert generische Tabellen- oder CRUD-Zugriffe. Der Database Service bleibt für Providerbetrieb, Fähigkeiten, Schemaausführung, Health, Backup und Restore verantwortlich.
 
+Der Vertrag gilt ausschließlich für die RALF-Core-Allocation. Gitea, OpenBao und andere externe Database Consumer verwenden ihre eigenen nativen Datenbank- beziehungsweise Storage-Zugriffe und niemals ConversationRepository.
+
 ## Verantwortung
 
 Das Repository ermöglicht ausschließlich das konsistente Speichern und Wiederherstellen von `Conversation` und `Message` gemäß den [Domänenregeln](../domains/conversation.md). Es erzwingt beziehungsweise bewahrt fachlich relevante Invarianten, Reihenfolge, Statusübergänge, Transaktionsgrenzen und Löschzusammenhang.
@@ -108,7 +110,7 @@ Nicht erforderlich sind `json_documents`, `full_text_search`, `advisory_locks`, 
 
 ## Rollen- und Schemavertrag
 
-Normale Repository-Operationen verwenden ausschließlich `application_role` mit minimalen Conversation-Lese- und Schreibrechten. Der Vertrag bietet keine Rollenverwaltung und keine Schemaänderung. Migrationspakete gehören fachlich zur Conversation-Domäne, werden aber nur über den Database Service und `migration_role` geplant und ausgeführt.
+Normale Repository-Operationen verwenden ausschließlich die allocation-eigene `application_identity` mit minimalen Conversation-Lese- und Schreibrechten. Der Vertrag bietet keine Rollenverwaltung und keine Schemaänderung. Migrationspakete gehören fachlich zur Conversation-Domäne, werden aber nur über den Database Service und `migration_identity` geplant und ausgeführt.
 
 Der konkrete PostgreSQL-Adapter, Objektbezeichnungen, Datentypen, Constraints und Indizes werden in diesem Vertrag nicht festgelegt.
 

--- a/docs/contracts/database-allocation-v0.1.md
+++ b/docs/contracts/database-allocation-v0.1.md
@@ -1,0 +1,235 @@
+# Database Allocation Contract 0.1
+
+## Status und Zweck
+
+Dieser Vertrag beschreibt eine isolierte Zuweisung von Datenbankressourcen an genau einen Database Consumer. Er ist Teil der providerneutralen Verwaltungsebene des Database Service und definiert weder eine technische API noch SQL, Datenbankobjekte oder ein Konfigurationsformat.
+
+Eine Allocation ist eine Vertrags- und Lebenszykluseinheit. Ein Consumer-Profil ist dagegen nur eine wiederverwendbare Anforderungsbeschreibung und keine laufende Allocation.
+
+## Consumer
+
+Jede Allocation referenziert genau einen `consumer_id` und genau einen Consumer-Typ:
+
+- `ralf_native`
+- `external_application`
+- `platform_internal`
+
+Ein Consumer kann später mehrere ausdrücklich geplante Allocations besitzen, etwa für getrennte Betriebszwecke. Eine einzelne Allocation wird jedoch nie mehreren Consumern gemeinsam zugeordnet.
+
+## Vertragsbegriffe
+
+Eine Allocation besitzt fachlich mindestens:
+
+| Begriff | Bedeutung |
+| --- | --- |
+| `allocation_id` | Stabile, nicht geheime Identität der Zuweisung. |
+| `consumer_id` | Eindeutiger Consumer der Allocation. |
+| `provider_instance_id` | Zugeordnete Providerinstanz. |
+| `database_name_reference` | Nicht geheime Referenz auf die zugewiesene Datenbankressource. |
+| `isolation_class` | Gewählte Isolationsform. |
+| `schema_lifecycle` | Eigentums- und Migrationsmodus des Schemas. |
+| `required_capabilities` | Fähigkeiten, ohne die die Allocation nicht kompatibel ist. |
+| `optional_capabilities` | Nutzbare, aber nicht zwingende Fähigkeiten. |
+| `identity_references` | Nicht geheime Referenzen auf allocation-eigene technische Identitäten. |
+| `secret_references` | Nicht geheime absolute Referenzen unter `/secrets`. |
+| `backup_policy_reference` | Zugeordneter Backupvertrag. |
+| `retention_policy_reference` | Zugeordnete Aufbewahrungsregel. |
+| `status` | Providerneutraler Allocation-Zustand. |
+
+Für spätere Platzierungsentscheidungen muss die Allocation zusätzlich Verfügbarkeits-, Isolations-, Ressourcen-, Backup- und Restore-Anforderungen ausdrücken können.
+
+## Isolationsklassen
+
+### `logical_database`
+
+Der Consumer erhält eine eigene logische Datenbank innerhalb einer gemeinsam betriebenen Providerinstanz. Eigene Identitäten und fehlende Rechte auf andere Allocations bleiben Pflicht.
+
+### `dedicated_provider_instance`
+
+Der Consumer erhält aufgrund von Sicherheits-, Verfügbarkeits-, Ressourcen- oder Kompatibilitätsanforderungen eine eigene Providerinstanz.
+
+### `external_provider`
+
+Die Allocation referenziert eine bereits vorhandene externe Datenbankbereitstellung. Umfang, Verantwortung und erlaubte Verwaltung müssen ausdrücklich festgelegt werden.
+
+Referenzstandard für PostgreSQL im Database-Service-Vertrag 0.1 ist `logical_database`; dies verhindert keine spätere dedizierte Platzierung.
+
+## Isolationseigenschaften
+
+Eine gültige Allocation gewährleistet:
+
+- genau einen Consumer,
+- genau einen aktiven Provider,
+- eigene technische Identitäten,
+- keine Zugriffsrechte auf Datenbanken anderer Consumer,
+- kein gemeinsames Anwendungsschema mit anderen Allocations,
+- keine gemeinsame Anwendungsidentität oder gemeinsames Kennwort,
+- keine Provider-Superuseridentität für den Consumer,
+- allocation-bezogene Health-, Readiness-, Backup- und Restorezustände.
+
+Eine gemeinsam genutzte Providerinstanz ist eine sichtbare gemeinsame Fehlerdomäne, nicht der Beweis gemeinsamer Daten- oder Berechtigungsgrenzen.
+
+## Schema-Lebenszyklus
+
+Jede Allocation verwendet genau einen Modus.
+
+### `domain_managed`
+
+Eine RALF-Domäne besitzt fachlich Schema und versionierte Migrationen. Der Database Service plant, prüft Providerfähigkeiten und führt nur freigegebene Migrationspakete aus. RALF Core und Conversation verwenden diesen Modus.
+
+### `application_managed`
+
+Eine externe Anwendung besitzt Schema und Migrationen. Der Database Service übersetzt oder beansprucht diese nicht. Das Consumer-Profil muss offenlegen, ob Laufzeit- und Migrationsidentität trennbar sind, wann erweiterte Rechte benötigt werden und ob sie danach reduziert werden können.
+
+### `platform_preprovisioned`
+
+Die Plattform legt ausdrücklich vertraglich geforderte Datenbankobjekte kontrolliert vor dem Anwendungsstart an. Dieser Modus ist nur mit einem konkreten Consumer-Vertrag zulässig.
+
+## Technische Identitäten
+
+Mögliche allocation-bezogene Identitäten sind:
+
+- `allocation_owner`
+- `migration_identity`
+- `application_identity`
+- `backup_identity`
+- `monitoring_identity`
+
+Nicht jede Allocation benötigt jede getrennte Identität. Fehlende Trennbarkeit muss im Consumer-Profil ausdrücklich erklärt und sicherheitlich bewertet werden.
+
+`allocation_owner` wird nicht im normalen Anwendungsbetrieb verwendet. `application_identity` erhält ausschließlich die für den Consumer erforderlichen Rechte. Backup- und Monitoringidentitäten dürfen zentral betrieben werden, bleiben aber auf den vereinbarten Umfang begrenzt.
+
+## Secret-Referenzen
+
+Secretwerte sind kein Bestandteil dieses Vertrags. Die kanonische externe Wurzel ist `/secrets`; allocation-bezogene Referenzen liegen unter:
+
+```text
+/secrets/database-service/allocations/<allocation-id>/
+```
+
+Mögliche spätere Dateinamen sind `owner-password`, `migration-password`, `application-password`, `backup-password` und `monitoring-password`. Nicht benötigte Dateien werden nicht erzeugt.
+
+Eine Referenz muss absolut sein, innerhalb `/secrets` verbleiben, Traversierung und unerwartete Symlinks ausschließen sowie auf eine restriktiv lesbare Datei zeigen. Normale Konfiguration speichert nie den Secretwert oder eine vollständige Verbindungs-URL mit Zugangsdaten.
+
+Erzeugung, erstmalige Bereitstellung und Rotation sind getrennte geplante Vorgänge. Vorhandene Geheimnisse werden nicht automatisch überschrieben.
+
+## Fähigkeiten und Kompatibilität
+
+Eine Allocation ist nur kompatibel, wenn ihre `required_capabilities` von der zugeordneten Providerinstanz erfüllt werden. Optionale Fähigkeiten dürfen fehlen, ohne die grundlegende Bereitschaft zu verhindern.
+
+RALF Core Conversation verlangt `relational_storage`, `transactions`, `schema_migrations`, `constraints`, `indexes`, `backup` und `restore`. Externe Consumer erklären eigene Anforderungen; diese werden nicht aus dem Conversation-Profil abgeleitet.
+
+## Zustände
+
+Eine Allocation verwendet zunächst:
+
+| Zustand | Bedeutung |
+| --- | --- |
+| `unknown` | Zustand ist nicht verlässlich bekannt. |
+| `unconfigured` | Pflichtzuordnung oder Vertragsdaten fehlen. |
+| `configured` | Vertrag ist vollständig, Bereitschaft aber nicht bestätigt. |
+| `starting` | Zuweisung wird für den Consumer bereitgestellt oder geprüft. |
+| `ready` | Isolation, Identitäten, Fähigkeiten und Schema sind verwendbar. |
+| `degraded` | Allocation ist eingeschränkt; erlaubte Zugriffe müssen explizit sein. |
+| `maintenance` | Geplanter Wartungszustand. |
+| `migration_required` | Schema-Lebenszyklus verlangt eine Migration. |
+| `migrating` | Eine autorisierte Migration läuft. |
+| `backup_running` | Allocation-bezogenes Backup läuft. |
+| `restore_running` | Allocation-bezogener Restore läuft. |
+| `failed` | Sicherer Betrieb ist nicht möglich. |
+| `stopped` | Allocation ist kontrolliert nicht verfügbar. |
+
+Die vollständigen Zustandsübergänge bleiben Teil des nächsten Spezifikationsschritts. Eine Allocation darf nicht `ready` melden, nur weil ihre Providerinstanz gesund ist.
+
+## Health und Readiness
+
+`allocation_health` beschreibt, ob die zugewiesene Ressource grundsätzlich funktioniert. `allocation_readiness` beschreibt, ob genau dieser Consumer sie sicher verwenden kann.
+
+Readiness verlangt mindestens:
+
+- Providerinstanz `ready`,
+- zugewiesene Ressource vorhanden,
+- Pflichtfähigkeiten erfüllt,
+- Secret-Referenzen sicher auflösbar,
+- benötigte Identitäten verwendbar,
+- Schema-Lebenszyklus im erwarteten Zustand,
+- erforderlicher Backupvertrag vorhanden,
+- keine fremden Zugriffsrechte.
+
+Eine nicht bereite Allocation beeinflusst andere Allocations nicht automatisch. Ein Providerfehler kann dagegen mehrere Allocations derselben Instanz betreffen und muss entsprechend sichtbar sein.
+
+## Backup
+
+Ein allocation-bezogenes Backup referenziert mindestens `provider_instance_id`, `allocation_id` und `consumer_id`. Standard für 0.1 ist ein logisches Backup der einzelnen Allocation.
+
+Backup ist erst erfolgreich, wenn Erzeugung und technische Verifikation abgeschlossen sind. Aufbewahrung, Verschlüsselung und Speicherort werden durch referenzierte Policies festgelegt und nicht in Secretwerten oder Datenbankzugangsdaten eingebettet.
+
+## Restore
+
+Restore ist eine eigene geplante Operation mit geprüfter Quelle, eindeutiger Ziel-Allocation, sichtbarer Auswirkung, Schema- beziehungsweise Anwendungszustandsprüfung, ausdrücklicher Freigabe und anschließender Integritäts- und Readiness-Prüfung.
+
+Ein Restore darf keine fremde Allocation oder die gesamte Providerinstanz stillschweigend überschreiben. Providerweite Wiederherstellung ist ein gesonderter Vertrag.
+
+## Providerneutrale Fehlerklassen
+
+- `allocation_not_found`
+- `allocation_conflict`
+- `consumer_conflict`
+- `provider_unavailable`
+- `provider_conflict`
+- `capability_missing`
+- `isolation_violation`
+- `identity_error`
+- `secret_reference_error`
+- `schema_mismatch`
+- `migration_required`
+- `migration_failed`
+- `backup_failed`
+- `restore_failed`
+- `storage_exhausted`
+- `unknown_error`
+
+Fehler enthalten später eine nicht geheime Allocation-, Consumer-, Provider- und Operationsreferenz. Providerrohfehler und Secretwerte werden nicht Bestandteil des allgemeinen Vertrags.
+
+## Freigaben und Änderungen
+
+Folgende Änderungen benötigen später jeweils einen Plan mit sichtbaren Auswirkungen und eine ausdrückliche Freigabe:
+
+- Allocation anlegen oder entfernen,
+- Providerinstanz oder Isolationsklasse ändern,
+- Fähigkeiten oder Ressourcenanforderungen ändern,
+- Identitäten oder Secret-Referenzen ändern,
+- Migration ausführen,
+- Backup- oder Retention-Policy ändern,
+- Restore durchführen,
+- Secrets erzeugen oder rotieren.
+
+Keine Bestätigung dieses Architekturvertrags ist bereits eine Applyfreigabe.
+
+## Consumer-Beispiele
+
+### RALF Core
+
+`ralf_native`, `domain_managed`, eigene Allocation. Der ConversationRepository-Vertrag gilt ausschließlich hier.
+
+### Gitea
+
+Möglicher `external_application` Consumer mit eigenem Datenbankzugriff und `application_managed`. Gitea verwendet nicht ConversationRepository.
+
+### OpenBao
+
+Möglicher `external_application` Consumer. PostgreSQL bleibt optionale Storage-Wahl; Integrated Storage muss gleichwertig geprüft werden. OpenBao verwendet nicht ConversationRepository.
+
+## Offene Punkte
+
+- tatsächliche erste Allocations,
+- vollständige Zustandsübergänge,
+- Platzierungsentscheidung gemeinsam oder dediziert,
+- Rechte bei anwendungseigenen Migrationen,
+- Zugriff der Consumer auf `/secrets`,
+- Eigentümer-, Gruppen- und Rotationsmodell,
+- Ressourcen- und Netzwerkgrenzen,
+- allocation- und providerweite Backupbeziehung,
+- PostgreSQL-Referenzversion.
+
+**Nächster Schritt:** PostgreSQL-Referenzprovider und Allocation-Lebenszyklus spezifizieren, ohne eine Providerinstanz oder Allocation anzulegen.

--- a/docs/contracts/database-service-v0.1.md
+++ b/docs/contracts/database-service-v0.1.md
@@ -32,6 +32,8 @@ Ohne eine dieser Fähigkeiten ist ein Provider für Database Service 0.1 nicht k
 
 Eine RALF-Domäne darf eine optionale Fähigkeit für ihr eigenes Profil zur Voraussetzung machen. Dadurch wird sie nicht automatisch für alle Database-Service-Nutzer verpflichtend.
 
+Der erste Kunde, die Conversation-Domäne in RALF Core, benötigt keine dieser optionalen Fähigkeiten.
+
 ### Später
 
 - `vector_search`
@@ -200,16 +202,22 @@ Jeder spätere Fehlerdatensatz enthält mindestens `error_code`, `category`, `me
 - Migrationen, Backups und Restores sind mit Plan, Operation, Ergebnis und nicht geheimen Referenzen nachvollziehbar.
 - Providerdiagnosen werden redigiert, bevor sie eine öffentliche Vertragsgrenze überschreiten.
 
+## Erster Datenbankkunde
+
+[ADR-0002](../decisions/ADR-0002-first-database-customer.md) entscheidet RALF Core als ersten Kunden und Conversation als erste persistente Domäne. Der [ConversationRepository Contract 0.1](conversation-repository-v0.1.md) konkretisiert fachliche Lese- und Schreibvorgänge domänenspezifisch, ohne sie in eine allgemeine Database-Service-API zu überführen.
+
+Conversation verlangt `relational_storage`, `transactions`, `schema_migrations`, `constraints` und `indexes`. Backup und Restore verbleiben im Database Service. Schemaeigentum und fachliche Bedeutung bleiben bei RALF Core; der Database Service verantwortet die kontrollierte Ausführung freigegebener Migrationen, nicht das Conversation-Modell.
+
 ## Offene Vertragsfragen
 
-1. **Unmittelbar nächste Entscheidung:** Welche fachlichen Daten werden zuerst gespeichert, und welche erste RALF-Komponente benötigt den Database Service?
-2. Wie sehen die domänenspezifischen Repository-Verträge dieses ersten Datenbankkunden aus?
-3. Welche PostgreSQL-Version wird als Referenzversion gewählt?
-4. Wie kommunizieren RALF-Komponenten mit dem Database Service, ohne eine universelle Datenzugriffs-API zu schaffen?
-5. Wie werden Secrets sicher und deployment-spezifisch bereitgestellt?
-6. Wo liegen Daten und Backups in den ersten unterstützten Betriebsprofilen?
-7. Welche Backup-Retention wird später verlangt?
-8. Werden `json_documents` oder `full_text_search` für 0.1 nach Festlegung der ersten Fachdaten verpflichtend?
-9. Wie werden Migrationen technisch paketiert und ihrem Provider eindeutig zugeordnet?
+Die frühere Frage nach dem ersten Datenbankkunden und dessen Repository-Grenze ist durch ADR-0002 entschieden. Offen bleiben:
+
+1. **Unmittelbar nächste Entscheidung:** Welche minimale Verantwortung besitzt RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime?
+2. Welche PostgreSQL-Version wird als Referenzversion gewählt?
+3. Wie wird ein domänenspezifischer Repository-Vertrag technisch angebunden, ohne eine universelle Datenzugriffs-API zu schaffen?
+4. Wie werden Secrets sicher und deployment-spezifisch bereitgestellt?
+5. Wo liegen Daten und Backups in den ersten unterstützten Betriebsprofilen?
+6. Welche Backup-Retention wird später verlangt?
+7. Wie werden Migrationen technisch paketiert und ihrem Provider eindeutig zugeordnet?
 
 Keine dieser Fragen autorisiert bereits eine Implementierung oder Installation.

--- a/docs/contracts/database-service-v0.1.md
+++ b/docs/contracts/database-service-v0.1.md
@@ -2,222 +2,249 @@
 
 ## Status und Zweck
 
-Dieses Dokument definiert die fachliche Vertragsoberfläche des Database Service in Version 0.1. Es legt weder REST, RPC, MCP, Python-Signaturen noch ein SQL- oder Dateiformat fest. PostgreSQL ist der erste Referenzprovider, bleibt jedoch außerhalb des öffentlichen Vertrags.
+Dieser Vertrag beschreibt die providerneutrale Verwaltungsebene der gemeinsam nutzbaren Database-Service-Plattform. Er legt weder REST, RPC, MCP, Python-Signaturen, SQL noch ein Konfigurationsformat fest.
+
+PostgreSQL ist der erste Referenzprovider, bleibt aber außerhalb des öffentlichen Vertrags. Der detaillierte Vertrag einer isolierten Zuweisung steht im [Database Allocation Contract 0.1](database-allocation-v0.1.md).
 
 ## Vertragsumfang 0.1
 
-Der Vertrag gilt für genau einen aktiven Provider, eine RALF-Datenbankinstanz und eine logische RALF-Datenbank. Er beschreibt Fähigkeiten, Provider- und Schemazustand, kontrollierte Migrationen, Health, Readiness, Backup, Restore, Rollenanforderungen und providerneutrale Fehler.
+Version 0.1 beschreibt einen oder mehrere Datenbankprovider, mindestens eine Providerinstanz und mehrere voneinander isolierbare Database Allocations für RALF-native, externe und spätere plattforminterne Consumer. Pro Allocation ist genau ein Provider aktiv. Eine Installation muss nicht sofort mehrere Allocations oder Providerinstanzen anlegen.
 
-Er definiert keine fachlichen Tabellen, Datenmodelle, Queries oder allgemeine Datenbankverwaltung für fremde Anwendungen.
+Der Vertrag umfasst:
 
-## Fähigkeiten
+- Providerinstanzen und ihre Fähigkeiten,
+- Consumer-Profile und Database Allocations,
+- Isolation und technische Identitäten,
+- nicht geheime Secret-Referenzen,
+- Provider- und Allocation-Lebenszyklus,
+- Health und Readiness,
+- Schema-Lebenszyklus und Kompatibilität,
+- allocation-bezogene Backups und Restores,
+- providerneutrale Fehler und Freigabegrenzen.
 
-### Erforderlich
+Er setzt weder genau einen Consumer noch genau eine logische Datenbank voraus.
 
-- `relational_storage`
-- `transactions`
-- `schema_migrations`
-- `constraints`
-- `indexes`
-- `backup`
-- `restore`
+## Verwaltungs- und Datenebene
 
-Ohne eine dieser Fähigkeiten ist ein Provider für Database Service 0.1 nicht kompatibel.
+Der Vertrag steuert ausschließlich die Verwaltungsebene. Er beschreibt Zustände, Pläne und kontrollierte Lebenszyklusaktionen für Providerinstanzen und Allocations.
 
-### Optional nutzbar
+Die Datenebene verwendet das native Protokoll des Providers. Der Database Service ist kein SQL-Proxy, übersetzt keine Anwendungsabfragen und bietet keine universellen Lese-, Schreib- oder CRUD-Operationen.
 
-- `json_documents`
-- `full_text_search`
-- `advisory_locks`
+RALF-native Consumer konkretisieren fachliche Datenzugriffe durch eigene Repository-Verträge. Externe Anwendungen verwenden ihre eigenen Treiber und Schemata. Kein externer Consumer wird zur Verwendung eines RALF-Domänenvertrags verpflichtet.
 
-Eine RALF-Domäne darf eine optionale Fähigkeit für ihr eigenes Profil zur Voraussetzung machen. Dadurch wird sie nicht automatisch für alle Database-Service-Nutzer verpflichtend.
+## Consumer und Profile
 
-Der erste Kunde, die Conversation-Domäne in RALF Core, benötigt keine dieser optionalen Fähigkeiten.
+Ein Database Consumer benötigt genau eine oder mehrere ausdrücklich geplante Allocations. Zulässige Consumer-Arten sind:
 
-### Später
+- `ralf_native`
+- `external_application`
+- `platform_internal`
 
-- `vector_search`
-- `point_in_time_recovery`
-- `replication`
-- `high_availability`
+Ein Consumer-Profil beschreibt unterstützte Provider, benötigte und optionale Fähigkeiten, Schema-Lebenszyklus, Identitätsmodell, Backup- und Health-Erwartungen sowie bekannte Einschränkungen. Es ist keine laufende Allocation und erzeugt keine Datenbank.
 
-Diese Fähigkeiten sind ausdrücklich nicht Teil der Mindestzusage von 0.1.
+RALF Core ist der erste spezifizierte `ralf_native` Consumer. Gitea und OpenBao sind mögliche `external_application` Consumer; ihre tatsächliche Auswahl bleibt offen.
 
-## Fachliche Vertragsoperationen
+## Providerfähigkeiten
 
-Die folgenden Namen gliedern Verantwortungen. Sie sind Platzhalter und keine öffentlichen Funktionssignaturen.
+### Grundlegender Katalog
 
-### Status
+| Fähigkeit | Einordnung für das Database-Service-Profil 0.1 |
+| --- | --- |
+| `relational_storage` | erforderlich |
+| `transactions` | erforderlich |
+| `schema_migrations` | erforderlich, wenn eine Allocation Migrationen verlangt |
+| `constraints` | erforderlich |
+| `indexes` | erforderlich |
+| `backup` | erforderlich |
+| `restore` | erforderlich |
+| `json_documents` | optional |
+| `full_text_search` | optional |
+| `advisory_locks` | optional |
+| `vector_search` | später |
+| `point_in_time_recovery` | später |
+| `replication` | später |
+| `high_availability` | später |
 
-- `get_service_status`
-- `get_provider_information`
-- `get_capabilities`
-- `get_schema_status`
+Jede Allocation erklärt ihre tatsächlich erforderlichen Fähigkeiten. Ein Provider kann grundsätzlich verfügbar sein und dennoch für eine konkrete Allocation inkompatibel bleiben.
 
-### Datenoperationen
+## Fachliche Vertragsgruppen
 
-- `begin_transaction`
-- `commit_transaction`
-- `rollback_transaction`
-- `execute_read`
-- `execute_write`
+Die folgenden Gruppen beschreiben Verantwortungen, keine technischen Methoden oder Signaturen.
 
-Diese Begriffe beschreiben die benötigten Transaktions- und Datenzugriffseigenschaften. Gemäß ADR‑0001 werden fachliche Lese- und Schreiboperationen später in domänenspezifischen Repository-Verträgen konkretisiert, nicht als universelle Database-Service-API.
+### Providerverwaltung
 
-### Schema
+- Provideridentität und Version erfassen,
+- Providerfähigkeiten bewerten,
+- Providerinstanz planen und ihren Lebenszyklus kontrollieren,
+- Provider-Health und -Readiness melden.
 
-- `get_current_schema_version`
-- `get_target_schema_version`
-- `plan_migrations`
-- `apply_migrations`
+### Allocation-Verwaltung
 
-### Sicherung
+- Consumer und Profil referenzieren,
+- Isolation und Providerzuordnung planen,
+- Identitäts- und Secret-Referenzen prüfen,
+- Allocation-Lebenszyklus und Kompatibilität melden,
+- Schema-, Backup- und Restorevertrag zuordnen.
 
-- `plan_backup`
-- `create_backup`
-- `verify_backup`
-- `plan_restore`
-- `restore_backup`
+### Schema und Migration
 
-### Diagnose
+- Schema-Lebenszyklusmodus kennen,
+- aktuelle und erwartete Version beziehungsweise den anwendungseigenen Zustand bewerten,
+- freizugebende Migrationen planen,
+- ausschließlich dafür autorisierte Migrationen ausführen,
+- keine unbekannte oder stille Migration beim Dienststart vortäuschen.
 
-- `health_check`
-- `readiness_check`
-- `diagnose`
+### Sicherung und Wiederherstellung
+
+- allocation-bezogene Backups planen, erzeugen und verifizieren,
+- einen Restore separat planen und bestätigen lassen,
+- Quelle, Ziel und betroffene Allocation eindeutig benennen,
+- andere Allocations vor unbeabsichtigten Auswirkungen schützen.
+
+## Isolation und Identitäten
+
+Referenzstandard ist `logical_database`: eine logische Datenbank, eigene Identitäten und keine Rechte auf andere Allocations pro Consumer. Weitere Klassen sind `dedicated_provider_instance` und `external_provider`.
+
+Identitätsreferenzen sind allocation-bezogen:
+
+- `allocation_owner`
+- `migration_identity`
+- `application_identity`
+- `backup_identity`
+- `monitoring_identity`
+
+Eine gemeinsame Anwendungsidentität, ein gemeinsames Kennwort oder ein gemeinsames Anwendungsschema für mehrere Consumer ist unzulässig. Consumer verwenden keine Provider-Superuseridentität.
+
+Consumer-Profile dürfen begründete Abweichungen deklarieren, etwa eine nicht trennbare Migrationsidentität bei `application_managed`. Die Abweichung muss sichtbar und hinsichtlich ihrer zeitweise erweiterten Rechte bewertet sein.
+
+## Schema-Lebenszyklus
+
+Jede Allocation besitzt genau einen Modus:
+
+- `domain_managed`
+- `application_managed`
+- `platform_preprovisioned`
+
+Bei `domain_managed` liefert eine RALF-Domäne versionierte Migrationspakete; der Database Service plant und führt sie nach eigener Freigabe aus. Bei `application_managed` besitzt die externe Anwendung Schema und Migrationen. Bei `platform_preprovisioned` legt die Plattform ausdrücklich vertraglich verlangte Objekte vor Anwendungsstart an.
+
+Der Database Service beansprucht nicht die fachliche Eigentümerschaft externer Anwendungsschemata.
+
+## Secrets-Vertrag
+
+Alle geheimen Datenbankwerte liegen ausschließlich unter der absoluten externen Wurzel `/secrets`. Normale Konfiguration enthält nur nicht geheime `secret_references`, deren Ziel innerhalb `/secrets/database-service/` liegt.
+
+Der Vertrag speichert keine Kennwörter, privaten Schlüssel, Tokens oder vollständigen Connection Strings. Das Repository behält zusätzlich `secrets/` als ausgeschlossenen lokalen Pfad.
+
+Secret-Referenzen werden später auf absoluten Pfad, Verbleib innerhalb der Wurzel, fehlende Traversierung, unerwartete Symlinks und restriktive Rechte geprüft. Erzeugung und Rotation sind eigene freizugebende Vorgänge; diese Spezifikation schreibt oder liest keine Secretdatei.
+
+OpenBao kann später Secrets-Provider werden, ersetzt `/secrets` aber nicht automatisch. Insbesondere dürfen OpenBao-Bootstrap-Geheimnisse bei einer eigenen PostgreSQL-Allocation nicht zirkulär aus OpenBao bezogen werden.
 
 ## Lebenszykluszustände
 
-„Administrativ“ bedeutet eine ausdrücklich geplante und autorisierte Lebenszyklusaktion. Diagnose ist in jedem Zustand lesend zulässig, soweit der Provider erreichbar ist.
+Providerinstanzen und Allocations verwenden getrennte Zustandsmeldungen. Der gemeinsame Katalog lautet:
 
-| Zustand | Bedeutung | Lesen | Schreiben | Administrative Aktionen |
-| --- | --- | --- | --- | --- |
-| `unknown` | Zustand wurde noch nicht zuverlässig ermittelt. | nein | nein | nur Diagnose und sichere Bestandsaufnahme |
-| `unconfigured` | Provider oder logische Datenbank ist noch nicht vollständig konfiguriert. | nein | nein | Konfiguration darf geplant werden |
-| `configured` | Konfiguration ist vorhanden, Betriebsbereitschaft aber noch nicht bestätigt. | nein | nein | Start und Prüfung dürfen geplant werden |
-| `starting` | Provider startet oder stellt Verbindungen her. | nein | nein | Statusprüfung, kein paralleler Lebenszykluswechsel |
-| `ready` | Alle Pflichtfähigkeiten, Schema- und Sicherheitsprüfungen sind erfüllt. | ja | ja | geplante Standardaktionen zulässig |
-| `degraded` | Betrieb ist eingeschränkt; Umfang ist diagnostiziert. | nur wenn ausdrücklich als sicher bewertet | nur wenn ausdrücklich als sicher bewertet | Diagnose und freigegebene Korrekturplanung |
-| `maintenance` | Geplanter Wartungsmodus. | standardmäßig nein | nein | ausschließlich freigegebene Wartungsaktionen |
-| `migration_required` | Provider ist gesund, aber das Schema ist nicht zur Zielversion kompatibel. | höchstens ausdrücklich kompatible Reads | nein | Migrationsplanung zulässig |
-| `migrating` | Eine freigegebene Migration läuft. | nein, sofern Migration nichts anderes garantiert | nein | nur der laufende Migrationsvorgang |
-| `backup_running` | Eine Sicherung läuft. | ja, wenn der Provider konsistente Reads garantiert | nur wenn die Backupmethode Konsistenz garantiert | nur Backupüberwachung oder Abbruch nach eigener Regel |
-| `restore_running` | Eine Wiederherstellung läuft. | nein | nein | nur der laufende Restorevorgang |
-| `failed` | Ein kritischer Fehler verhindert sicheren Betrieb. | nein | nein | Diagnose und ausdrücklich geplante Wiederherstellung |
-| `stopped` | Provider ist kontrolliert gestoppt. | nein | nein | Start, Diagnose oder Restoreplanung zulässig |
+- `unknown`
+- `unconfigured`
+- `configured`
+- `starting`
+- `ready`
+- `degraded`
+- `maintenance`
+- `migration_required`
+- `migrating`
+- `backup_running`
+- `restore_running`
+- `failed`
+- `stopped`
 
-Zugriffe in `degraded` oder `backup_running` benötigen später eine konkrete, providerseitig belegte Zusage. Ohne diese Zusage gilt „nicht zulässig“.
+Nicht jeder Zustand ist auf beide Ebenen gleich anwendbar. `migration_required` bezieht sich beispielsweise auf eine Allocation, während ein Provider gleichzeitig `ready` sein kann. Zugriff ist nur erlaubt, wenn die konkrete Allocation dafür bereit ist; ein Fehler einer Allocation macht andere Allocations nicht automatisch fehlerhaft.
 
 ## Health und Readiness
 
-**Health** beantwortet, ob Provider beziehungsweise Datenbankprozess grundsätzlich funktionieren. Mögliche Kriterien sind Erreichbarkeit, Verbindungsaufbau und eine einfache interne Prüfung.
+Eine Providerinstanz meldet getrennt `provider_health` und `provider_readiness`. Jede Allocation meldet unabhängig `allocation_health` und `allocation_readiness`.
 
-**Readiness** beantwortet, ob RALF die Datenbank aktuell sicher verwenden darf. Zusätzlich müssen mindestens gelten:
+Provider-Health beantwortet, ob der Provider grundsätzlich funktioniert. Provider-Readiness berücksichtigt zusätzlich den für neue oder bestehende Allocations nutzbaren Betriebszustand.
 
-- alle erforderlichen Fähigkeiten sind vorhanden,
-- die richtige logische Datenbank ist erreichbar,
-- die Schemaversion ist bekannt und kompatibel,
-- keine notwendige Migration und kein Restore steht im Weg,
-- kein kritischer Speicherzustand liegt vor,
-- die Anwendungsidentität besitzt genau die erforderlichen minimalen Rechte.
+Allocation-Readiness verlangt mindestens:
 
-Health und Readiness sind unabhängig. Ein laufender, erreichbarer PostgreSQL-Provider kann gesund, aber wegen einer fehlenden RALF-Schemamigration nicht bereit sein.
+- Providerinstanz ist bereit,
+- zugewiesene logische Datenbank beziehungsweise Ressource ist vorhanden,
+- erforderliche Fähigkeiten sind erfüllt,
+- Secret-Referenzen sind sicher auflösbar,
+- technische Identitäten sind mit den minimal notwendigen Rechten verwendbar,
+- Schema entspricht dem gewählten Lebenszyklusmodus,
+- erforderlicher Backupvertrag ist vorhanden,
+- kein Zugriff auf fremde Allocations ist möglich.
 
-## Schema- und Migrationsvertrag
-
-- Migrationen sind versioniert und eindeutig geordnet.
-- Der aktuelle Schemawert wird in der Datenbank selbst gespeichert.
-- Jede Migration besitzt eine stabile ID.
-- Vor jeder Migration wird ein nachvollziehbarer Plan angezeigt.
-- Jede Migration benötigt eine eigene ausdrückliche Freigabe.
-- Ein normaler Dienststart führt keine unbekannte oder stillschweigende Migration aus.
-- Eine fehlgeschlagene Migration wird niemals als erfolgreich markiert.
-- Rollbackfähigkeit wird für jede Migration einzeln dokumentiert; Rückwärtsausführung ist keine allgemeine Zusage.
-- Struktur- und Datenmigrationen werden unterscheidbar dokumentiert.
-- Unbekannte neuere oder inkompatible Schemaversionen führen zu `schema_mismatch` statt zu einem vorgetäuschten Downgrade.
-- Providerspezifische Migrationsartefakte und SQL-Dateien gehören ausschließlich zum jeweiligen Provider.
-
-Die technische Paketierung von Migrationen bleibt offen.
+Ein Provider kann gesund sein, während eine einzelne Allocation wegen `migration_required`, fehlender Identität oder Konfigurationskonflikt nicht bereit ist.
 
 ## Backupvertrag
 
-Ein Backupdatensatz beschreibt mindestens:
+Ein allocation-bezogener Backupdatensatz beschreibt mindestens:
 
-| Feld | Bedeutung |
-| --- | --- |
-| `backup_id` | Stabile Identität der Sicherung. |
-| `provider_id` | Provider, der die Sicherung erzeugt hat. |
-| `created_at` | Nachvollziehbarer Erstellungszeitpunkt. |
-| `schema_version` | Gesicherte RALF-Schemaversion. |
-| `database_identity` | Nicht geheime Identität der gesicherten logischen Datenbank. |
-| `backup_type` | Art der Sicherung. |
-| `integrity_status` | Ergebnis der technischen Überprüfbarkeit. |
-| `encryption_status` | Deklarierter Verschlüsselungszustand ohne Schlüsselmaterial. |
-| `storage_reference` | Deployment-spezifischer Verweis auf den Speicherort. |
+- `backup_id`
+- `provider_instance_id`
+- `allocation_id`
+- `consumer_id`
+- `created_at`
+- `schema_version_or_state`
+- `backup_type`
+- `integrity_status`
+- `encryption_status`
+- `storage_reference`
 
-Zulässige fachliche Typen sind zunächst `logical`, `physical` und `snapshot`. Für 0.1 wird `logical` bevorzugt; die konkrete Umsetzung ist noch nicht entschieden.
-
-Eine Sicherung ist erst erfolgreich, wenn ihre Erzeugung technisch abgeschlossen und ihre Überprüfbarkeit bestätigt ist. Eine vorhandene Datei allein gilt nicht als verifiziertes Backup. Der Vertrag enthält keine Kennwörter oder Schlüssel. Speicherort, Aufbewahrung und Verschlüsselung bleiben deployment-spezifisch. Automatische Löschung alter Sicherungen gehört nicht zu 0.1.
+Der Standard für 0.1 ist ein logisches Backup pro Allocation. Eine erzeugte Datei allein ist noch kein verifiziertes Backup. Speicherort, Aufbewahrung und Verschlüsselung bleiben deployment-spezifisch. Providerweite Sicherungen können später zusätzlich bestehen.
 
 ## Restorevertrag
 
-Jeder Restore ist ein eigener geplanter Vorgang und benötigt mindestens:
+Ein Restore benötigt eine geprüfte Sicherung, eindeutige Quell- und Ziel-Allocation, Schema- beziehungsweise Anwendungszustandsprüfung, sichtbare Auswirkungen, ausdrückliche Bestätigung, kontrollierte Ausführung sowie anschließende Integritäts- und Readiness-Prüfung.
 
-1. Auswahl eines verifizierten Backups,
-2. sichtbare Angabe von Quelle und Ziel,
-3. Prüfung von Schemaversion und Zielzustand,
-4. ausdrückliche Bestätigung,
-5. kontrollierte einmalige Ausführung,
-6. anschließende Integritäts-, Health- und Readiness-Prüfung.
-
-Es gibt keinen automatischen Restore und kein stillschweigendes Überschreiben einer produktiven Datenbank.
+Ein Allocation-Restore darf weder eine andere Allocation noch die gesamte Providerinstanz stillschweigend überschreiben. Es gibt keinen automatischen Restore.
 
 ## Providerneutrale Fehlerklassen
 
 | Kategorie | Bedeutung |
 | --- | --- |
-| `configuration_error` | Nicht geheime Konfiguration ist ungültig oder unvollständig. |
-| `connection_error` | Verbindung konnte nicht hergestellt oder gehalten werden. |
-| `authentication_error` | Identität konnte nicht erfolgreich nachgewiesen werden. |
-| `authorization_error` | Identität besitzt nicht die erforderlichen minimalen Rechte. |
-| `capability_missing` | Eine erforderliche Fähigkeit fehlt. |
-| `schema_mismatch` | Datenbankschema ist unbekannt oder inkompatibel. |
-| `migration_required` | Eine bekannte Migration ist vor sicherem Betrieb erforderlich. |
+| `configuration_error` | Nicht geheime Vertragsdaten sind ungültig oder unvollständig. |
+| `provider_unavailable` | Providerinstanz ist nicht verfügbar. |
+| `provider_conflict` | Providerzustand oder Fähigkeiten widersprechen dem Vertrag. |
+| `allocation_unavailable` | Zugewiesene Datenbankressource ist nicht verfügbar. |
+| `allocation_conflict` | Isolation, Identitäten oder Zuordnung widersprechen dem Allocation-Vertrag. |
+| `connection_error` | Native Verbindung konnte nicht hergestellt oder gehalten werden. |
+| `authentication_error` | Technische Identität konnte nicht nachgewiesen werden. |
+| `authorization_error` | Identität besitzt falsche oder unzureichende Rechte. |
+| `secret_reference_error` | Secret-Referenz ist ungültig oder nicht sicher auflösbar. |
+| `capability_missing` | Eine für die Allocation erforderliche Fähigkeit fehlt. |
+| `schema_mismatch` | Schema- oder Anwendungszustand ist unbekannt oder inkompatibel. |
+| `migration_required` | Eine bekannte Migration ist vor Bereitschaft erforderlich. |
 | `migration_failed` | Eine freigegebene Migration ist fehlgeschlagen. |
-| `transaction_failed` | Eine Transaktion konnte nicht erfolgreich abgeschlossen werden. |
-| `constraint_violation` | Eine deklarierte Integritätsbedingung wurde verletzt. |
-| `storage_exhausted` | Verfügbarer Speicher reicht für den sicheren Vorgang nicht aus. |
-| `backup_failed` | Sicherung oder deren Verifikation ist fehlgeschlagen. |
+| `storage_exhausted` | Ressource reicht für sicheren Betrieb nicht aus. |
+| `backup_failed` | Sicherung oder Verifikation ist fehlgeschlagen. |
 | `restore_failed` | Wiederherstellung oder Abschlussprüfung ist fehlgeschlagen. |
-| `provider_unavailable` | Provider ist nicht verfügbar. |
-| `provider_conflict` | Providerzustand widerspricht dem ausgewählten Vertrag. |
 | `unknown_error` | Fehler konnte keiner stabilen Kategorie zugeordnet werden. |
 
-Jeder spätere Fehlerdatensatz enthält mindestens `error_code`, `category`, `message`, `retryable`, `provider_reference` und `operation_reference`. Providerspezifische Fehlercodes dürfen intern für Diagnose und Audit erhalten bleiben, werden aber nicht Teil des allgemeinen RALF-Fehlervertrags.
+Providerspezifische Fehler dürfen intern für Diagnose erhalten bleiben, werden aber nicht allgemeiner Vertragsbestandteil.
 
-## Sicherheits- und Auditvertrag
+## Freigabegrenzen
 
-- Die fachlichen Rollen `database_owner`, `migration_role`, `application_role`, `backup_role` und `monitoring_role` bleiben getrennt.
-- Die Anwendung arbeitet nie mit einer administrativen Superuseridentität.
-- Geheimnisse stehen weder im Repository noch in normaler Konfiguration, Statusantworten oder Logs.
-- Migrationen, Backups und Restores sind mit Plan, Operation, Ergebnis und nicht geheimen Referenzen nachvollziehbar.
-- Providerdiagnosen werden redigiert, bevor sie eine öffentliche Vertragsgrenze überschreiten.
+Anlage, Änderung, Migration, Backup, Restore, Identitätsänderung, Secret-Erzeugung oder -Rotation sowie Verschiebung einer Allocation auf eine andere Providerinstanz benötigen später jeweils einen sichtbaren Plan und eine eigene Freigabe. Eine Beschreibung in diesem Vertrag ist keine Ausführungsfreigabe.
 
-## Erster Datenbankkunde
+## Erster RALF-nativer Consumer
 
-[ADR-0002](../decisions/ADR-0002-first-database-customer.md) entscheidet RALF Core als ersten Kunden und Conversation als erste persistente Domäne. Der [ConversationRepository Contract 0.1](conversation-repository-v0.1.md) konkretisiert fachliche Lese- und Schreibvorgänge domänenspezifisch, ohne sie in eine allgemeine Database-Service-API zu überführen.
+[ADR-0002](../decisions/ADR-0002-first-database-customer.md) legt RALF Core als ersten spezifizierten RALF-nativen Consumer fest. Seine Conversation-Domäne verwendet ausschließlich in ihrer eigenen Allocation den [ConversationRepository Contract](conversation-repository-v0.1.md). Gitea, OpenBao und andere externe Anwendungen verwenden diesen Vertrag nicht.
 
-Conversation verlangt `relational_storage`, `transactions`, `schema_migrations`, `constraints` und `indexes`. Backup und Restore verbleiben im Database Service. Schemaeigentum und fachliche Bedeutung bleiben bei RALF Core; der Database Service verantwortet die kontrollierte Ausführung freigegebener Migrationen, nicht das Conversation-Modell.
+[ADR-0003](../decisions/ADR-0003-shared-database-platform.md) präzisiert die gemeinsam nutzbare Plattform und die Mehrkundenstruktur.
 
-## Offene Vertragsfragen
+## Offene Entscheidungen
 
-Die frühere Frage nach dem ersten Datenbankkunden und dessen Repository-Grenze ist durch ADR-0002 entschieden. Offen bleiben:
+1. Welche Allocations werden zuerst tatsächlich angelegt?
+2. Welche Provider- und Allocation-Zustandsübergänge gehören in das Referenzprofil?
+3. Welche Consumer benötigen dedizierte Providerinstanzen?
+4. Wie werden externe anwendungseigene Migrationen sicher freigegeben oder beobachtet?
+5. Wie erhalten Consumer Zugriff auf Secretdateien unter `/secrets`?
+6. Welche Eigentümer-, Gruppen- und Rotationsregeln gelten dort?
+7. Welche Backups sind allocation-bezogen und welche providerweit?
+8. Wie werden Ressourcen- und Netzwerkgrenzen abgebildet?
+9. Welche PostgreSQL-Version wird Referenzversion?
 
-1. **Unmittelbar nächste Entscheidung:** Welche minimale Verantwortung besitzt RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime?
-2. Welche PostgreSQL-Version wird als Referenzversion gewählt?
-3. Wie wird ein domänenspezifischer Repository-Vertrag technisch angebunden, ohne eine universelle Datenzugriffs-API zu schaffen?
-4. Wie werden Secrets sicher und deployment-spezifisch bereitgestellt?
-5. Wo liegen Daten und Backups in den ersten unterstützten Betriebsprofilen?
-6. Welche Backup-Retention wird später verlangt?
-7. Wie werden Migrationen technisch paketiert und ihrem Provider eindeutig zugeordnet?
-
-Keine dieser Fragen autorisiert bereits eine Implementierung oder Installation.
+**Nächster kleiner Schritt:** PostgreSQL-Referenzprovider und Allocation-Lebenszyklus spezifizieren, ohne PostgreSQL zu installieren.

--- a/docs/decisions/ADR-0001-database-service.md
+++ b/docs/decisions/ADR-0001-database-service.md
@@ -17,7 +17,11 @@ Der öffentliche Vertrag beschreibt Fähigkeiten, Zustände, Schema- und Migrati
 
 RALF abstrahiert Provider nicht auf einen behaupteten kleinsten gemeinsamen Nenner. Provider deklarieren Fähigkeiten; RALF-Profile und Domänen deklarieren ihre Anforderungen. Fehlt eine Pflichtfähigkeit, ist die Kombination inkompatibel oder eingeschränkt.
 
-Der Database Service wird als Betriebs- und Vertragsdienst ausgelegt. Fachliche Datenmodelle und Datenzugriffe verbleiben in domänenspezifischen Repository-Verträgen. Die fachlichen Begriffe `execute_read` und `execute_write` in Vertrag 0.1 sind daher keine Entscheidung für eine universelle technische Datenzugriffs-API.
+Der Database Service wird als Betriebs- und Vertragsdienst ausgelegt. Fachliche Datenmodelle und Datenzugriffe verbleiben in domänenspezifischen Repository-Verträgen. Die zum Entscheidungszeitpunkt im Vertrag genannten fachlichen Begriffe `execute_read` und `execute_write` waren daher keine Entscheidung für eine universelle technische Datenzugriffs-API. ADR-0003 präzisiert die Datenebene als nativen Providerzugriff und entfernt diese Begriffe aus dem aktuellen Database-Service-Vertrag.
+
+## Spätere Präzisierung
+
+[ADR-0003](ADR-0003-shared-database-platform.md) präzisiert den Database Service als gemeinsam nutzbare Datenbankplattform. Er ist nicht auf RALF-interne Fachdaten beschränkt, sondern kann isolierte Database Allocations für RALF-native und externe Consumer verwalten. Die providerneutrale Grundentscheidung dieses ADR bleibt bestehen.
 
 ## Begründung
 
@@ -60,3 +64,5 @@ Eine allgemeine Datenzugriffsschicht mit universellen Lese- und Schreiboperation
 - konkrete Providerimplementierung und Installation.
 
 Der nächste Schritt ist die Entscheidung, welche fachlichen Daten zuerst gespeichert werden und welche RALF-Komponente dafür als erster Datenbankkunde verantwortlich ist. Er ist ausdrücklich noch keine PostgreSQL-Installation.
+
+Diese historische nächste Frage wurde durch [ADR-0002](ADR-0002-first-database-customer.md) für den ersten RALF-nativen Consumer beantwortet; sie begrenzt die Plattform nicht auf diesen Consumer.

--- a/docs/decisions/ADR-0002-first-database-customer.md
+++ b/docs/decisions/ADR-0002-first-database-customer.md
@@ -1,17 +1,17 @@
-# ADR-0002: RALF Core und Conversation als erster Datenbankkunde
+# ADR-0002: RALF Core und Conversation als erster RALF-nativer Database Consumer
 
 - **Status:** Angenommen
 - **Datum:** 2026-08-02
 
 ## Kontext
 
-ADR-0001 hat den Database Service als providerneutrale persistente Fähigkeit festgelegt und fachliche Datenzugriffe den jeweiligen Domänenverträgen zugeordnet. Für den nächsten Schritt muss ein realer fachlicher Kunde benannt werden, damit die Abstraktion an einem kleinen, nützlichen Datenbestand präzisiert werden kann, ohne bereits PostgreSQL oder eine technische Schnittstelle zu implementieren.
+ADR-0001 hat den Database Service als providerneutrale persistente Fähigkeit festgelegt und fachliche Datenzugriffe den jeweiligen Domänenverträgen zugeordnet. Für den nächsten Schritt muss ein erster RALF-nativer Consumer benannt werden, damit die Abstraktion an einem kleinen, nützlichen Datenbestand präzisiert werden kann, ohne bereits PostgreSQL oder eine technische Schnittstelle zu implementieren.
 
 RALF soll nach dem Architektur-Neustart von innen nach außen zu einem nutzbaren Assistentenkern wachsen. Unterhaltung ist dafür zentral, während Installer-, Inventar-, Memory-, Benutzer- oder Providerdaten noch keinen vergleichbar unmittelbaren Kernnutzen begründen.
 
 ## Entscheidung
 
-RALF Core ist der erste fachliche Kunde des Database Service. Seine erste persistente Domäne ist Conversation; der erste dauerhafte fachliche Datenbestand besteht ausschließlich aus Unterhaltungen und deren geordneten Nachrichten.
+RALF Core ist der erste spezifizierte RALF-native Database Consumer. Seine erste persistente Domäne ist Conversation; der erste dauerhafte RALF-Fachdatenbestand besteht ausschließlich aus Unterhaltungen und deren geordneten Nachrichten.
 
 Conversation bleibt in Version 0.1 Bestandteil von RALF Core und verwendet den domänenspezifischen `ConversationRepository`-Vertrag. Es entsteht kein eigenständig deploybarer Conversation-Microservice.
 
@@ -19,13 +19,15 @@ RALF Core besitzt das Conversation-Modell und dessen fachliches Schema. Der Data
 
 Andere RALF-Komponenten erhalten keinen direkten Zugriff auf Conversation-Persistenzstrukturen.
 
+[ADR-0003](ADR-0003-shared-database-platform.md) präzisiert, dass RALF Core weder einziger Consumer noch Eigentümer des Database Service oder einer PostgreSQL-Providerinstanz ist. ConversationRepository gilt ausschließlich für die RALF-Core-Allocation; externe Anwendungen verwenden eigene Datenbankzugriffe.
+
 ## Begründung
 
 - Conversation liefert früh einen erkennbaren Nutzen für den eigentlichen RALF-Kern.
 - Ein begrenzter fachlicher Bestand prüft die in ADR-0001 gewählte Repository-Grenze konkret.
 - Die Einbettung in RALF Core vermeidet derzeit unnötige Netzwerk-, Deployment- und Betriebsgrenzen.
 - Klare Domänen- und Repository-Verträge erlauben eine spätere Auslagerung, falls reale Skalierungs- oder Sicherheitsanforderungen entstehen.
-- Nur tatsächlich benötigte Database-Service-Fähigkeiten werden für den ersten Kunden verbindlich.
+- Nur tatsächlich benötigte Database-Service-Fähigkeiten werden für den ersten RALF-nativen Consumer verbindlich.
 
 ## Konsequenzen
 
@@ -35,7 +37,7 @@ Andere RALF-Komponenten erhalten keinen direkten Zugriff auf Conversation-Persis
 - Conversation und Database Service besitzen klar getrennte Verantwortlichkeiten.
 - PostgreSQL bleibt austauschbarer Referenzprovider hinter der Vertragsgrenze.
 - Version 0.1 benötigt weder Benutzer-, Mandanten-, Memory-, Tool- noch Modellpersistenz.
-- `json_documents` und `full_text_search` werden für den ersten Kunden nicht verpflichtend.
+- `json_documents` und `full_text_search` werden für den ersten RALF-nativen Consumer nicht verpflichtend.
 
 ### Aufwand und Risiken
 
@@ -80,4 +82,4 @@ Zurückgestellt, weil 0.1 zunächst einen einzelnen RALF-Instanzkontext verwende
 
 ## Nächster Schritt
 
-Als Nächstes wird fachlich entschieden, welche minimale Verantwortung RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime besitzt. Dies ist weiterhin keine PostgreSQL-Installation und keine Implementierung.
+Die minimale Verantwortung von RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime bleibt als Core-Folgefrage offen. ADR-0003 setzt als nächsten projektweiten Schritt zunächst die Spezifikation des PostgreSQL-Referenzproviders und des Allocation-Lebenszyklus fest. Dies ist weiterhin keine PostgreSQL-Installation und keine Implementierung.

--- a/docs/decisions/ADR-0002-first-database-customer.md
+++ b/docs/decisions/ADR-0002-first-database-customer.md
@@ -1,0 +1,83 @@
+# ADR-0002: RALF Core und Conversation als erster Datenbankkunde
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-02
+
+## Kontext
+
+ADR-0001 hat den Database Service als providerneutrale persistente Fähigkeit festgelegt und fachliche Datenzugriffe den jeweiligen Domänenverträgen zugeordnet. Für den nächsten Schritt muss ein realer fachlicher Kunde benannt werden, damit die Abstraktion an einem kleinen, nützlichen Datenbestand präzisiert werden kann, ohne bereits PostgreSQL oder eine technische Schnittstelle zu implementieren.
+
+RALF soll nach dem Architektur-Neustart von innen nach außen zu einem nutzbaren Assistentenkern wachsen. Unterhaltung ist dafür zentral, während Installer-, Inventar-, Memory-, Benutzer- oder Providerdaten noch keinen vergleichbar unmittelbaren Kernnutzen begründen.
+
+## Entscheidung
+
+RALF Core ist der erste fachliche Kunde des Database Service. Seine erste persistente Domäne ist Conversation; der erste dauerhafte fachliche Datenbestand besteht ausschließlich aus Unterhaltungen und deren geordneten Nachrichten.
+
+Conversation bleibt in Version 0.1 Bestandteil von RALF Core und verwendet den domänenspezifischen `ConversationRepository`-Vertrag. Es entsteht kein eigenständig deploybarer Conversation-Microservice.
+
+RALF Core besitzt das Conversation-Modell und dessen fachliches Schema. Der Database Service besitzt diese Fachdomäne nicht; er verwaltet Provider, Fähigkeiten, Datenbanklebenszyklus, kontrollierte Schemaausführung, Health, Backup und Restore. PostgreSQL-spezifische Details bleiben in einem späteren Infrastrukturadapter beziehungsweise Provider.
+
+Andere RALF-Komponenten erhalten keinen direkten Zugriff auf Conversation-Persistenzstrukturen.
+
+## Begründung
+
+- Conversation liefert früh einen erkennbaren Nutzen für den eigentlichen RALF-Kern.
+- Ein begrenzter fachlicher Bestand prüft die in ADR-0001 gewählte Repository-Grenze konkret.
+- Die Einbettung in RALF Core vermeidet derzeit unnötige Netzwerk-, Deployment- und Betriebsgrenzen.
+- Klare Domänen- und Repository-Verträge erlauben eine spätere Auslagerung, falls reale Skalierungs- oder Sicherheitsanforderungen entstehen.
+- Nur tatsächlich benötigte Database-Service-Fähigkeiten werden für den ersten Kunden verbindlich.
+
+## Konsequenzen
+
+### Positiv
+
+- Die erste Persistenzentscheidung folgt einem fachlichen Anwendungsfall statt einer generischen Speicherabstraktion.
+- Conversation und Database Service besitzen klar getrennte Verantwortlichkeiten.
+- PostgreSQL bleibt austauschbarer Referenzprovider hinter der Vertragsgrenze.
+- Version 0.1 benötigt weder Benutzer-, Mandanten-, Memory-, Tool- noch Modellpersistenz.
+- `json_documents` und `full_text_search` werden für den ersten Kunden nicht verpflichtend.
+
+### Aufwand und Risiken
+
+- RALF Core benötigt später einen sorgfältig begrenzten Infrastrukturadapter.
+- Parallelität, Idempotenz, Streaming und endgültige Löschung brauchen weitere Entscheidungen.
+- Ohne Benutzer- oder Workspace-Modell gilt zunächst ein einzelner fachlicher Instanzkontext.
+- Conversation-Inhalte können sensibel sein und benötigen später Datenschutz-, Export- und Aufbewahrungsverträge.
+
+## Verworfene und zurückgestellte Alternativen
+
+### Installer- oder Inventardaten zuerst
+
+Verworfen, weil der Neustart bewusst zuerst den eigentlichen RALF-Kern entwickelt und keine neue Installations- oder Controllerarchitektur vorzieht.
+
+### Generischer Key-Value- oder CRUD-Speicher
+
+Verworfen, weil eine generische Speicheroberfläche keine klare fachliche Eigentümerschaft schafft und die in ADR-0001 abgelehnte Universal-API wieder einführen würde.
+
+### Langzeitgedächtnis zuerst
+
+Verworfen, weil noch nicht feststeht, was RALF erinnern soll und welche Regeln für Einwilligung, Herkunft, Aufbewahrung und Löschung gelten.
+
+### Eigener Conversation-Microservice
+
+Für 0.1 verworfen, weil keine unabhängigen Skalierungs-, Sicherheits- oder Deploymentanforderungen vorliegen. Hypothetische spätere Skalierung rechtfertigt heute keinen Netzwerkdienst.
+
+### Benutzer- und Mandantenmodell zuerst
+
+Zurückgestellt, weil 0.1 zunächst einen einzelnen RALF-Instanzkontext verwendet. Mehrbenutzer- oder Mandantenfähigkeit benötigt später eine eigene Entscheidung und Migration.
+
+## Nicht entschiedene Punkte
+
+- minimale Verantwortung und Anwendungsschnittstelle von RALF Core,
+- Start einer Conversation,
+- Orchestrierung und Streaming späterer Modellantworten,
+- Idempotenz und konkurrierende Schreibvorgänge,
+- Nachrichtenkorrekturen und „erneut senden“,
+- maximale Textgröße,
+- Export, Aufbewahrung und endgültige Löschung,
+- spätere Benutzer- und Workspace-Grenzen,
+- Struktur des ersten PostgreSQL-Infrastrukturadapters.
+
+## Nächster Schritt
+
+Als Nächstes wird fachlich entschieden, welche minimale Verantwortung RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime besitzt. Dies ist weiterhin keine PostgreSQL-Installation und keine Implementierung.

--- a/docs/decisions/ADR-0003-shared-database-platform.md
+++ b/docs/decisions/ADR-0003-shared-database-platform.md
@@ -1,0 +1,104 @@
+# ADR-0003: Database Service als gemeinsam nutzbare Datenbankplattform
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-02
+
+## Kontext
+
+ADR-0001 hat den Database Service als providerneutrale Datenbankfähigkeit definiert. ADR-0002 hat RALF Core und Conversation als ersten fachlich spezifizierten Kunden beschrieben. Diese Formulierungen konnten den falschen Eindruck erzeugen, der Database Service sei ausschließlich ein Persistenzdienst für RALF Core oder besitze genau eine RALF-Datenbank.
+
+RALF soll jedoch vorhandene und neue Datenbankbedarfe mehrerer Anwendungen kontrolliert bündeln können. Neben RALF Core können beispielsweise Gitea, OpenBao oder spätere Plattformkomponenten einen relationalen Datenbankprovider benötigen. Ihre Datenmodelle, Migrationsregeln und Sicherheitsanforderungen unterscheiden sich.
+
+## Entscheidung
+
+Der Database Service ist eine gemeinsam nutzbare Datenbankplattform. Er verwaltet eine oder mehrere Providerinstanzen und stellt voneinander isolierte **Database Allocations** für RALF-native Consumer, externe Anwendungen und spätere interne Plattformkomponenten bereit.
+
+PostgreSQL bleibt der erste Referenzprovider. Eine Allocation verwendet genau einen aktiven Provider und gehört genau einem Consumer. Referenzstandard ist eine eigene logische Datenbank mit eigenen technischen Identitäten je Consumer innerhalb einer gemeinsam betriebenen PostgreSQL-Providerinstanz. Dedizierte oder externe Providerinstanzen bleiben möglich.
+
+RALF Core ist der erste spezifizierte RALF-native Consumer, aber weder einziger Datenbankkunde noch Eigentümer des Database Service oder der PostgreSQL-Instanz.
+
+Die providerneutrale Verwaltungsebene beschreibt Provider, Allocations, Isolation, Identitäts- und Secret-Referenzen, Fähigkeiten, Lifecycle, Health, Readiness, Backup und Restore. Die Datenebene verwendet das native Providerprotokoll. Der Database Service ist kein SQL-Proxy und keine universelle CRUD-API.
+
+RALF-native Domänen verwenden eigene Repository-Verträge und Infrastrukturadapter. Externe Anwendungen wie Gitea oder optional OpenBao verwenden ihre nativen Datenbanktreiber und eigenen Schemata. Ihre Fachmodelle werden nicht in RALF-Verträge übersetzt.
+
+## Begründung
+
+- Gemeinsamer Providerbetrieb kann Betriebsaufwand reduzieren, ohne Daten und Rechte gemeinsam zu machen.
+- Allocations machen Consumer, Isolation, Schemaeigentum, Identitäten, Backups und Restoreziele explizit.
+- Externe Anwendungen können native, von ihnen unterstützte Datenbankzugriffe behalten.
+- RALF-native Domänen behalten fachliche Repository-Grenzen.
+- Einzelne sicherheitskritische oder inkompatible Consumer können später dediziert platziert werden.
+- Providerneutralität bleibt erhalten, während PostgreSQL eine konkrete Referenz bildet.
+
+## Konsequenzen
+
+### Positive Folgen
+
+- Mehrere Consumer können denselben Plattformdienst kontrolliert nutzen.
+- Eine logische Datenbank pro Consumer ist ein klarer Referenzstandard.
+- Schema-, Identitäts-, Backup- und Restoreverantwortung wird allocation-bezogen sichtbar.
+- Gitea, OpenBao und andere Anwendungen müssen keine RALF-Domänen-API übernehmen.
+- RALF Core und Conversation bleiben unverändert fachlich abgegrenzt.
+
+### Aufwand und Risiken
+
+- Provider- und Allocation-Lebenszyklen müssen getrennt modelliert werden.
+- Eine gemeinsame Providerinstanz bleibt eine gemeinsame Fehlerdomäne.
+- Consumer-Profile müssen Migrations- und Identitätsbesonderheiten offenlegen.
+- Ressourcen-, Netzwerk- und Backupisolation benötigen spätere konkrete Verträge.
+- OpenBao benötigt eine bewusste Storage- und Bootstrap-Secrets-Entscheidung.
+
+## Sicherheitsfolgen
+
+- Jede Allocation erhält eigene technische Identitäten und Secret-Referenzen.
+- Consumer erhalten keine Rechte auf fremde Allocations.
+- Gemeinsame Anwendungskonten, Kennwörter und Anwendungsschemata sind ausgeschlossen.
+- Consumer verwenden keine PostgreSQL-Superuseridentität.
+- Eine externe Anwendung mit anwendungseigenen Migrationen muss erweiterte Rechte und deren zeitliche Begrenzung ausdrücklich deklarieren.
+- Restore und Löschung werden allocation-bezogen geplant und dürfen fremde Allocations nicht stillschweigend verändern.
+- Sicherheitskritische Consumer können eine dedizierte Providerinstanz verlangen.
+
+## Secrets-Vertrag
+
+Die absolute Wurzel `/secrets` bleibt der verbindliche externe Bootstrap-Vertrauensanker. Provider- und Allocation-Geheimnisse liegen ausschließlich darunter; normale Konfiguration speichert nur nicht geheime Referenzen. Das Repository behält `secrets/` als Ausschluss.
+
+OpenBao kann später als Secrets-Provider untersucht werden, ersetzt `/secrets` aber nicht automatisch. Nutzt OpenBao selbst eine Database Allocation, dürfen die zum Start dieser Allocation notwendigen Geheimnisse nicht zirkulär aus OpenBao bezogen werden. Eine spätere Migration anderer Geheimnisse ist eine eigene Entscheidung mit eigenem Plan.
+
+## Verworfene und zurückgestellte Alternativen
+
+### Eine gemeinsame RALF-Datenbank
+
+Verworfen, weil externe Anwendungen eigene Datenbanken, Schemata und Lebenszyklen benötigen und nicht Eigentum einer RALF-Domäne werden.
+
+### Universeller Datenzugriffsproxy
+
+Verworfen, weil Gitea, OpenBao und andere Anwendungen ihre nativen Treiber und Datenmodelle verwenden. Ein Proxy würde Abfrageübersetzung, zusätzliche Fehlerbilder und eine künstliche Universal-API schaffen.
+
+### Gemeinsames Schema für alle Consumer
+
+Verworfen wegen fachlicher Kopplung, Sicherheitsrisiken und unkontrollierbarer Backup- und Restoreauswirkungen.
+
+### Gemeinsame technische Identität
+
+Verworfen, weil Rechte nicht minimal begrenzbar und Zugriffe nicht sauber nachvollziehbar wären.
+
+### OpenBao sofort als einziger Secrets-Speicher
+
+Zurückgestellt, weil OpenBao als eigener Database Consumer eine zirkuläre Bootstrap-Abhängigkeit erzeugen könnte und `/secrets` ausdrücklich der bestehende externe Vertrauensanker bleibt.
+
+## Offene Punkte
+
+- erste tatsächlich anzulegende Allocations,
+- RALF-Core-only oder zusätzlich Gitea im ersten Referenzdeployment,
+- OpenBao Integrated Storage oder PostgreSQL,
+- Kriterien für dedizierte Providerinstanzen,
+- Behandlung anwendungseigener Migrationen,
+- Zugriff und Rechte unter `/secrets`,
+- Secret-Rotation,
+- allocation- und providerweite Backups,
+- Ressourcen- und Netzwerkgrenzen,
+- PostgreSQL-Referenzversion.
+
+## Nächster Schritt
+
+Als Nächstes werden PostgreSQL-Referenzprovider und Allocation-Lebenszyklus spezifiziert. Es wird noch keine PostgreSQL-Instanz, Datenbank, Identität oder Allocation angelegt.

--- a/docs/domains/conversation.md
+++ b/docs/domains/conversation.md
@@ -152,7 +152,7 @@ Zu klären sind insbesondere doppelte Benutzernachrichten nach Netzwerkfehlern, 
 
 Das fachliche Conversation-Schema gehört RALF Core beziehungsweise dieser Domäne. Andere Domänen ändern es nicht direkt. Spätere versionierte Migrationspakete stammen aus der Conversation-Domäne; der Database Service plant, validiert und führt freigegebene Migrationen aus. PostgreSQL-spezifische Artefakte bleiben in einem späteren Provideradapter. Core-Start allein löst keine Migration aus.
 
-RALF Core verwendet im Normalbetrieb ausschließlich `application_role` für Conversation-Lese- und Schreibvorgänge sowie deren Transaktionen. Diese Rolle darf weder Schema und Rollen verändern noch Backups oder Datenbankadministration ausführen. Schemaänderungen verwenden ausschließlich `migration_role`; Backup und Monitoring bleiben `backup_role` und `monitoring_role` vorbehalten.
+RALF Core verwendet im Normalbetrieb ausschließlich die `application_identity` seiner eigenen Database Allocation für Conversation-Lese- und Schreibvorgänge sowie deren Transaktionen. Diese Identität darf weder Schema und Identitäten verändern noch Backups oder Datenbankadministration ausführen. Schemaänderungen verwenden ausschließlich `migration_identity`; Backup und Monitoring bleiben getrennten allocation-bezogenen Identitäten vorbehalten.
 
 ## Datenschutz und Löschung
 
@@ -188,4 +188,4 @@ Version 0.1 definiert keine Benutzerkonten, Organisationen, Mandanten oder Works
 9. Welche Komponente orchestriert Conversation und Modellruntime?
 10. Wie wird der erste PostgreSQL-Repositoryadapter strukturiert?
 
-**Unmittelbar nächste Entscheidung:** Welche minimale Verantwortung besitzt RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime?
+**Offene Conversation-Folgefrage:** Welche minimale Verantwortung besitzt RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime? Der nächste projektweite Schritt ist zunächst die Spezifikation des PostgreSQL-Referenzproviders und des Allocation-Lebenszyklus.

--- a/docs/domains/conversation.md
+++ b/docs/domains/conversation.md
@@ -1,0 +1,191 @@
+# Conversation-Domäne 0.1
+
+## Zweck
+
+Die Conversation-Domäne bewahrt den fachlichen Verlauf einer Unterhaltung zwischen einem Menschen und RALF. Sie ist die erste persistente Domäne von RALF Core und umfasst in Version 0.1 ausschließlich Unterhaltungen (`Conversation`) und Nachrichten (`Message`).
+
+Sie verantwortet das Anlegen, die geordnete Nachrichtenablage, den Unterhaltungszustand, den Lebenszyklus einer Assistentenantwort, Archivierung, ausdrückliche Löschung und die konsistente Wiederherstellung eines Gesprächsverlaufs.
+
+Die nachfolgenden Eigenschaftsnamen sind fachliche Begriffe. Sie legen weder Tabellen, SQL-Spalten, Datentypen noch eine Programmiersprache fest.
+
+## Persistenter Umfang 0.1
+
+Version 0.1 speichert ausschließlich `Conversation` und `Message`. Nicht stillschweigend ergänzt werden Benutzerkonten, Organisationen, Mandanten, Workspaces, Erinnerungen, Wissensobjekte, Embeddings, Tool-Aufrufe, Skill-Konfigurationen, Providerinventar, Modellkonfigurationen, Dateien, Anhänge, systemweite Auditdaten, Nutzungsabrechnung oder Telemetrie.
+
+Weitere persistente Domänen benötigen einen konkreten fachlichen Bedarf und eine eigene Entscheidung.
+
+## Fachliches Modell Conversation
+
+| Eigenschaft | Fachliche Bedeutung |
+| --- | --- |
+| `conversation_id` | Stabile, eindeutige und für Nutzer nicht bedeutungstragende Identität. Eine fortlaufende öffentlich erratbare Nummer ist keine Vertragsvorgabe; das konkrete Format bleibt offen. |
+| `title` | Optionaler menschenlesbarer Titel mit später festzulegender Maximallänge. Er darf manuell oder automatisch gesetzt werden und ersetzt keine technische Identität. |
+| `status` | Fachlicher Zustand `active` oder `archived`. |
+| `revision` | Monoton steigender fachlicher Revisionsstand, der bei Anlage einen vertraglich definierten Initialwert erhält, bei fachlichen Änderungen erhöht wird und später konkurrierende Änderungen erkennbar machen kann. Konkreter Zahlenwert und Technik bleiben offen. |
+| `created_at` | Vom System vergebener Erstellungszeitpunkt in UTC mit Zeitzoneninformation. |
+| `updated_at` | Vom System vergebener Zeitpunkt der letzten fachlichen Änderung in UTC mit Zeitzoneninformation. |
+
+### Zustände
+
+`active` erlaubt neue Nachrichten und erscheint standardmäßig in aktiven Übersichten.
+
+`archived` bleibt lesbar, lehnt neue Nachrichten standardmäßig ab und kann später durch eine ausdrücklich entworfene Operation reaktiviert werden.
+
+`deleted` ist kein normal gespeicherter Zustand. Löschung ist eine ausdrückliche fachliche Operation und kein dauerhaft sichtbares Pseudolöschen. Tombstones würden eine eigene rechtliche oder technische Begründung benötigen.
+
+## Fachliches Modell Message
+
+| Eigenschaft | Fachliche Bedeutung |
+| --- | --- |
+| `message_id` | Stabile eindeutige Identität einer Nachricht; das Format bleibt offen. |
+| `conversation_id` | Unveränderliche Zuordnung zu genau einer Unterhaltung. |
+| `sequence` | Innerhalb einer Unterhaltung eindeutige, monoton steigende Reihenfolge. |
+| `role` | Gesprächsseite `user` oder `assistant`. |
+| `status` | Lebenszykluszustand abhängig von der Rolle. |
+| `content_type` | In 0.1 ausschließlich `text/plain`. |
+| `content` | Unicode-Text ohne stille Kürzung oder inhaltlich unbemerkte Normalisierung. |
+| `created_at` | Vom System vergebener Erstellungszeitpunkt in UTC mit Zeitzoneninformation. |
+| `completed_at` | Abschlusszeitpunkt eines terminalen Nachrichtenzustands, sonst nicht gesetzt. |
+| `error` | Optionale providerneutrale Fehlerdarstellung einer fehlgeschlagenen Assistentenantwort. |
+
+Konkrete Datenbanktypen werden nicht festgelegt.
+
+## Nachrichtenreihenfolge
+
+Jede Nachricht erhält ihre Sequenz transaktional innerhalb ihrer Unterhaltung. Zwei Nachrichten derselben Unterhaltung dürfen nie dieselbe Sequenz besitzen. Nachrichten verschiedener Unterhaltungen verwenden unabhängige Sequenzen. Zeitstempel allein bestimmen die Reihenfolge nicht.
+
+## Rollen und Inhalt
+
+Version 0.1 unterstützt ausschließlich `user` und `assistant`. Die später denkbaren Rollen `system` und `tool` gehören nicht zum aktiven Vertrag. Interne Systemanweisungen, Prompts und Toolprotokolle werden nicht als normale Gesprächsnachrichten gespeichert.
+
+Der einzige Inhaltstyp ist `text/plain`. Markdown ist kein verbindlicher Speichertyp; eine spätere Darstellung darf Text interpretieren. HTML, Bilder, Audio, Video, Binärdaten, Anhänge, strukturierte Tool-Aufrufe und Embeddings sind ausgeschlossen.
+
+Eine erfolgreich abgeschlossene Nachricht enthält nicht leeren Unicode-Text. Eine feste maximale Textlänge wird später als Betriebsgrenze entschieden. Inhalte werden niemals still gekürzt, als HTML ausgeführt oder durch unbemerkte Normalisierung fachlich verändert.
+
+Gesprächsinhalte können personenbezogene, vertrauliche oder sonst sensible Daten enthalten. Der Vertrag behauptet nicht, sie seien geheimnisfrei.
+
+## Nachrichtenlebenszyklus
+
+### Benutzernachricht
+
+Eine Benutzernachricht wird atomar im Zustand `completed` gespeichert. Für sie sind `in_progress`, `failed` und `cancelled` unzulässig.
+
+### Assistentenantwort
+
+| Zustand | Bedeutung |
+| --- | --- |
+| `in_progress` | Antwort wurde begonnen und ihr Inhalt darf kontrolliert erweitert werden. Sie ist noch nicht endgültig. Pro Unterhaltung ist zunächst höchstens eine solche Antwort zulässig. |
+| `completed` | Antwort ist abgeschlossen, ihr Inhalt ist nicht leer und `completed_at` ist gesetzt. |
+| `failed` | Antwort konnte nicht abgeschlossen werden. Teilinhalt und eine redigierte providerneutrale Fehlerzusammenfassung dürfen erhalten bleiben. |
+| `cancelled` | Antwort wurde bewusst abgebrochen. Teilinhalt darf erhalten bleiben; es folgt kein automatischer Generierungsversuch. |
+
+Nachrichten in `completed`, `failed` oder `cancelled` sind terminal, besitzen `completed_at` und sind fachlich unveränderlich. Eine Korrektur erfordert eine neue Nachricht oder einen später ausdrücklich entworfenen Supersede-Vertrag. Unprotokollierte Bearbeitung abgeschlossener Nachrichten ist in 0.1 ausgeschlossen.
+
+## Fehlerdarstellung
+
+Eine fehlgeschlagene Assistentenantwort darf fachlich höchstens `error_code`, `error_category`, `error_summary` und `retryable` enthalten. Zulässige providerneutrale Kategorien sind zunächst:
+
+- `model_unavailable`
+- `generation_failed`
+- `generation_cancelled`
+- `timeout`
+- `content_rejected`
+- `storage_failed`
+- `unknown`
+
+Nicht gespeichert werden vollständige Stacktraces, API-Schlüssel, Authorization-Header, vollständige Providerantworten, interne Systemprompts, geheime Umgebungsvariablen oder private Modellproviderdaten. Konkrete Providerfehler sind nicht Teil dieses Vertrags.
+
+## Fachliche Invarianten
+
+- Jede Nachricht gehört genau einer Unterhaltung und kann diese Zuordnung nicht wechseln.
+- `sequence` ist pro Unterhaltung eindeutig und monoton steigend.
+- Benutzernachrichten werden atomar abgeschlossen gespeichert.
+- Pro Unterhaltung ist höchstens eine Assistentenantwort `in_progress`.
+- Eine archivierte Unterhaltung akzeptiert keine neue Nachricht.
+- Eine terminale Nachricht wird nicht überschrieben.
+- `completed_at` ist ausschließlich bei `completed`, `failed` oder `cancelled` gesetzt.
+- Eine erfolgreich abgeschlossene Textnachricht besitzt nicht leeren Inhalt.
+- Der Conversation-Revisionsstand erhöht sich bei fachlichen Änderungen.
+- Unterhaltung und Nachrichten werden bei Löschung zusammenhängend behandelt.
+- Teilweise gespeicherte fachliche Operationen gelten nicht als erfolgreich.
+
+## Transaktionsgrenzen
+
+### Unterhaltung anlegen
+
+`create_conversation` hinterlässt entweder eine vollständige neue Unterhaltung oder keine Unterhaltung.
+
+### Benutzernachricht anhängen
+
+Folgende Schritte sind eine atomare fachliche Operation:
+
+1. Unterhaltung auf `active` prüfen,
+2. nächste Sequenz vergeben,
+3. abgeschlossene Benutzernachricht speichern,
+4. Conversation-Revision aktualisieren.
+
+### Assistentenantwort beginnen
+
+Folgende Schritte sind atomar:
+
+1. Unterhaltung auf `active` prüfen,
+2. sicherstellen, dass keine andere Antwort `in_progress` ist,
+3. nächste Sequenz vergeben,
+4. Assistentennachricht als `in_progress` anlegen,
+5. Conversation-Revision aktualisieren.
+
+### Assistentenantwort abschließen
+
+Aktueller Status, finaler Inhalt, Statuswechsel, Abschlusszeitpunkt und Conversation-Revision werden zusammenhängend geprüft beziehungsweise aktualisiert. Dasselbe Prinzip gilt für `failed` und `cancelled`.
+
+### Unterhaltung löschen
+
+Unterhaltung und alle zugehörigen Nachrichten werden als eine fachliche Löschoperation behandelt. Sicherungskopien werden dadurch nicht automatisch außerhalb ihrer Aufbewahrungsregeln verändert.
+
+## Parallelität und Wiederholungen
+
+Verbindlich sind keine doppelte Sequenz, keine stillschweigende doppelte Speicherung und höchstens eine aktive Assistentenantwort je Unterhaltung. Noch offen bleibt, ob erwartete Revisionen, fachliche Operation-IDs oder Idempotency-Keys doppelte Requests und konkurrierende Änderungen erkennen.
+
+Zu klären sind insbesondere doppelte Benutzernachrichten nach Netzwerkfehlern, parallele Antwortstarts und die Wiederholung eines bereits erfolgreichen Abschlusses. Eine konkrete Optimistic-Locking- oder Idempotenztechnik wird nicht vorweggenommen.
+
+## Schemaeigentum und Rollen
+
+Das fachliche Conversation-Schema gehört RALF Core beziehungsweise dieser Domäne. Andere Domänen ändern es nicht direkt. Spätere versionierte Migrationspakete stammen aus der Conversation-Domäne; der Database Service plant, validiert und führt freigegebene Migrationen aus. PostgreSQL-spezifische Artefakte bleiben in einem späteren Provideradapter. Core-Start allein löst keine Migration aus.
+
+RALF Core verwendet im Normalbetrieb ausschließlich `application_role` für Conversation-Lese- und Schreibvorgänge sowie deren Transaktionen. Diese Rolle darf weder Schema und Rollen verändern noch Backups oder Datenbankadministration ausführen. Schemaänderungen verwenden ausschließlich `migration_role`; Backup und Monitoring bleiben `backup_role` und `monitoring_role` vorbehalten.
+
+## Datenschutz und Löschung
+
+- Logs dürfen Gesprächsinhalte nicht unnötig duplizieren.
+- Technische Fehlerlogs enthalten Nachrichteninhalte nicht standardmäßig vollständig.
+- Eine ausdrückliche Löschoperation entfernt aktive Conversation-Daten zusammenhängend.
+- Archivierung ist keine Löschung.
+- Backups können gelöschte Daten bis zum Ablauf ihrer Aufbewahrung enthalten.
+- Export, Aufbewahrungsfristen, Backup-Löschung und rechtliche Anforderungen benötigen eigene Verträge.
+
+Es wird noch keine Datenschutzautomatik definiert.
+
+## Nicht-Verantwortlichkeiten und spätere Domänen
+
+Conversation verantwortet weder Modellinferenz, Promptaufbau, Modellauswahl, Tokenisierung, Streaming, Tool-Ausführung, semantische Suche, Dateiablage, Benutzeridentität, Authentifizierung, Berechtigungen noch rohe Modellproviderfehler.
+
+Conversation History ist nicht automatisch Langzeitgedächtnis. Spätere Memory-Domänen dürfen Conversation-Daten referenzieren oder ausgewählte Informationen ableiten, benötigen aber eigene Herkunfts-, Aufbewahrungs- und Löschregeln. Sie dürfen Nachrichten nicht stillschweigend als Erinnerungen umdeuten.
+
+Dokumente, Wissensquellen und Retrieval gehören nicht in Conversation. Ebenso kennt die Domäne keine Modellinstanz, Modell-ID, API-Adresse oder Provider-Credentials.
+
+Version 0.1 definiert keine Benutzerkonten, Organisationen, Mandanten oder Workspaces. `user` bezeichnet eine Gesprächsseite, nicht ein authentifiziertes Konto. Jede Installation bildet zunächst einen fachlichen Instanzkontext; Mehrbenutzer- oder Mandantenfähigkeit benötigt eine spätere Entscheidung und Migration.
+
+## Offene Entscheidungen
+
+1. Welche konkrete Anwendungsschnittstelle besitzt RALF Core?
+2. Wie wird eine Conversation gestartet?
+3. Wie werden Modellantworten später gestreamt?
+4. Benötigt 0.1 eine Operation-ID oder einen Idempotency-Key?
+5. Wie werden Nachrichtenkorrekturen und „erneut senden“ modelliert?
+6. Welche maximale Textgröße gilt?
+7. Wie werden Export und endgültige Löschung behandelt?
+8. Wann werden Benutzer- oder Workspace-Grenzen eingeführt?
+9. Welche Komponente orchestriert Conversation und Modellruntime?
+10. Wie wird der erste PostgreSQL-Repositoryadapter strukturiert?
+
+**Unmittelbar nächste Entscheidung:** Welche minimale Verantwortung besitzt RALF Core zwischen Benutzereingabe, `ConversationRepository` und einer späteren Modellruntime?


### PR DESCRIPTION
## Ergebnis

- definiert den Database Service als gemeinsam nutzbare, providerneutrale Datenbankplattform
- trennt die RALF-steuerbare Verwaltungsebene von der nativen Provider-Datenebene
- führt isolierte Database Allocations für genau einen Consumer ein
- legt eine logische Datenbank mit eigenen Identitäten pro Consumer als Referenzstandard fest
- begrenzt RALF Core auf den ersten spezifizierten RALF-nativen Consumer
- erhält Conversation als erste RALF-Domäne und beschränkt ConversationRepository auf die RALF-Core-Allocation
- dokumentiert Gitea und OpenBao als mögliche externe Consumer mit nativen Zugriffen
- bindet alle geheimen Datenbankwerte an die externe Wurzel /secrets; im Repository verbleiben nur nicht geheime Referenzen

## Verträge und Entscheidungen

- neuer Database Allocation Contract 0.1
- ADR-0001 historisch erhalten und durch ADR-0003 präzisiert
- ADR-0002 auf den ersten RALF-nativen Consumer begrenzt
- neues ADR-0003 zur Shared-Platform- und Multi-Consumer-Architektur
- getrennte Schema-Lebenszyklen domain_managed, application_managed und platform_preprovisioned
- allocation-bezogene Identitäten, Health, Readiness, Backup und Restore

## Umfang

Ausschließlich Spezifikationsdokumente. Keine Implementierung, keine PostgreSQL-Instanz, keine Datenbank, keine Rolle, kein Secret, kein SQL, keine Netzwerk- oder Infrastrukturänderung. PR #43 bleibt Draft.

## Prüfungen

- git diff --check
- Markdown-Überschriftenstruktur und interne Links
- ADR-Reihenfolge 0001, 0002, 0003
- Mehrkunden-, Allocation-, Isolation-, Schema-, Identity-, Health- und Backup-Vertragsabdeckung
- Widerspruchssuche zu Ein-Consumer-, ConversationRepository-, OpenBao- und Sharing-Aussagen
- keine konkrete PostgreSQL-Version
- kein SQL, keine Tabellennamen und keine Connection Strings mit Zugangsdaten
- /secrets nicht angelegt oder verändert
- lokales secrets/ weiterhin ignoriert, nicht gestaged und unverändert
- keine Implementierungsverzeichnisse oder ausführbaren Dateien