### PR TITLE
Specify PostgreSQL provider, allocation lifecycle, and first deployment profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,11 @@ Die erste fachliche Spezifikation trennt den fähigkeitsorientierten RALF-Vertra
 - [Architektur des Database Service](docs/architecture/database-service.md)
 - [RALF Database Contract 0.1](docs/contracts/database-service-v0.1.md)
 - [Database Allocation Contract 0.1](docs/contracts/database-allocation-v0.1.md)
+- [Provider 001: PostgreSQL](docs/providers/postgresql.md)
+- [Database-Allocation-Lebenszyklus](docs/lifecycle/database-allocation.md)
 - [ADR-0001: providerneutrale Datenbankfähigkeit](docs/decisions/ADR-0001-database-service.md)
 - [ADR-0003: gemeinsam nutzbare Datenbankplattform](docs/decisions/ADR-0003-shared-database-platform.md)
+- [ADR-0004: PostgreSQL als erster Referenzprovider](docs/decisions/ADR-0004-postgresql-reference-provider.md)
 
 Der erste spezifizierte RALF-native Database Consumer ist **RALF Core**. Seine erste persistente Domäne **Conversation** speichert ausschließlich Unterhaltungen und geordnete Nachrichten. Conversation bleibt zunächst eine Core-Domäne und verwendet nur in der RALF-Core-Allocation einen fachlichen Repository-Vertrag:
 
@@ -27,6 +30,8 @@ Externe Anwendungen wie Gitea oder optional OpenBao können eigene Allocations m
 
 Es gibt weiterhin keine Implementierung. Insbesondere existieren noch kein SQL, keine Tabellen, PostgreSQL-Installation, Programmierschnittstelle, Modellruntime, Benutzerverwaltung, Weboberfläche oder Infrastruktur.
 
-Der nächste kleine Schritt ist die Spezifikation des PostgreSQL-Referenzproviders und des Allocation-Lebenszyklus. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
+Provider 001 beschreibt PostgreSQL nun als konkrete Referenz hinter dem providerneutralen Vertrag. Providerinstanz und Allocation besitzen getrennte Zustände; der Referenzstandard bleibt eine logische Datenbank mit eigenen Identitäten pro Consumer. Die Spezifikation legt weder eine PostgreSQL-Version noch ein Deployment oder reale Allocations fest.
+
+Der nächste kleine Schritt ist die Auswahl der PostgreSQL-Referenzversion, des ersten Deploymentprofils und der tatsächlich anzulegenden Allocations. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
 
 RALF entsteht transparent durch Vibe Coding: Menschen bestimmen Ziele, Entscheidungen und Grenzen; Coding-Agenten unterstützen die Umsetzung in kleinen, überprüfbaren Schritten.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Die erste fachliche Spezifikation trennt den fähigkeitsorientierten RALF-Vertra
 - [ADR-0001: providerneutrale Datenbankfähigkeit](docs/decisions/ADR-0001-database-service.md)
 - [ADR-0003: gemeinsam nutzbare Datenbankplattform](docs/decisions/ADR-0003-shared-database-platform.md)
 - [ADR-0004: PostgreSQL als erster Referenzprovider](docs/decisions/ADR-0004-postgresql-reference-provider.md)
+- [ADR-0005: erstes PostgreSQL-Deploymentprofil](docs/decisions/ADR-0005-first-postgresql-deployment-profile.md)
 
 Der erste spezifizierte RALF-native Database Consumer ist **RALF Core**. Seine erste persistente Domäne **Conversation** speichert ausschließlich Unterhaltungen und geordnete Nachrichten. Conversation bleibt zunächst eine Core-Domäne und verwendet nur in der RALF-Core-Allocation einen fachlichen Repository-Vertrag:
 
@@ -30,8 +31,10 @@ Externe Anwendungen wie Gitea oder optional OpenBao können eigene Allocations m
 
 Es gibt weiterhin keine Implementierung. Insbesondere existieren noch kein SQL, keine Tabellen, PostgreSQL-Installation, Programmierschnittstelle, Modellruntime, Benutzerverwaltung, Weboberfläche oder Infrastruktur.
 
-Provider 001 beschreibt PostgreSQL nun als konkrete Referenz hinter dem providerneutralen Vertrag. Providerinstanz und Allocation besitzen getrennte Zustände; der Referenzstandard bleibt eine logische Datenbank mit eigenen Identitäten pro Consumer. Die Spezifikation legt weder eine PostgreSQL-Version noch ein Deployment oder reale Allocations fest.
+Provider 001 beschreibt PostgreSQL als konkrete Referenz hinter dem providerneutralen Vertrag. Das erste deployment-spezifische Profil wählt PostgreSQL Major 18 und die gemeinsame Providerinstanz `postgresql-main`. Ihr initial dokumentierter Minor-Stand ist 18.4; installiert wird später die dann neueste stabile 18.x-Minor-Version. Ein automatischer Wechsel auf PostgreSQL 19 ist ausgeschlossen.
 
-Der nächste kleine Schritt ist die Auswahl der PostgreSQL-Referenzversion, des ersten Deploymentprofils und der tatsächlich anzulegenden Allocations. Auch danach erfolgt nicht automatisch eine PostgreSQL-Installation.
+Für die erste Referenzinstallation sind vier isolierte Allocations ausgewählt: Gitea, OpenBao, Semaphore UI und Node-RED. RALF Core erhält noch keine Allocation. OpenBao verwendet in diesem Deployment bewusst PostgreSQL; Node-RED nutzt seine Allocation nur für relationale Flow-Anwendungsdaten, nicht automatisch als internen Speicher.
+
+Der nächste kleine Schritt ist ein zunächst read-only geplanter Implementierungspfad. Vor jeder Mutation werden noch Betriebsform, Netzwerkgrenze, Ressourcen, Backupziel, Rechte unter `/secrets` und kompatible Anwendungsversionen festgelegt. PostgreSQL ist weiterhin nicht installiert.
 
 RALF entsteht transparent durch Vibe Coding: Menschen bestimmen Ziele, Entscheidungen und Grenzen; Coding-Agenten unterstützen die Umsetzung in kleinen, überprüfbaren Schritten.

--- a/docs/architecture/database-service.md
+++ b/docs/architecture/database-service.md
@@ -32,7 +32,7 @@ PostgreSQL ist der erste Referenzprovider, aber kein Bestandteil des öffentlich
  PostgreSQL-Adapter       Datenbankzugriff     Storage-Zugriff
 ```
 
-Das Modell beschreibt mögliche isolierte Zuweisungen, keine bereits laufende Installation. Weder Gitea noch OpenBao noch eine konkrete Allocation werden in diesem Schritt eingerichtet.
+Das Modell beschreibt mögliche isolierte Zuweisungen, keine bereits laufende Installation. [ADR-0005](../decisions/ADR-0005-first-postgresql-deployment-profile.md) wählt für das erste Referenzdeployment Gitea, OpenBao, Semaphore UI und Node-RED als vier isolierte Allocations; eingerichtet ist davon noch keine.
 
 ## Verwaltungs- und Datenebene
 
@@ -156,7 +156,7 @@ Gitea ist ein möglicher `external_application`-Consumer und unterstützt Postgr
 
 ### OpenBao
 
-OpenBao ist ein möglicher `external_application`-Consumer. Sein PostgreSQL-Backend gilt als produktions- und HA-fähige Storage-Option; für die meisten neuen Installationen bleibt das von OpenBao empfohlene Integrated Storage dennoch ein gleichwertig zu prüfender Kandidat. PostgreSQL wird nicht automatisch ausgewählt. Bei einer PostgreSQL-Allocation wären eigene logische Datenbank, eigene Identitäten und fehlende Rechte auf andere Allocations Pflicht. Die konkrete Storage-Entscheidung bleibt offen.
+OpenBao ist ein möglicher `external_application`-Consumer. Sein PostgreSQL-Backend gilt als produktions- und HA-fähige Storage-Option; für andere Installationen bleibt Integrated Storage ein gleichwertig zu prüfender Kandidat. ADR-0005 wählt PostgreSQL ausschließlich für das erste Referenzdeployment. Eigene logische Datenbank, eigene Identitäten und fehlende Rechte auf andere Allocations bleiben Pflicht.
 
 ## Identitäten und Rollen pro Allocation
 
@@ -222,7 +222,7 @@ Version 0.1 beschreibt Backups mindestens allocation-bezogen. Jedes Backup gehö
 
 Ein Restore einer Allocation darf keine andere Allocation oder die gesamte Providerinstanz stillschweigend überschreiben. Providerweite physische Sicherungen können später zusätzlich geplant werden.
 
-Bei OpenBao hängt der Backupvertrag vom gewählten Storage-Backend ab. Integrated Storage liegt außerhalb des PostgreSQL-Database-Service-Backups; eine PostgreSQL-Allocation fällt unter den Allocation-Backupvertrag. Diese Wahl wird nicht vorweggenommen.
+Bei OpenBao hängt der Backupvertrag vom deployment-spezifisch gewählten Storage-Backend ab. Integrated Storage liegt außerhalb des PostgreSQL-Database-Service-Backups; die in ADR-0005 gewählte PostgreSQL-Allocation fällt unter den Allocation-Backupvertrag.
 
 ## Providerprinzip
 
@@ -238,21 +238,18 @@ Der Database Service ist kein SQL-Proxy, allgemeiner CRUD-Dienst, Datei- oder Ob
 
 PostgreSQL ist als [Provider 001](../providers/postgresql.md) der erste konkrete Referenzprovider. Eine PostgreSQL Provider Instance ist ein betriebener Server beziehungsweise Cluster mit null oder mehr isolierten Allocations. Providerinstanz und Allocation besitzen getrennte [Lebenszyklen](../lifecycle/database-allocation.md); eine bereite Instanz macht eine einzelne Allocation nicht automatisch bereit.
 
-Der Referenzstandard verwendet eine logische Datenbank und eigene technische Identitäten pro Allocation. Eine konkrete Version, Paketquelle, Betriebsform, Netzwerkgrenze, Serverkonfiguration, Datenbankbezeichnung, Identität, Port, Adresse oder Zugangsdaten werden noch nicht festgelegt. [ADR-0004](../decisions/ADR-0004-postgresql-reference-provider.md) hält diese Grenze verbindlich fest.
+Der Referenzstandard verwendet eine logische Datenbank und eigene technische Identitäten pro Allocation. ADR-0005 legt PostgreSQL Major 18, die 18.x-Minor-Policy, `postgresql-main` und vier initiale Allocations fest. Paketquelle, Betriebsform, Netzwerkgrenze, Serverkonfiguration, konkrete Datenbanknamen, PostgreSQL-Benutzernamen, Port, Adresse und Secretwerte bleiben bis zum Folgeplan offen. [ADR-0004](../decisions/ADR-0004-postgresql-reference-provider.md) und ADR-0005 halten diese Grenzen fest.
 
 ## Offene Entscheidungen
 
-1. Welche Allocations werden in der ersten realen PostgreSQL-Instanz angelegt?
-2. Beginnt die Referenzinstallation nur mit RALF Core oder zusätzlich mit Gitea?
-3. Verwendet OpenBao Integrated Storage oder PostgreSQL?
-4. Welche Consumer benötigen eine dedizierte Providerinstanz?
-5. Welche externen Anwendungen führen Migrationen selbst aus?
-6. Wie erhalten Anwendungen Zugriff auf ihre Secrets unter `/secrets`?
-7. Welche Eigentümer- und Gruppenrechte gelten unter `/secrets`?
-8. Wie erfolgt Secret-Rotation?
-9. Welche Backups erfolgen pro Allocation und welche providerweit?
-10. Wie werden Ressourcenlimits pro Allocation abgebildet?
-11. Welche Netzwerkgrenzen gelten zwischen Consumer und Provider?
-12. Welche PostgreSQL-Version wird Referenzversion?
+1. Welche Consumer benötigen später eine dedizierte Providerinstanz?
+2. Welche externen Anwendungen führen Migrationen selbst aus?
+3. Wie erhalten Anwendungen Zugriff auf ihre Secrets unter `/secrets`?
+4. Welche Eigentümer- und Gruppenrechte gelten unter `/secrets`?
+5. Wie erfolgt Secret-Rotation?
+6. Welche Backups erfolgen pro Allocation und welche providerweit?
+7. Wie werden Ressourcenlimits pro Allocation abgebildet?
+8. Welche Netzwerkgrenzen gelten zwischen Consumer und Provider?
+9. Wie wird das in ADR-0005 gewählte Profil konkret betrieben und read-only geplant?
 
-**Nächster kleiner Schritt:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen, ohne PostgreSQL zu installieren.
+**Nächster kleiner Schritt:** Einen ausschließlich read-only arbeitenden Deploymentplan für PostgreSQL 18, `postgresql-main` und die vier ausgewählten Allocations erstellen.

--- a/docs/architecture/database-service.md
+++ b/docs/architecture/database-service.md
@@ -236,7 +236,9 @@ Der Database Service ist kein SQL-Proxy, allgemeiner CRUD-Dienst, Datei- oder Ob
 
 ## PostgreSQL als Referenzprovider
 
-PostgreSQL ist der erste Provider. Eine konkrete Version, Paketquelle, Betriebsform, Netzwerkgrenze, Serverkonfiguration, Datenbankbezeichnung, Identität, Port, Adresse oder Zugangsdaten werden noch nicht festgelegt.
+PostgreSQL ist als [Provider 001](../providers/postgresql.md) der erste konkrete Referenzprovider. Eine PostgreSQL Provider Instance ist ein betriebener Server beziehungsweise Cluster mit null oder mehr isolierten Allocations. Providerinstanz und Allocation besitzen getrennte [Lebenszyklen](../lifecycle/database-allocation.md); eine bereite Instanz macht eine einzelne Allocation nicht automatisch bereit.
+
+Der Referenzstandard verwendet eine logische Datenbank und eigene technische Identitäten pro Allocation. Eine konkrete Version, Paketquelle, Betriebsform, Netzwerkgrenze, Serverkonfiguration, Datenbankbezeichnung, Identität, Port, Adresse oder Zugangsdaten werden noch nicht festgelegt. [ADR-0004](../decisions/ADR-0004-postgresql-reference-provider.md) hält diese Grenze verbindlich fest.
 
 ## Offene Entscheidungen
 
@@ -253,4 +255,4 @@ PostgreSQL ist der erste Provider. Eine konkrete Version, Paketquelle, Betriebsf
 11. Welche Netzwerkgrenzen gelten zwischen Consumer und Provider?
 12. Welche PostgreSQL-Version wird Referenzversion?
 
-**Nächster kleiner Schritt:** Definiere den PostgreSQL-Referenzprovider und den Allocation-Lebenszyklus, ohne PostgreSQL zu installieren.
+**Nächster kleiner Schritt:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen, ohne PostgreSQL zu installieren.

--- a/docs/contracts/database-allocation-v0.1.md
+++ b/docs/contracts/database-allocation-v0.1.md
@@ -219,15 +219,24 @@ Möglicher `external_application` Consumer mit eigenem Datenbankzugriff und `app
 
 Möglicher `external_application` Consumer. PostgreSQL bleibt optionale Storage-Wahl; Integrated Storage muss gleichwertig geprüft werden. OpenBao verwendet nicht ConversationRepository.
 
+## Erstes Referenzdeployment
+
+[ADR-0005](../decisions/ADR-0005-first-postgresql-deployment-profile.md) wählt für die Providerinstanz `postgresql-main` genau vier Allocations: `gitea`, `openbao`, `semaphore` und `nodered`. Alle sind `external_application`, verwenden `logical_database`, besitzen `application_managed` als Schema-Lebenszyklus und sind ausdrücklich ausgewählt.
+
+Jede Allocation besitzt eine eigene logische Datenbank, eine eigene `application_identity` und eine eigene Referenz auf `application-password` unter `/secrets/database-service/allocations/<allocation-id>/`. Rechte auf fremde Allocations, gemeinsame Anwendungsrollen, gemeinsame Anwendungspasswörter und gemeinsam genutzte Anwendungsschemata sind ausgeschlossen. Health, Readiness, Backup und Restore bleiben allocation-bezogen.
+
+OpenBao verwendet in diesem Deployment PostgreSQL als Storage; die Auswahl gilt nicht allgemein. Node-RED verwendet seine Allocation ausschließlich für relationale Flow-Anwendungsdaten, nicht automatisch für Flowdateien, Credentials, Context oder den internen Node-RED-Storage.
+
+RALF Core erhält in diesem ersten realen Deployment keine Allocation. Seine spätere `domain_managed` Allocation setzt einen implementierten Core sowie ein konkretes Schema oder Migrationspaket voraus.
+
 ## Offene Punkte
 
-- tatsächliche erste Allocations,
 - Platzierungsentscheidung gemeinsam oder dediziert,
 - Rechte bei anwendungseigenen Migrationen,
 - Zugriff der Consumer auf `/secrets`,
 - Eigentümer-, Gruppen- und Rotationsmodell,
 - Ressourcen- und Netzwerkgrenzen,
 - allocation- und providerweite Backupbeziehung,
-- PostgreSQL-Referenzversion.
+- konkrete Consumer-Versionskompatibilität.
 
-**Nächster Schritt:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen, ohne eine Providerinstanz oder Allocation anzulegen.
+**Nächster Schritt:** Einen zunächst read-only geplanten Implementierungspfad ausarbeiten, ohne eine Providerinstanz oder Allocation anzulegen.

--- a/docs/contracts/database-allocation-v0.1.md
+++ b/docs/contracts/database-allocation-v0.1.md
@@ -121,25 +121,15 @@ RALF Core Conversation verlangt `relational_storage`, `transactions`, `schema_mi
 
 ## Zustände
 
-Eine Allocation verwendet zunächst:
+Der normative [Database-Allocation-Lebenszyklus](../lifecycle/database-allocation.md) definiert die Zustände `requested`, `planned`, `provisioning`, `configured`, `migration_required`, `migrating`, `ready`, `degraded`, `backup_running`, `restore_planned`, `restore_running`, `suspended`, `deleting`, `deleted` und `failed` einschließlich erlaubter Zugriffe und administrativer Grenzen.
 
-| Zustand | Bedeutung |
-| --- | --- |
-| `unknown` | Zustand ist nicht verlässlich bekannt. |
-| `unconfigured` | Pflichtzuordnung oder Vertragsdaten fehlen. |
-| `configured` | Vertrag ist vollständig, Bereitschaft aber nicht bestätigt. |
-| `starting` | Zuweisung wird für den Consumer bereitgestellt oder geprüft. |
-| `ready` | Isolation, Identitäten, Fähigkeiten und Schema sind verwendbar. |
-| `degraded` | Allocation ist eingeschränkt; erlaubte Zugriffe müssen explizit sein. |
-| `maintenance` | Geplanter Wartungszustand. |
-| `migration_required` | Schema-Lebenszyklus verlangt eine Migration. |
-| `migrating` | Eine autorisierte Migration läuft. |
-| `backup_running` | Allocation-bezogenes Backup läuft. |
-| `restore_running` | Allocation-bezogener Restore läuft. |
-| `failed` | Sicherer Betrieb ist nicht möglich. |
-| `stopped` | Allocation ist kontrolliert nicht verfügbar. |
+Eine Allocation darf nicht `ready` melden, nur weil ihre Providerinstanz gesund ist. Ein Dienststart erzeugt weder eine Allocation noch eine Migration oder einen anderen mutierenden Zustandsübergang.
 
-Die vollständigen Zustandsübergänge bleiben Teil des nächsten Spezifikationsschritts. Eine Allocation darf nicht `ready` melden, nur weil ihre Providerinstanz gesund ist.
+## Fachliche Operationen und Allocation-Plan
+
+Der Lebenszyklus beschreibt die fachlichen Operationen von Planung und Anlage über Verifikation, Migration, Suspendierung, Backup, Restore und Secret-Rotation bis zur geplanten Löschung. Diese Namen sind keine technischen Signaturen.
+
+Jede Mutation benötigt einen Plan mit Ausgangs- und Zielzustand, Voraussetzungen, sichtbaren Mutationen, Risiken, ausdrücklicher Freigabe und Abschlussverifikation. Der Plan benennt Consumer, Profil, Providerinstanz, Version, Isolation, Datenbankreferenz, Schema-Lebenszyklus, Fähigkeiten, Identitäten, Secret-Referenzen, Netzwerkgrenze, Policies, Ressourcen, Validierung und Rollback-Grenzen. Er enthält keine Secretwerte oder ausführbaren freien Befehle.
 
 ## Health und Readiness
 
@@ -173,20 +163,29 @@ Ein Restore darf keine fremde Allocation oder die gesamte Providerinstanz stills
 ## Providerneutrale Fehlerklassen
 
 - `allocation_not_found`
+- `allocation_not_ready`
+- `allocation_already_exists`
 - `allocation_conflict`
 - `consumer_conflict`
+- `provider_not_ready`
+- `provider_version_incompatible`
 - `provider_unavailable`
 - `provider_conflict`
 - `capability_missing`
 - `isolation_violation`
-- `identity_error`
-- `secret_reference_error`
+- `identity_conflict`
+- `secret_reference_invalid`
+- `secret_already_exists`
+- `secret_unavailable`
 - `schema_mismatch`
+- `schema_lifecycle_conflict`
 - `migration_required`
 - `migration_failed`
 - `backup_failed`
+- `backup_not_verified`
+- `restore_conflict`
 - `restore_failed`
-- `storage_exhausted`
+- `resource_exhausted`
 - `unknown_error`
 
 Fehler enthalten später eine nicht geheime Allocation-, Consumer-, Provider- und Operationsreferenz. Providerrohfehler und Secretwerte werden nicht Bestandteil des allgemeinen Vertrags.
@@ -223,7 +222,6 @@ Möglicher `external_application` Consumer. PostgreSQL bleibt optionale Storage-
 ## Offene Punkte
 
 - tatsächliche erste Allocations,
-- vollständige Zustandsübergänge,
 - Platzierungsentscheidung gemeinsam oder dediziert,
 - Rechte bei anwendungseigenen Migrationen,
 - Zugriff der Consumer auf `/secrets`,
@@ -232,4 +230,4 @@ Möglicher `external_application` Consumer. PostgreSQL bleibt optionale Storage-
 - allocation- und providerweite Backupbeziehung,
 - PostgreSQL-Referenzversion.
 
-**Nächster Schritt:** PostgreSQL-Referenzprovider und Allocation-Lebenszyklus spezifizieren, ohne eine Providerinstanz oder Allocation anzulegen.
+**Nächster Schritt:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen, ohne eine Providerinstanz oder Allocation anzulegen.

--- a/docs/contracts/database-service-v0.1.md
+++ b/docs/contracts/database-service-v0.1.md
@@ -4,7 +4,7 @@
 
 Dieser Vertrag beschreibt die providerneutrale Verwaltungsebene der gemeinsam nutzbaren Database-Service-Plattform. Er legt weder REST, RPC, MCP, Python-Signaturen, SQL noch ein Konfigurationsformat fest.
 
-PostgreSQL ist der erste Referenzprovider, bleibt aber außerhalb des öffentlichen Vertrags. Der detaillierte Vertrag einer isolierten Zuweisung steht im [Database Allocation Contract 0.1](database-allocation-v0.1.md).
+PostgreSQL ist der erste Referenzprovider, bleibt aber außerhalb des öffentlichen Vertrags. Seine konkrete Spezifikation steht unter [Provider 001: PostgreSQL](../providers/postgresql.md). Der detaillierte Vertrag einer isolierten Zuweisung steht im [Database Allocation Contract 0.1](database-allocation-v0.1.md), dessen Zustandsübergänge der [Database-Allocation-Lebenszyklus](../lifecycle/database-allocation.md) präzisiert.
 
 ## Vertragsumfang 0.1
 
@@ -141,23 +141,9 @@ OpenBao kann später Secrets-Provider werden, ersetzt `/secrets` aber nicht auto
 
 ## Lebenszykluszustände
 
-Providerinstanzen und Allocations verwenden getrennte Zustandsmeldungen. Der gemeinsame Katalog lautet:
+Providerinstanzen und Allocations verwenden ausdrücklich getrennte Zustandskataloge. Der [PostgreSQL-Providervertrag](../providers/postgresql.md) definiert den Instanzlebenszyklus von `unknown` und `declared` bis `ready`, `failed` oder `retired`. Der [Allocation-Lebenszyklus](../lifecycle/database-allocation.md) reicht von `requested` und `planned` über Bereitstellung, Migration, Backup und Restore bis `deleted` oder `failed`.
 
-- `unknown`
-- `unconfigured`
-- `configured`
-- `starting`
-- `ready`
-- `degraded`
-- `maintenance`
-- `migration_required`
-- `migrating`
-- `backup_running`
-- `restore_running`
-- `failed`
-- `stopped`
-
-Nicht jeder Zustand ist auf beide Ebenen gleich anwendbar. `migration_required` bezieht sich beispielsweise auf eine Allocation, während ein Provider gleichzeitig `ready` sein kann. Zugriff ist nur erlaubt, wenn die konkrete Allocation dafür bereit ist; ein Fehler einer Allocation macht andere Allocations nicht automatisch fehlerhaft.
+`migration_required` bezieht sich auf eine Allocation, während ihr Provider gleichzeitig `ready` sein kann. Zugriff ist nur erlaubt, wenn die konkrete Allocation dafür bereit ist; ein Fehler einer Allocation macht andere Allocations nicht automatisch fehlerhaft. Kein mutierender Übergang erfolgt allein durch einen Dienststart.
 
 ## Health und Readiness
 
@@ -206,21 +192,35 @@ Ein Allocation-Restore darf weder eine andere Allocation noch die gesamte Provid
 | Kategorie | Bedeutung |
 | --- | --- |
 | `configuration_error` | Nicht geheime Vertragsdaten sind ungültig oder unvollständig. |
+| `provider_not_ready` | Providerinstanz ist vorhanden, aber für die Operation nicht bereit. |
+| `provider_version_incompatible` | Provider-Version ist mit Allocation oder Plan unvereinbar. |
 | `provider_unavailable` | Providerinstanz ist nicht verfügbar. |
 | `provider_conflict` | Providerzustand oder Fähigkeiten widersprechen dem Vertrag. |
 | `allocation_unavailable` | Zugewiesene Datenbankressource ist nicht verfügbar. |
 | `allocation_conflict` | Isolation, Identitäten oder Zuordnung widersprechen dem Allocation-Vertrag. |
+| `allocation_not_found` | Referenzierte Allocation existiert nicht. |
+| `allocation_not_ready` | Allocation ist vorhanden, aber für die Operation nicht bereit. |
+| `allocation_already_exists` | Die geplante Allocation kollidiert mit einer bestehenden Zuweisung. |
 | `connection_error` | Native Verbindung konnte nicht hergestellt oder gehalten werden. |
 | `authentication_error` | Technische Identität konnte nicht nachgewiesen werden. |
 | `authorization_error` | Identität besitzt falsche oder unzureichende Rechte. |
+| `identity_conflict` | Geplante oder vorhandene Identitäten verletzen den Allocation-Vertrag. |
 | `secret_reference_error` | Secret-Referenz ist ungültig oder nicht sicher auflösbar. |
+| `secret_reference_invalid` | Secret-Referenz verletzt Pfad- oder Sicherheitsregeln. |
+| `secret_already_exists` | Eine nicht zu überschreibende Secretdatei ist bereits vorhanden. |
+| `secret_unavailable` | Eine benötigte Secret-Referenz ist nicht sicher verwendbar. |
 | `capability_missing` | Eine für die Allocation erforderliche Fähigkeit fehlt. |
 | `schema_mismatch` | Schema- oder Anwendungszustand ist unbekannt oder inkompatibel. |
+| `schema_lifecycle_conflict` | Schemaeigentum oder Migrationsmodus widerspricht dem Consumervertrag. |
 | `migration_required` | Eine bekannte Migration ist vor Bereitschaft erforderlich. |
 | `migration_failed` | Eine freigegebene Migration ist fehlgeschlagen. |
 | `storage_exhausted` | Ressource reicht für sicheren Betrieb nicht aus. |
+| `resource_exhausted` | Eine vereinbarte Allocation- oder Providerressource ist erschöpft. |
 | `backup_failed` | Sicherung oder Verifikation ist fehlgeschlagen. |
+| `backup_not_verified` | Backup existiert, ist aber nicht als verwendbar verifiziert. |
+| `restore_conflict` | Restorequelle, Ziel oder Zustand widerspricht dem Restorevertrag. |
 | `restore_failed` | Wiederherstellung oder Abschlussprüfung ist fehlgeschlagen. |
+| `isolation_violation` | Eine Consumer- oder Allocation-Grenze wurde verletzt. |
 | `unknown_error` | Fehler konnte keiner stabilen Kategorie zugeordnet werden. |
 
 Providerspezifische Fehler dürfen intern für Diagnose erhalten bleiben, werden aber nicht allgemeiner Vertragsbestandteil.
@@ -235,16 +235,18 @@ Anlage, Änderung, Migration, Backup, Restore, Identitätsänderung, Secret-Erze
 
 [ADR-0003](../decisions/ADR-0003-shared-database-platform.md) präzisiert die gemeinsam nutzbare Plattform und die Mehrkundenstruktur.
 
+[ADR-0004](../decisions/ADR-0004-postgresql-reference-provider.md) konkretisiert den ersten Provider, ohne ihn in den öffentlichen Vertrag aufzunehmen.
+
 ## Offene Entscheidungen
 
 1. Welche Allocations werden zuerst tatsächlich angelegt?
-2. Welche Provider- und Allocation-Zustandsübergänge gehören in das Referenzprofil?
+2. Welche PostgreSQL-Major-Version und welches Deploymentprofil bilden die Referenz?
 3. Welche Consumer benötigen dedizierte Providerinstanzen?
 4. Wie werden externe anwendungseigene Migrationen sicher freigegeben oder beobachtet?
 5. Wie erhalten Consumer Zugriff auf Secretdateien unter `/secrets`?
 6. Welche Eigentümer-, Gruppen- und Rotationsregeln gelten dort?
 7. Welche Backups sind allocation-bezogen und welche providerweit?
 8. Wie werden Ressourcen- und Netzwerkgrenzen abgebildet?
-9. Welche PostgreSQL-Version wird Referenzversion?
+9. Welche Erweiterungen sind im PostgreSQL-Basisprofil zulässig?
 
-**Nächster kleiner Schritt:** PostgreSQL-Referenzprovider und Allocation-Lebenszyklus spezifizieren, ohne PostgreSQL zu installieren.
+**Nächster kleiner Schritt:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen, ohne PostgreSQL zu installieren.

--- a/docs/contracts/database-service-v0.1.md
+++ b/docs/contracts/database-service-v0.1.md
@@ -42,7 +42,7 @@ Ein Database Consumer benötigt genau eine oder mehrere ausdrücklich geplante A
 
 Ein Consumer-Profil beschreibt unterstützte Provider, benötigte und optionale Fähigkeiten, Schema-Lebenszyklus, Identitätsmodell, Backup- und Health-Erwartungen sowie bekannte Einschränkungen. Es ist keine laufende Allocation und erzeugt keine Datenbank.
 
-RALF Core ist der erste spezifizierte `ralf_native` Consumer. Gitea und OpenBao sind mögliche `external_application` Consumer; ihre tatsächliche Auswahl bleibt offen.
+RALF Core ist der erste spezifizierte `ralf_native` Consumer. Im ersten Referenzdeployment erhält Core noch keine Allocation; ADR-0005 wählt stattdessen Gitea, OpenBao, Semaphore UI und Node-RED als vier `external_application` Consumer aus.
 
 ## Providerfähigkeiten
 
@@ -237,16 +237,17 @@ Anlage, Änderung, Migration, Backup, Restore, Identitätsänderung, Secret-Erze
 
 [ADR-0004](../decisions/ADR-0004-postgresql-reference-provider.md) konkretisiert den ersten Provider, ohne ihn in den öffentlichen Vertrag aufzunehmen.
 
+[ADR-0005](../decisions/ADR-0005-first-postgresql-deployment-profile.md) wählt deployment-spezifisch PostgreSQL Major 18, `postgresql-main` und die ersten vier Allocations. Der allgemeine Vertrag bleibt providerneutral.
+
 ## Offene Entscheidungen
 
-1. Welche Allocations werden zuerst tatsächlich angelegt?
-2. Welche PostgreSQL-Major-Version und welches Deploymentprofil bilden die Referenz?
-3. Welche Consumer benötigen dedizierte Providerinstanzen?
-4. Wie werden externe anwendungseigene Migrationen sicher freigegeben oder beobachtet?
-5. Wie erhalten Consumer Zugriff auf Secretdateien unter `/secrets`?
-6. Welche Eigentümer-, Gruppen- und Rotationsregeln gelten dort?
-7. Welche Backups sind allocation-bezogen und welche providerweit?
-8. Wie werden Ressourcen- und Netzwerkgrenzen abgebildet?
-9. Welche Erweiterungen sind im PostgreSQL-Basisprofil zulässig?
+1. Welche Consumer benötigen dedizierte Providerinstanzen?
+2. Wie werden externe anwendungseigene Migrationen sicher freigegeben oder beobachtet?
+3. Wie erhalten Consumer Zugriff auf Secretdateien unter `/secrets`?
+4. Welche Eigentümer-, Gruppen- und Rotationsregeln gelten dort?
+5. Welche Backups sind allocation-bezogen und welche providerweit?
+6. Wie werden Ressourcen- und Netzwerkgrenzen abgebildet?
+7. Welche Erweiterungen sind im PostgreSQL-Basisprofil zulässig?
+8. Wie wird das in ADR-0005 gewählte Profil konkret und mutierungsfrei geplant?
 
-**Nächster kleiner Schritt:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen, ohne PostgreSQL zu installieren.
+**Nächster kleiner Schritt:** Einen ausschließlich read-only arbeitenden Deploymentplaner spezifizieren und implementieren, ohne PostgreSQL oder eine Allocation anzulegen.

--- a/docs/decisions/ADR-0003-shared-database-platform.md
+++ b/docs/decisions/ADR-0003-shared-database-platform.md
@@ -101,4 +101,4 @@ Zurückgestellt, weil OpenBao als eigener Database Consumer eine zirkuläre Boot
 
 ## Nächster Schritt
 
-Als Nächstes werden PostgreSQL-Referenzprovider und Allocation-Lebenszyklus spezifiziert. Es wird noch keine PostgreSQL-Instanz, Datenbank, Identität oder Allocation angelegt.
+[ADR-0004](ADR-0004-postgresql-reference-provider.md) hat PostgreSQL als ersten konkreten Referenzprovider sowie die getrennten Provider- und Allocation-Lebenszyklen festgelegt. Als Nächstes werden PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations ausgewählt. Es wird noch keine PostgreSQL-Instanz, Datenbank, Identität oder Allocation angelegt.

--- a/docs/decisions/ADR-0003-shared-database-platform.md
+++ b/docs/decisions/ADR-0003-shared-database-platform.md
@@ -88,17 +88,14 @@ Zurückgestellt, weil OpenBao als eigener Database Consumer eine zirkuläre Boot
 
 ## Offene Punkte
 
-- erste tatsächlich anzulegende Allocations,
-- RALF-Core-only oder zusätzlich Gitea im ersten Referenzdeployment,
-- OpenBao Integrated Storage oder PostgreSQL,
 - Kriterien für dedizierte Providerinstanzen,
 - Behandlung anwendungseigener Migrationen,
 - Zugriff und Rechte unter `/secrets`,
 - Secret-Rotation,
 - allocation- und providerweite Backups,
 - Ressourcen- und Netzwerkgrenzen,
-- PostgreSQL-Referenzversion.
+- konkrete Betriebs- und Netzwerkgrenzen des gewählten Referenzprofils.
 
 ## Nächster Schritt
 
-[ADR-0004](ADR-0004-postgresql-reference-provider.md) hat PostgreSQL als ersten konkreten Referenzprovider sowie die getrennten Provider- und Allocation-Lebenszyklen festgelegt. Als Nächstes werden PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations ausgewählt. Es wird noch keine PostgreSQL-Instanz, Datenbank, Identität oder Allocation angelegt.
+[ADR-0004](ADR-0004-postgresql-reference-provider.md) hat PostgreSQL als ersten konkreten Referenzprovider sowie die getrennten Provider- und Allocation-Lebenszyklen festgelegt. [ADR-0005](ADR-0005-first-postgresql-deployment-profile.md) wählt PostgreSQL Major 18, `postgresql-main` und vier initiale Allocations. Als Nächstes entsteht ausschließlich ein read-only Deploymentplan; es wird weiterhin keine PostgreSQL-Instanz, Datenbank, Identität oder Allocation angelegt.

--- a/docs/decisions/ADR-0004-postgresql-reference-provider.md
+++ b/docs/decisions/ADR-0004-postgresql-reference-provider.md
@@ -19,6 +19,10 @@ Alle Datenbankgeheimnisse werden ausschließlich unter `/secrets` verwaltet. Pl�
 
 Die konkrete PostgreSQL-Major-Version, das Deploymentprofil und die ersten tatsächlich anzulegenden Allocations werden separat entschieden.
 
+## Spätere Präzisierung
+
+[ADR-0005](ADR-0005-first-postgresql-deployment-profile.md) wählt für die erste Referenzumgebung PostgreSQL Major 18, die Providerinstanz `postgresql-main` und vier isolierte Allocations. Diese deployment-spezifische Auswahl ändert weder die Providerneutralität noch die Möglichkeit anderer Platzierungen.
+
 ## Begründung
 
 - PostgreSQL bildet die für die ersten Consumer benötigten relationalen und transaktionalen Fähigkeiten belastbar ab.
@@ -97,9 +101,8 @@ Verworfen als Zwang, weil Sicherheits-, Verfügbarkeits-, Versions-, Erweiterung
 
 ## Offene Punkte
 
-- PostgreSQL-Referenzversion und Wartungsmatrix,
-- erstes Deploymentprofil,
-- erste tatsächlich anzulegende Allocations,
+- technische Verifikation der in ADR-0005 gewählten Referenzversion und Wartungsmatrix,
+- technische Umsetzung des in ADR-0005 gewählten Deploymentprofils,
 - Netzwerkgrenzen zwischen Consumern und Provider,
 - Eigentümer- und Zugriffsmodell unter `/secrets`,
 - Secret-Rotation,
@@ -111,4 +114,4 @@ Verworfen als Zwang, weil Sicherheits-, Verfügbarkeits-, Versions-, Erweiterung
 
 ## Nächster Schritt
 
-Als Nächstes werden PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations ausgewählt. Bis dahin werden weder PostgreSQL noch Datenbanken, Identitäten, Secrets oder Netzwerkfreigaben angelegt.
+ADR-0005 beantwortet Versions-, Profil- und Allocation-Auswahl. Als Nächstes entsteht ein konkreter, zunächst read-only geplanter Implementierungspfad. PostgreSQL, Datenbanken, Identitäten, Secrets und Netzwerkfreigaben bleiben bis zu einem separat bestätigten Apply unverändert.

--- a/docs/decisions/ADR-0004-postgresql-reference-provider.md
+++ b/docs/decisions/ADR-0004-postgresql-reference-provider.md
@@ -1,0 +1,114 @@
+# ADR-0004: PostgreSQL als erster Referenzprovider
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-02
+
+## Kontext
+
+ADR-0001 hat den Database Service als providerneutrale Datenbankfähigkeit festgelegt. ADR-0003 hat daraus eine gemeinsam nutzbare Plattform mit isolierten Database Allocations für RALF-native und externe Consumer gemacht. Für die nächste Architekturgrenze benötigt RALF einen ersten konkreten Providervertrag und einen eindeutigen Allocation-Lebenszyklus, ohne bereits Software oder Infrastruktur bereitzustellen.
+
+PostgreSQL kann mehrere logische Datenbanken, getrennte technische Identitäten, transaktionale Schemamigrationen sowie logische Backups und Restores bereitstellen. Eine gemeinsam betriebene Instanz reduziert Betriebsaufwand, bleibt aber eine gemeinsame Fehlerdomäne und ist daher nicht für jeden Consumer zwingend richtig.
+
+## Entscheidung
+
+PostgreSQL ist der erste Referenzprovider des Database Service. Er implementiert die providerneutrale Verwaltungsebene; Consumer greifen auf ihre jeweilige Allocation über das native PostgreSQL-Protokoll zu. Der Database Service ist kein SQL-Proxy und übersetzt keine Anwendungsabfragen.
+
+Der Referenzstandard verwendet eine isolierte logische Datenbank und eigene technische Identitäten pro Allocation. Eine Providerinstanz kann mehrere Allocations tragen; einzelne Allocations können bei begründeten Sicherheits-, Verfügbarkeits-, Versions-, Erweiterungs-, Ressourcen- oder Wiederherstellungsanforderungen eine dedizierte Instanz verlangen.
+
+Alle Datenbankgeheimnisse werden ausschließlich unter `/secrets` verwaltet. Pläne und normale Konfiguration enthalten nur nicht geheime absolute Secret-Referenzen.
+
+Die konkrete PostgreSQL-Major-Version, das Deploymentprofil und die ersten tatsächlich anzulegenden Allocations werden separat entschieden.
+
+## Begründung
+
+- PostgreSQL bildet die für die ersten Consumer benötigten relationalen und transaktionalen Fähigkeiten belastbar ab.
+- Logische Datenbanken und getrennte Identitäten schaffen eine verständliche Referenzisolation.
+- Native Providerzugriffe erhalten die Datenmodelle und Migrationswege externer Anwendungen.
+- Ein expliziter Provider- und Allocation-Lebenszyklus verhindert stille Bereitstellung oder Migration beim Dienststart.
+- Eine optionale dedizierte Platzierung macht Sicherheits- und Fehlerdomänenanforderungen sichtbar.
+- Die Providerneutralität des allgemeinen Database-Service-Vertrags bleibt bestehen.
+
+## Konsequenzen
+
+### Positive Folgen
+
+- RALF Core, Gitea und weitere Consumer können getrennte Allocations erhalten.
+- Provider- und Allocation-Status werden unabhängig bewertet.
+- Fähigkeiten werden für die konkrete Instanz nachgewiesen statt aus dem Produktnamen abgeleitet.
+- Backup, Restore, Migration, Secret-Rotation und Löschung besitzen getrennte Plan- und Freigabegrenzen.
+- Eine spätere zweite Providerimplementierung muss denselben providerneutralen Verwaltungsvertrag erfüllen.
+
+### Aufwand und Risiken
+
+- Eine gemeinsam genutzte Instanz bleibt eine gemeinsame Fehler- und Ressourcendomäne.
+- Isolation, minimale Rechte und fehlende Fremdzugriffe müssen später technisch verifiziert werden.
+- Consumer mit anwendungseigenen Migrationen können abweichende Identitätsmodelle benötigen.
+- Major-Upgrades, Erweiterungen, Ressourcenlimits und Netzwerkgrenzen benötigen eigene Pläne.
+- Providerweite Sicherungen und allocation-bezogene Restores müssen klar getrennt bleiben.
+
+## Sicherheitsfolgen
+
+- Jede Allocation erhält eigene technische Identitäten und Secret-Referenzen.
+- Consumer erhalten keine Rechte auf fremde Allocations und verwenden keine PostgreSQL-Superuseridentität.
+- Gemeinsame Anwendungskonten, Kennwörter, Anwendungsschemata und Consumer-übergreifende Anwendungstabellen sind ausgeschlossen.
+- Providerweite administrative Objekte bleiben außerhalb normaler Consumeridentitäten.
+- `vector_search` wird nur bei ausdrücklich installierter und verifizierter Erweiterung gemeldet.
+- Eine dedizierte Providerinstanz bleibt für höhere Isolationsanforderungen möglich.
+
+## Secrets-Vertrag
+
+`/secrets` ist die einzige kanonische externe Secrets-Wurzel. Provider- und Allocation-Geheimnisse liegen unter getrennten, strikt validierten Pfaden; Repository und Pläne enthalten nur Referenzen. Werte erscheinen weder in Git, Logs, Standardausgabe, Prozessargumenten noch normalen Umgebungsvariablen und werden nicht automatisch überschrieben.
+
+OpenBao ersetzt diesen Bootstrap-Vertrauensanker nicht automatisch. Falls OpenBao eine PostgreSQL-Allocation erhält, werden seine eigenen Bootstrap-Datenbankgeheimnisse nicht zirkulär aus OpenBao bezogen.
+
+## Verworfene und zurückgestellte Alternativen
+
+### Eine gemeinsame Datenbank für alle Consumer
+
+Verworfen wegen fehlender Daten-, Schema-, Rechte- und Restoreisolation.
+
+### Ein gemeinsames Anwendungskonto
+
+Verworfen, weil minimale Rechte und nachvollziehbare Zugriffe pro Allocation nicht gewährleistet wären.
+
+### Database Service als SQL-Proxy
+
+Verworfen, weil dies native Treiber und Datenmodelle durch eine künstliche Universal-API ersetzen würde.
+
+### PostgreSQL-Superuser für Anwendungen
+
+Verworfen, weil normale Consumer keine providerweiten Administrationsrechte benötigen.
+
+### Secrets im Repository
+
+Verworfen; das Repository enthält ausschließlich nicht geheime Referenzen.
+
+### Secrets ausschließlich in OpenBao
+
+Zurückgestellt, weil OpenBao selbst Database Consumer sein kann und dadurch eine zirkuläre Bootstrap-Abhängigkeit entstünde.
+
+### Sofort eine dedizierte Instanz pro Consumer
+
+Verworfen als zwingender Standard, weil dies ohne konkreten Isolationsbedarf unnötigen Betriebsaufwand erzeugt.
+
+### Sofort alle Consumer auf einer gemeinsamen Instanz
+
+Verworfen als Zwang, weil Sicherheits-, Verfügbarkeits-, Versions-, Erweiterungs- oder Ressourcenanforderungen eine Trennung verlangen können.
+
+## Offene Punkte
+
+- PostgreSQL-Referenzversion und Wartungsmatrix,
+- erstes Deploymentprofil,
+- erste tatsächlich anzulegende Allocations,
+- Netzwerkgrenzen zwischen Consumern und Provider,
+- Eigentümer- und Zugriffsmodell unter `/secrets`,
+- Secret-Rotation,
+- Ressourcenlimits und Platzierungskriterien,
+- Backupziel, Retention und providerweite Sicherungen,
+- zulässige Erweiterungen,
+- Major-Upgradeverfahren,
+- konkrete Behandlung providerweiter Standardobjekte.
+
+## Nächster Schritt
+
+Als Nächstes werden PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations ausgewählt. Bis dahin werden weder PostgreSQL noch Datenbanken, Identitäten, Secrets oder Netzwerkfreigaben angelegt.

--- a/docs/decisions/ADR-0005-first-postgresql-deployment-profile.md
+++ b/docs/decisions/ADR-0005-first-postgresql-deployment-profile.md
@@ -1,0 +1,124 @@
+# ADR-0005: Erstes PostgreSQL-Deploymentprofil
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-02
+
+## Kontext
+
+ADR-0004 definiert PostgreSQL als ersten Referenzprovider, lässt jedoch Major-Version, Instanzprofil und erste Allocations offen. Für einen späteren reproduzierbaren Implementierungsplan müssen diese Auswahlentscheidungen feststehen, ohne bereits PostgreSQL, Datenbanken, Identitäten, Rollen oder Secrets anzulegen.
+
+Die erste Referenzumgebung benötigt Datenbankzuweisungen für Gitea, OpenBao, Semaphore UI und relationale Anwendungsdaten von Node-RED. RALF Core ist noch nicht implementiert und besitzt noch kein konkretes Schema oder Migrationspaket.
+
+## Entscheidung
+
+### PostgreSQL-Version
+
+- Referenz-Major-Version ist PostgreSQL **18**.
+- Initial dokumentierter Minor-Stand ist **18.4**.
+- Zum späteren Installationszeitpunkt wird die neueste stabile **18.x**-Minor-Version ausgewählt.
+- 18.4 ist kein dauerhaft festgeschriebener Installationsstand.
+- Ein automatischer Wechsel auf PostgreSQL 19 ist ausgeschlossen.
+- Jedes Major-Upgrade benötigt einen eigenen Plan und eine eigene ausdrückliche Freigabe.
+
+### Providerinstanz
+
+| Begriff | Auswahl |
+| --- | --- |
+| `provider_instance_id` | `postgresql-main` |
+| Provider | PostgreSQL |
+| `isolation_profile` | `shared-provider-with-isolated-logical-databases` |
+
+Eine gemeinsame Providerinstanz trägt zunächst vier voneinander isolierte logische Database Allocations. Diese Platzierung ist Referenzprofil, kein Zwang für andere Deployments oder spätere erhöhte Isolationsanforderungen.
+
+### Erste Allocations
+
+| `allocation_id` | Consumer | `consumer_type` | `isolation_class` | `schema_lifecycle` | Auswahl und Zweck |
+| --- | --- | --- | --- | --- | --- |
+| `gitea` | Gitea | `external_application` | `logical_database` | `application_managed` | `selected: true` |
+| `openbao` | OpenBao | `external_application` | `logical_database` | `application_managed` | `selected: true`, `sensitivity: high` |
+| `semaphore` | Semaphore UI | `external_application` | `logical_database` | `application_managed` | `selected: true` |
+| `nodered` | Node-RED | `external_application` | `logical_database` | `application_managed` | `selected: true`, `purpose: flow_application_data` |
+
+Logische Datenbanknamen und konkrete PostgreSQL-Benutzernamen werden noch nicht festgelegt.
+
+## OpenBao-Storage
+
+PostgreSQL ist für OpenBao in dieser Referenzumgebung bewusst als Storage ausgewählt. Diese Wahl ist deployment-spezifisch und macht PostgreSQL nicht zum allgemeinen Pflicht-Storage für OpenBao. Integrated Storage bleibt für andere Installationen eine zulässige Alternative.
+
+Die als hochsensibel eingestufte OpenBao-Allocation kann später bei nachgewiesenem Bedarf auf eine dedizierte Providerinstanz verlagert werden. Eine solche Änderung benötigt einen eigenen Plan.
+
+OpenBao bezieht seine Bootstrap-Datenbankgeheimnisse nicht aus sich selbst. `/secrets` bleibt der externe Bootstrap-Vertrauensanker.
+
+## Node-RED-Abgrenzung
+
+Die Node-RED-Allocation dient ausschließlich relationalen Daten von Node-RED-Flows. Sie wird nicht automatisch zum internen Node-RED-Storage.
+
+Flowdateien, Credentials und Context bleiben zunächst außerhalb dieser Allocation. Eine spätere Änderung des Node-RED-Storage-Vertrags benötigt eine eigene Entscheidung.
+
+## RALF Core
+
+RALF Core erhält im ersten realen Deployment noch keine Allocation. Seine Allocation wird erst angelegt, wenn Core implementiert ist und ein konkretes fachliches Schema beziehungsweise Migrationspaket vorliegt. Die frühere Entscheidung, RALF Core als ersten spezifizierten RALF-nativen Consumer zu behandeln, bleibt davon unberührt.
+
+## Isolationsvertrag
+
+Für jede der vier Allocations gilt:
+
+- eigene logische Datenbank,
+- eigene `application_identity`,
+- eigenes `application-password` unter `/secrets`,
+- keine Rechte auf andere Allocations,
+- keine gemeinsame Anwendungsrolle,
+- kein gemeinsames Anwendungspasswort,
+- kein gemeinsam genutztes Anwendungsschema,
+- allocation-bezogener Health- und Readinessstatus,
+- allocation-bezogener Backup- und Restorevertrag.
+
+Die gemeinsame Providerinstanz bleibt eine gemeinsame Betriebs-, Ressourcen- und Fehlerdomäne. Die Daten- und Berechtigungsgrenzen der Allocations bleiben dennoch getrennt.
+
+## Secrets-Vertrag
+
+`/secrets` ist die einzige Secrets-Wurzel. Für den späteren Plan sind ausschließlich folgende nicht geheime Referenzen vorgesehen:
+
+```text
+/secrets/database-service/providers/postgresql-main/administrative-password
+/secrets/database-service/allocations/gitea/application-password
+/secrets/database-service/allocations/openbao/application-password
+/secrets/database-service/allocations/semaphore/application-password
+/secrets/database-service/allocations/nodered/application-password
+```
+
+Dieser Entscheidungsdurchlauf legt keine dieser Dateien an. Er dokumentiert weder Werte, Hashes, Beispielpasswörter noch Connection Strings. `/secrets` und das lokale ausgeschlossene `secrets/` bleiben unverändert.
+
+## Begründung
+
+- PostgreSQL 18 bildet den verbindlichen Major-Rahmen, ohne Sicherheits- und Fehlerkorrekturen späterer 18.x-Minor-Versionen auszuschließen.
+- Die gemeinsame Instanz reduziert zunächst den Betriebsaufwand.
+- Eine logische Datenbank und eigene Identität pro Consumer bewahren die vereinbarte Allocation-Isolation.
+- Gitea, OpenBao und Semaphore UI besitzen anwendungseigene Schema-Lebenszyklen.
+- Node-RED erhält einen bewusst begrenzten relationalen Anwendungsdatenspeicher.
+- RALF Core wird nicht vor seiner Implementierung und seinem Migrationsvertrag vorweggenommen.
+
+## Konsequenzen
+
+- Der spätere Plan muss genau eine Providerinstanz und genau vier initiale Allocations beschreiben.
+- Vor einer Installation wird die dann aktuelle stabile 18.x-Version ermittelt und gegen die unterstützten Consumer-Versionen geprüft.
+- PostgreSQL 19 oder ein anderes Major-Upgrade darf nicht durch normale Aktualisierung eingeführt werden.
+- Jede Allocation benötigt eigene Identität, Secret-Referenz, Health, Readiness, Backup und Restore.
+- OpenBao und Node-RED besitzen die dokumentierten deployment-spezifischen Storage-Grenzen.
+- Die konkrete technische Umsetzung bleibt vollständig offen und benötigt einen neuen Plan.
+
+## Nicht entschieden
+
+- Betriebssystem und Betriebsform von `postgresql-main`,
+- Netzwerkgrenze,
+- CPU-, Speicher- und Storage-Ressourcen,
+- Backupziel und Retention,
+- Eigentümer und Dateirechte unter `/secrets`,
+- konkrete kompatible Versionen von Gitea, OpenBao, Semaphore UI und Node-RED,
+- konkrete logische Datenbanknamen und PostgreSQL-Benutzernamen,
+- Secret-Rotation,
+- zulässige Erweiterungen und Detailkonfiguration.
+
+## Nächster Schritt
+
+Als Nächstes wird ein konkreter, zunächst read-only geplanter Implementierungspfad für PostgreSQL 18, eine Providerinstanz, vier isolierte logische Allocations und Secrets ausschließlich unter `/secrets` entworfen. Vor der ersten Mutation werden alle unter „Nicht entschieden“ genannten Betriebsparameter festgelegt und der vollständige Plan ausdrücklich bestätigt.

--- a/docs/lifecycle/database-allocation.md
+++ b/docs/lifecycle/database-allocation.md
@@ -183,4 +183,4 @@ PostgreSQL-spezifische SQLSTATE-Werte bleiben intern im Provideradapter. Sie wer
 - Nachweis fehlender Rechte auf fremde Allocations,
 - Grenzen und Verfahren eines späteren Rollbacks.
 
-**Nächste Entscheidung:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen.
+**Nächster Schritt:** Das in ADR-0005 gewählte Profil ausschließlich read-only planen; noch keine Allocation anlegen oder verändern.

--- a/docs/lifecycle/database-allocation.md
+++ b/docs/lifecycle/database-allocation.md
@@ -1,0 +1,186 @@
+# Database-Allocation-Lebenszyklus
+
+## Status und Zweck
+
+Dieses Dokument präzisiert die Zustände und fachlichen Operationen einer [Database Allocation](../contracts/database-allocation-v0.1.md). Es beschreibt weder eine technische API noch SQL, ausführbare Befehle oder automatische Übergänge.
+
+Providerinstanz und Allocation besitzen getrennte Lebenszyklen. Eine Providerinstanz kann `ready` sein, während eine einzelne Allocation beispielsweise `migration_required`, `suspended` oder `failed` ist.
+
+## Zustände
+
+Lese- und Schreibangaben beziehen sich auf den normalen Consumerzugriff. Administrative Aktionen sind ausschließlich geplante, ausdrücklich freigegebene Lebenszyklusoperationen.
+
+| Zustand | Bedeutung | Lesen | Schreiben | Administrative Aktionen |
+| --- | --- | --- | --- | --- |
+| `requested` | Consumerbedarf ist beschrieben; eine Providerinstanz ist noch nicht ausgewählt. | nein | nein | Anforderungen prüfen und Allocation planen |
+| `planned` | Providerinstanz, Isolation, Identitäten und Secret-Referenzen sind geplant; keine Mutation ist erfolgt. | nein | nein | Plan prüfen und Bereitstellung freigeben |
+| `provisioning` | Logische Datenbank und technische Identitäten werden kontrolliert angelegt. | nein | nein | nur freigegebene Bereitstellung und Verifikation |
+| `configured` | Datenbank und Identitäten existieren; Schema und Readiness sind noch nicht zwingend bestätigt. | nur gezielte Prüfung | nein | Verifikation oder Migrationsplanung |
+| `migration_required` | Datenbank ist erreichbar, der benötigte Schemastand fehlt. | nur wenn Vertrag und Schema dies sicher erlauben | nein | Migration planen |
+| `migrating` | Eine freigegebene Migration läuft. | nur gemäß Migrationsplan | nein, außer ausdrücklich erforderliche Migrationsschritte | Migration überwachen und verifizieren |
+| `ready` | Provider, Datenbank, Identitäten, Fähigkeiten, Schema und minimale Rechte sind bestätigt. | ja | ja | kontrollierte Betriebsoperationen |
+| `degraded` | Allocation ist eingeschränkt; Grund und erlaubte Zugriffe sind sichtbar. | abhängig von Einschränkung | abhängig von Einschränkung | Diagnose und gesondert freigegebene Korrektur |
+| `backup_running` | Allocation-bezogenes Backup läuft. | grundsätzlich ja, sofern Backupplan nichts anderes verlangt | nur wenn Konsistenzvertrag es erlaubt | Backup überwachen und verifizieren |
+| `restore_planned` | Restorequelle, Ziel und Auswirkungen sind geprüft und warten auf eigene Freigabe. | nach aktuellem Zustand | nach aktuellem Zustand | Restoreplan prüfen oder verwerfen |
+| `restore_running` | Freigegebener Restore betrifft genau diese Allocation. | nein | nein | Restore überwachen und abschließend prüfen |
+| `suspended` | Allocation bleibt vorhanden; normaler Anwendungszugriff ist bewusst deaktiviert. | nein | nein | Diagnose, Backup oder geplantes Resume |
+| `deleting` | Ausdrückliche Löschung ist vorbereitet oder aktiv; Backup und Retention sind berücksichtigt. | nein | nein | nur freigegebene Löschung und Nachprüfung |
+| `deleted` | Aktive Allocation ist entfernt; Backups können bis zum Retentionsende fortbestehen. | nein | nein | ausschließlich Retention und Abschlussnachweis |
+| `failed` | Sicherer Allocation-Betrieb ist nicht möglich. | nein | nein | Diagnose und gesondert geplante Wiederherstellung |
+
+Ein Start des Database Service oder eines Consumers löst keinen mutierenden Zustandsübergang aus.
+
+## Übergangsregeln
+
+- `requested` wird erst nach vollständiger und bestätigter Planung zu `planned`.
+- `planned` wird nur durch eine freigegebene Bereitstellung zu `provisioning`.
+- `configured` wird erst nach vollständiger Verifikation zu `ready` oder bei fehlendem Schemastand zu `migration_required`.
+- `migration_required` wird ausschließlich durch eine eigene Freigabe zu `migrating`.
+- `migrating`, `backup_running` und `restore_running` werden nie allein aufgrund eines gestarteten Prozesses als erfolgreich abgeschlossen gemeldet.
+- `suspended` bleibt bestehen, bis ein ausdrückliches Resume geplant, freigegeben und verifiziert wurde.
+- `deleting` verlangt eine vorherige Betrachtung von Retention und vorhandenen Backups.
+- `deleted` bedeutet nicht, dass Sicherungen außerhalb ihrer Aufbewahrungsregeln verschwunden sind.
+- Ein unbekannter oder widersprüchlicher Zustand wird nicht als `ready` interpretiert.
+
+## Fachliche Allocation-Operationen
+
+Die Namen gliedern den Vertrag und sind keine Funktionssignaturen:
+
+- `plan_allocation`
+- `create_allocation`
+- `verify_allocation`
+- `plan_migration`
+- `apply_migration`
+- `suspend_allocation`
+- `resume_allocation`
+- `plan_backup`
+- `create_backup`
+- `verify_backup`
+- `plan_restore`
+- `restore_backup`
+- `rotate_allocation_secrets`
+- `plan_delete_allocation`
+- `delete_allocation`
+
+Jede mutierende Operation benötigt später:
+
+1. aktuellen Zustand,
+2. Zielzustand,
+3. Voraussetzungen,
+4. sichtbare Mutationen,
+5. Risiken,
+6. ausdrückliche Freigabe,
+7. anschließende Verifikation.
+
+Eine Freigabe für einen Plan gilt nicht automatisch für einen anderen Plan oder eine andere Allocation.
+
+## Allocation-Plan
+
+Ein späterer Plan zeigt mindestens:
+
+- Consumer und Consumer-Profil,
+- Providerinstanz und Provider-Version,
+- Isolationsklasse,
+- nicht geheime logische Datenbankreferenz,
+- Schema-Lebenszyklus,
+- erforderliche und optionale Fähigkeiten,
+- vorgesehene technische Identitäten,
+- nicht geheime Secret-Referenzen unter `/secrets`,
+- Netzwerkgrenze,
+- Backup- und Restore-Policy,
+- Ressourcenanforderungen,
+- geplante Mutationen,
+- Validierungsschritte,
+- Grenzen eines Rollbacks.
+
+Der Plan enthält keine Secretwerte, Kennworthashes, Zugangsdaten oder ausführbaren freien Befehle.
+
+## Health und Readiness
+
+### Allocation-Health
+
+Health beantwortet, ob die zugewiesene Datenbank und ihre Identitäten grundsätzlich existieren und technisch erreichbar sind. Health allein erlaubt keinen normalen Consumerzugriff.
+
+### Allocation-Readiness
+
+Readiness beantwortet, ob genau dieser Consumer seine Allocation sicher verwenden kann. Mindestens erforderlich sind:
+
+- Providerinstanz `ready`,
+- logische Datenbank vorhanden,
+- Verbindung mit der vorgesehenen Anwendungsidentität möglich,
+- keine Rechte auf fremde Allocations,
+- erforderliche Fähigkeiten vorhanden,
+- Schema kompatibel,
+- keine blockierende Migration,
+- kein Restore aktiv,
+- Secret-Referenzen gültig,
+- Speicherzustand ausreichend.
+
+Eine Providerinstanz kann bereit sein, obwohl eine einzelne Allocation nicht bereit ist. Umgekehrt wird eine Allocation bei nicht bereitem Provider nicht als bereit gemeldet.
+
+## Backup-Lebenszyklus
+
+| Zustand | Bedeutung |
+| --- | --- |
+| `planned` | Umfang, Allocation, Ziel, Konsistenz- und Verifikationsanforderung sind beschrieben. |
+| `running` | Freigegebene Erzeugung läuft. |
+| `created` | Backupobjekt wurde erzeugt, ist aber noch nicht technisch verifiziert. |
+| `verified` | Integrität und vereinbarte Metadaten sind geprüft; erst jetzt ist das Backup verwendbar. |
+| `failed` | Erzeugung oder Verifikation ist fehlgeschlagen. |
+| `expired` | Aufbewahrungsfrist ist abgelaufen; weitere Behandlung folgt der Retention-Policy. |
+
+Der Referenzstandard für 0.1 ist ein logisches Backup genau einer Allocation. Providerweite physische Sicherungen sind eine spätere Zusatzfähigkeit.
+
+## Restore-Lebenszyklus
+
+| Zustand | Bedeutung |
+| --- | --- |
+| `planned` | Verifiziertes Backup, Ziel-Allocation und Auswirkungen sind benannt. |
+| `validated` | Quelle, Ziel, Kompatibilität und Zielzustand wurden geprüft; Ausführung bleibt unfreigegeben. |
+| `running` | Der ausdrücklich freigegebene Restore läuft. |
+| `completed` | Restore sowie Integritäts- und Readiness-Prüfung sind erfolgreich. |
+| `failed` | Restore oder Abschlussprüfung ist fehlgeschlagen. |
+
+Ein Restore betrifft ausschließlich die bezeichnete Allocation. Die Auswahl einer Allocation autorisiert niemals eine providerweite Wiederherstellung oder eine Änderung fremder Allocations.
+
+## Secret-Rotation
+
+`rotate_allocation_secrets` ist eine eigene geplante Operation. Sie darf bestehende Werte nicht automatisch überschreiben, muss Consumerumschaltung und Verifikation sichtbar machen und darf Secretwerte weder im Plan noch in Logs offenlegen. Die konkrete Rotationsfolge bleibt offen.
+
+## Providerneutrale Fehlerklassen
+
+- `provider_not_ready`
+- `provider_version_incompatible`
+- `allocation_conflict`
+- `allocation_not_found`
+- `allocation_not_ready`
+- `allocation_already_exists`
+- `identity_conflict`
+- `secret_reference_invalid`
+- `secret_already_exists`
+- `secret_unavailable`
+- `capability_missing`
+- `schema_lifecycle_conflict`
+- `migration_required`
+- `migration_failed`
+- `backup_failed`
+- `backup_not_verified`
+- `restore_conflict`
+- `restore_failed`
+- `isolation_violation`
+- `resource_exhausted`
+
+PostgreSQL-spezifische SQLSTATE-Werte bleiben intern im Provideradapter. Sie werden nicht Bestandteil des providerneutralen Allocation-Vertrags.
+
+## Offene Entscheidungen
+
+- zulässige Übergangsmatrix für anwendungseigene Migrationen,
+- Verhalten bei teilweise erfolgreicher Bereitstellung,
+- sicherer Rotationsablauf für laufende Consumer,
+- konkrete Ressourcen- und Netzwerkgrenzen,
+- Retention und Speicherort logischer Backups,
+- Kriterien für einen eingeschränkten Lesezugriff in `degraded` oder `maintenance`,
+- Nachweis fehlender Rechte auf fremde Allocations,
+- Grenzen und Verfahren eines späteren Rollbacks.
+
+**Nächste Entscheidung:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen.

--- a/docs/providers/postgresql.md
+++ b/docs/providers/postgresql.md
@@ -1,0 +1,256 @@
+# Provider 001: PostgreSQL
+
+## Status und Zweck
+
+PostgreSQL ist der erste Referenzprovider des Database Service. Der Provider implementiert die providerneutrale Verwaltungsebene und stellt jedem Consumer seine isolierte [Database Allocation](../contracts/database-allocation-v0.1.md) über das native PostgreSQL-Protokoll bereit.
+
+PostgreSQL ist weder Bestandteil des allgemeinen Database-Service-Vertrags noch eine universelle Datenzugriffs-API oder ein SQL-Proxy. Eine Providerentscheidung gilt immer für eine konkrete Allocation; PostgreSQL ist nicht automatisch für jeden Consumer geeignet.
+
+Ein Deployment kann eine Providerinstanz mit mehreren logischen Allocations oder mehrere Providerinstanzen mit unterschiedlichen Isolationsgrenzen verwenden. Diese Spezifikation trifft noch keine Platzierungs-, Versions- oder Deploymententscheidung und legt nichts an.
+
+## PostgreSQL Provider Instance
+
+Eine **PostgreSQL Provider Instance** ist ein konkret betriebener PostgreSQL-Datenbankserver beziehungsweise Cluster, auf dem null oder mehr Database Allocations liegen können.
+
+Sie besitzt fachlich mindestens:
+
+| Vertragsbegriff | Bedeutung |
+| --- | --- |
+| `provider_instance_id` | Stabile, deployment-spezifische Referenz der Instanz. |
+| `provider_id` | Providerkennung; für diesen Referenzprovider `postgresql`. |
+| `deployment_reference` | Nicht geheime Referenz auf die Betriebsumgebung. |
+| `version_information` | Explizit festgelegte und nachgewiesene Provider-Version. |
+| `capabilities` | Nachgewiesene Fähigkeiten mit Status und Einschränkungen. |
+| `lifecycle_status` | Aktueller Providerinstanz-Zustand. |
+| `health_status` | Grundsätzliche technische Funktionsfähigkeit. |
+| `readiness_status` | Sichere Nutzbarkeit für vorgesehene Allocations. |
+| `secret_references` | Nicht geheime Referenzen auf Providergeheimnisse unter `/secrets`. |
+| `network_policy_reference` | Referenz auf die erlaubte Netzwerkgrenze. |
+| `backup_policy_reference` | Referenz auf providerweite Sicherungsanforderungen, falls vorhanden. |
+| `resource_policy_reference` | Referenz auf Kapazitäts- und Ressourcengrenzen. |
+
+Keine konkrete Instanz-ID ist Teil dieses Vertrags.
+
+## Versionsvertrag
+
+- Die Major-Version wird vor Bereitstellung einer Providerinstanz ausdrücklich festgelegt.
+- Ein Major-Upgrade besitzt einen eigenen sichtbaren Plan, eine eigene Freigabe und eine anschließende Verifikation.
+- Eine Providerinstanz ändert ihre Version niemals stillschweigend.
+- Jede Allocation muss mit der gewählten Major-Version und den aktivierten Fähigkeiten kompatibel sein.
+- Eine spätere Versionsmatrix berücksichtigt mindestens Sicherheitsstatus, Wartungsstatus und die Anforderungen der Consumer.
+
+Die konkrete Referenzversion bleibt offen.
+
+## Fähigkeiten
+
+### Sicher unterstützt
+
+Der PostgreSQL-Provider kann folgende Fähigkeiten grundsätzlich bereitstellen:
+
+- `relational_storage`
+- `transactions`
+- `schema_migrations`
+- `constraints`
+- `indexes`
+- `json_documents`
+- `full_text_search`
+- `advisory_locks`
+- `backup`
+- `restore`
+
+„Sicher unterstützt“ ersetzt nicht die Prüfung einer konkreten Providerinstanz. Fähigkeiten werden erst für Planungs- und Readinessentscheidungen verwendet, wenn sie für diese Instanz nachgewiesen sind.
+
+### Deployment- oder erweiterungsabhängig
+
+- `point_in_time_recovery`
+- `replication`
+- `high_availability`
+- `vector_search`
+
+`vector_search` darf ausschließlich gemeldet werden, wenn eine geeignete Erweiterung ausdrücklich ausgewählt, installiert und verifiziert wurde. PostgreSQL allein bedeutet nicht, dass Vektorsuche verfügbar ist.
+
+### Fähigkeitsnachweis
+
+Jeder spätere Nachweis enthält mindestens:
+
+- Quelle der Feststellung,
+- Provider- und gegebenenfalls Erweiterungsversion,
+- Verifikationszeitpunkt,
+- Status,
+- bekannte Einschränkungen.
+
+Diese Spezifikation implementiert keine technische Probe.
+
+## Providerinstanz-Lebenszyklus
+
+Lese- und Schreibangaben beschreiben die grundsätzliche Zulässigkeit für bestehende Allocations. Deren eigene Readiness bleibt zusätzlich verbindlich.
+
+| Zustand | Bedeutung | Neue Allocations | Bestehende Lesezugriffe | Bestehende Schreibzugriffe | Administrative Aktionen |
+| --- | --- | --- | --- | --- | --- |
+| `unknown` | Zustand ist nicht verlässlich bekannt. | nein | nein | nein | nur Diagnose und Zustandsklärung |
+| `declared` | Bedarf oder vorhandene Instanz ist beschrieben, aber nicht vollständig geplant. | nein | nein | nein | Bestands- und Anforderungsplanung |
+| `planned` | Version, Deploymentgrenze und Zielzustand sind geplant; keine Mutation ist erfolgt. | nein | nein | nein | Planprüfung und Freigabe |
+| `provisioning` | Die spätere kontrollierte Bereitstellung läuft. | nein | nein | nein | nur der freigegebene Bereitstellungsvorgang |
+| `configured` | Provider ist konfiguriert, aber noch nicht betriebsbereit bestätigt. | nein | nein | nein | Prüfung und kontrollierter Start |
+| `starting` | Provider startet und wird geprüft. | nein | nein | nein | Startprüfung und Diagnose |
+| `ready` | Provider erfüllt die Readinesskriterien. | ja, nach Allocation-Plan | ja, wenn Allocation bereit | ja, wenn Allocation bereit | kontrollierte Provider- und Allocation-Operationen |
+| `degraded` | Provider ist grundsätzlich nutzbar, aber mindestens eine Einschränkung besteht. | nur nach sichtbarer Bewertung | abhängig von Einschränkung | abhängig von Einschränkung | Diagnose und begrenzte Korrektur |
+| `maintenance` | Geplante Wartung mit ausdrücklich beschriebenen Zugriffsbeschränkungen. | nein | nur wenn der Wartungsplan es erlaubt | nur wenn der Wartungsplan es erlaubt | ausschließlich freigegebene Wartung |
+| `stopping` | Kontrolliertes Anhalten läuft. | nein | nein | nein | nur Stop- und Zustandsprüfung |
+| `stopped` | Provider ist kontrolliert nicht in Betrieb. | nein | nein | nein | Diagnose, Wartung oder kontrollierter Start |
+| `failed` | Sicherer Betrieb ist nicht möglich. | nein | nein | nein | Diagnose und gesondert freigegebene Wiederherstellung |
+| `retired` | Providerinstanz ist dauerhaft außer Nutzung; aktive Allocations dürfen nicht verbleiben. | nein | nein | nein | nur Nachweis, Retention und Abschlussprüfung |
+
+Ein Zustandswechsel erfolgt nicht automatisch allein durch den Start eines RALF-Dienstes.
+
+### Kriterien für `ready`
+
+Mindestens:
+
+- PostgreSQL ist grundsätzlich erreichbar,
+- eine kontrollierte administrative Provideridentität ist verfügbar,
+- die Basiskonfiguration ist konsistent,
+- vorhandene Fähigkeiten sind bekannt,
+- keine blockierende Wartung läuft,
+- der Speicherzustand ist nicht kritisch,
+- vorgesehene Allocation-Verbindungen werden akzeptiert.
+
+### Bedeutung von `degraded`
+
+Mögliche Gründe sind knapper Speicher, überfällige Backupprüfung, eine fehlende optionale Fähigkeit oder eine fehlerhafte einzelne Allocation bei grundsätzlich nutzbarem Provider. Grund, Reichweite und erlaubte Zugriffe müssen sichtbar sein.
+
+### Bedeutung von `maintenance`
+
+Es wird keine neue Allocation angelegt. Lese- oder Schreibzugriffe dürfen nur fortbestehen, wenn der konkrete Wartungsplan dies ausdrücklich und sicher erlaubt.
+
+## PostgreSQL-Isolationsvertrag
+
+Referenzstandard ist:
+
+- eine logische PostgreSQL-Datenbank pro Allocation,
+- eigene technische Identitäten pro Allocation,
+- keine Rechte auf fremde Allocations,
+- keine gemeinsame Anwendungsidentität,
+- kein gemeinsames Anwendungspasswort,
+- kein gemeinsames Anwendungsschema,
+- keine Consumer-übergreifenden Anwendungstabellen.
+
+Normale Consumeridentitäten verwalten keine providerweiten administrativen Objekte. Consumer sollen keine unkontrollierten gemeinsamen providerweiten Objekte anlegen können. Die konkrete Behandlung des PostgreSQL-`public`-Schemas wird erst bei der Implementierung festgelegt.
+
+### Dedizierte Providerinstanz
+
+Eine Allocation kann eine eigene Instanz verlangen bei:
+
+- erhöhten Sicherheitsanforderungen,
+- unabhängiger Verfügbarkeit,
+- inkompatibler PostgreSQL-Major-Version,
+- inkompatiblen Erweiterungen,
+- stark abweichenden Ressourcenanforderungen,
+- besonderen Backup- oder Restorezielen,
+- bewusst vermiedener gemeinsamer Fehlerdomäne.
+
+Weder eine gemeinsame noch eine dedizierte Platzierung wird automatisch gewählt.
+
+## Identitätsmodell pro Allocation
+
+| Identität | Sicherheitsziel |
+| --- | --- |
+| `allocation_owner` | Besitzt zentrale Allocation-Objekte und wird nicht im normalen Anwendungsbetrieb verwendet. |
+| `migration_identity` | Darf ausschließlich freigegebene Schemaänderungen durchführen. |
+| `application_identity` | Darf ausschließlich normalen fachlichen Anwendungszugriff ausführen. |
+| `backup_identity` | Ist auf erforderliche Backup- und Restoreaufgaben begrenzt. |
+| `monitoring_identity` | Liest ausschließlich erforderliche Status- und Diagnosedaten. |
+
+Ein Consumer-Profil darf offenlegen, dass Laufzeit und Migration technisch nicht trennbar sind, Backup zentral durch den Provider erfolgt oder eine Identität nicht benötigt wird. Jede Abweichung bleibt sichtbar und wird sicherheitlich bewertet. Normale Anwendungen verwenden niemals eine PostgreSQL-Superuseridentität.
+
+## Verbindlicher Secrets-Vertrag
+
+Alle Datenbankgeheimnisse werden ausschließlich unter `/secrets` gelesen oder abgelegt. Vorgesehene, noch nicht angelegte Referenzstruktur:
+
+```text
+/secrets/
+└── database-service/
+    ├── providers/
+    │   └── <provider-instance-id>/
+    │       └── ...
+    └── allocations/
+        └── <allocation-id>/
+            ├── owner-password
+            ├── migration-password
+            ├── application-password
+            ├── backup-password
+            └── monitoring-password
+```
+
+Nicht jede Allocation benötigt jede Datei. Spätere Implementierungen müssen:
+
+- neue Secrets atomar unter `/secrets` schreiben,
+- Elternpfade und Dateinamen strikt validieren,
+- Traversierung und Auflösung außerhalb `/secrets` verhindern,
+- Symlinks ablehnen,
+- restriktive Eigentümer und Zugriffsmodi verwenden,
+- vorhandene Werte nur durch eine ausdrücklich geplante Rotation ersetzen,
+- Secretwerte von Git, Logs, Standardausgabe, Prozessargumenten und normalen Umgebungsvariablen fernhalten,
+- in normaler Konfiguration ausschließlich nicht geheime absolute Referenzen speichern.
+
+Providerreferenzen liegen unter `/secrets/database-service/providers/<provider-instance-id>/`; Allocation-Referenzen liegen unter `/secrets/database-service/allocations/<allocation-id>/`.
+
+Ein Plan nennt höchstens die nicht geheime Zielreferenz, niemals Secretwert, Kennworthash oder eine Verbindungsangabe mit Kennwort.
+
+Falls OpenBao später selbst eine PostgreSQL-Allocation verwendet, bezieht es seine Bootstrap-Datenbankgeheimnisse nicht aus sich selbst. `/secrets` bleibt der externe Bootstrap-Vertrauensanker. Das Repository schließt zusätzlich `secrets/` aus.
+
+## Consumer-Profile
+
+### RALF Core
+
+- Typ: `ralf_native`
+- Schema-Lebenszyklus: `domain_managed`
+- Referenzisolation: `logical_database`
+- Pflichtfähigkeiten: `relational_storage`, `transactions`, `schema_migrations`, `constraints`, `indexes`, `backup`, `restore`
+
+### Gitea
+
+- Typ: `external_application`
+- Schema-Lebenszyklus: `application_managed`
+- Referenzisolation: `logical_database`
+- PostgreSQL ist ein möglicher Provider.
+
+Gitea erhält eine eigene Allocation und eigene Identitäten. Version, Datenbankreferenz und Zugangsdaten bleiben offen.
+
+### OpenBao
+
+- Typ: `external_application`
+- Schema-Lebenszyklus: `application_managed` oder `platform_preprovisioned`
+- PostgreSQL ist eine optionale Storage-Wahl.
+
+Integrated Storage bleibt als Alternative offen. Diese Spezifikation plant keinen OpenBao-Consumer und keine OpenBao-Allocation.
+
+## Health und Readiness
+
+`provider_health` beantwortet, ob die Providerinstanz grundsätzlich technisch funktioniert. `provider_readiness` beantwortet, ob sie im vorgesehenen Vertrag sicher Allocations bedienen kann.
+
+Eine bereite Providerinstanz macht eine Allocation nicht automatisch bereit. Allocation-Health und -Readiness werden unabhängig im [Allocation-Lebenszyklus](../lifecycle/database-allocation.md) bewertet.
+
+## Backup und Restore
+
+Der Referenzstandard ist ein logisches Backup pro Allocation. Providerweite physische Sicherungen können später eine zusätzliche Fähigkeit sein, ersetzen aber nicht automatisch den allocation-bezogenen Vertrag.
+
+Ein Restore für eine Allocation darf niemals stillschweigend andere Allocations oder die gesamte Providerinstanz überschreiben.
+
+## Offene Entscheidungen
+
+1. Welche PostgreSQL-Major-Version wird Referenzversion?
+2. Wie wird PostgreSQL in der ersten Referenzumgebung betrieben?
+3. Welche Allocations werden im ersten realen Deployment angelegt?
+4. Wird zunächst nur RALF Core angelegt?
+5. Benötigt Gitea bereits im ersten Deployment eine Allocation?
+6. Welches Storage-Backend verwendet OpenBao?
+7. Welche Netzwerkgrenze gilt zwischen Consumer und PostgreSQL?
+8. Welche Dateieigentümer und Zugriffsmodi gelten unter `/secrets`?
+9. Wie erfolgt Secret-Rotation?
+10. Welche Ressourcenlimits gelten je Allocation?
+11. Wo werden logische Backups gespeichert und wie lange aufbewahrt?
+12. Welche Providererweiterungen sind im Basisprofil zulässig?
+13. Wie werden PostgreSQL-Major-Upgrades durchgeführt?
+
+**Nächste Entscheidung:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen.

--- a/docs/providers/postgresql.md
+++ b/docs/providers/postgresql.md
@@ -6,7 +6,7 @@ PostgreSQL ist der erste Referenzprovider des Database Service. Der Provider imp
 
 PostgreSQL ist weder Bestandteil des allgemeinen Database-Service-Vertrags noch eine universelle Datenzugriffs-API oder ein SQL-Proxy. Eine Providerentscheidung gilt immer für eine konkrete Allocation; PostgreSQL ist nicht automatisch für jeden Consumer geeignet.
 
-Ein Deployment kann eine Providerinstanz mit mehreren logischen Allocations oder mehrere Providerinstanzen mit unterschiedlichen Isolationsgrenzen verwenden. Diese Spezifikation trifft noch keine Platzierungs-, Versions- oder Deploymententscheidung und legt nichts an.
+Ein Deployment kann eine Providerinstanz mit mehreren logischen Allocations oder mehrere Providerinstanzen mit unterschiedlichen Isolationsgrenzen verwenden. [ADR-0005](../decisions/ADR-0005-first-postgresql-deployment-profile.md) trifft die erste deployment-spezifische Auswahl; diese Spezifikation selbst legt weiterhin nichts an.
 
 ## PostgreSQL Provider Instance
 
@@ -29,7 +29,7 @@ Sie besitzt fachlich mindestens:
 | `backup_policy_reference` | Referenz auf providerweite Sicherungsanforderungen, falls vorhanden. |
 | `resource_policy_reference` | Referenz auf Kapazitäts- und Ressourcengrenzen. |
 
-Keine konkrete Instanz-ID ist Teil dieses Vertrags.
+Der allgemeine Providervertrag schreibt keine Instanz-ID vor. Das erste Referenzdeployment verwendet deployment-spezifisch `postgresql-main`.
 
 ## Versionsvertrag
 
@@ -39,7 +39,17 @@ Keine konkrete Instanz-ID ist Teil dieses Vertrags.
 - Jede Allocation muss mit der gewählten Major-Version und den aktivierten Fähigkeiten kompatibel sein.
 - Eine spätere Versionsmatrix berücksichtigt mindestens Sicherheitsstatus, Wartungsstatus und die Anforderungen der Consumer.
 
-Die konkrete Referenzversion bleibt offen.
+### Erste Referenzversionspolitik
+
+Für das erste Referenzdeployment gilt:
+
+- Major-Version: **18**,
+- initial dokumentierter Minor-Stand: **18.4**,
+- Ziel zum Installationszeitpunkt: neueste stabile **18.x**-Minor-Version,
+- kein automatischer Wechsel auf PostgreSQL 19,
+- jedes Major-Upgrade benötigt einen eigenen Plan und eine eigene ausdrückliche Freigabe.
+
+18.4 ist ein dokumentierter Ausgangsstand und keine dauerhafte Minor-Fixierung. Die konkrete 18.x-Version wird unmittelbar vor einer späteren Installation erneut ermittelt und auf Kompatibilität mit den ausgewählten Consumern geprüft.
 
 ## Fähigkeiten
 
@@ -223,7 +233,50 @@ Gitea erhält eine eigene Allocation und eigene Identitäten. Version, Datenbank
 - Schema-Lebenszyklus: `application_managed` oder `platform_preprovisioned`
 - PostgreSQL ist eine optionale Storage-Wahl.
 
-Integrated Storage bleibt als Alternative offen. Diese Spezifikation plant keinen OpenBao-Consumer und keine OpenBao-Allocation.
+Integrated Storage bleibt allgemein eine Alternative. Das nachfolgend dokumentierte erste Referenzprofil wählt PostgreSQL ausschließlich deployment-spezifisch für OpenBao aus.
+
+## Erstes deployment-spezifisches Referenzprofil
+
+Das in [ADR-0005](../decisions/ADR-0005-first-postgresql-deployment-profile.md) beschlossene Profil lautet:
+
+| Feld | Auswahl |
+| --- | --- |
+| `provider_instance_id` | `postgresql-main` |
+| Provider | PostgreSQL |
+| `isolation_profile` | `shared-provider-with-isolated-logical-databases` |
+| PostgreSQL-Major | 18 |
+| initial dokumentierter Minor-Stand | 18.4 |
+
+Die gemeinsame Providerinstanz enthält zunächst genau vier ausgewählte Allocations:
+
+| `allocation_id` | Consumer | `consumer_type` | `isolation_class` | `schema_lifecycle` | Besondere Festlegung |
+| --- | --- | --- | --- | --- | --- |
+| `gitea` | Gitea | `external_application` | `logical_database` | `application_managed` | `selected: true` |
+| `openbao` | OpenBao | `external_application` | `logical_database` | `application_managed` | `selected: true`, `sensitivity: high` |
+| `semaphore` | Semaphore UI | `external_application` | `logical_database` | `application_managed` | `selected: true` |
+| `nodered` | Node-RED | `external_application` | `logical_database` | `application_managed` | `selected: true`, `purpose: flow_application_data` |
+
+PostgreSQL ist für OpenBao in dieser Referenzumgebung bewusst als Storage gewählt. Die Wahl ist deployment-spezifisch; Integrated Storage bleibt für andere Installationen zulässig. OpenBao kann bei später nachgewiesenem Isolationsbedarf eine dedizierte Providerinstanz erhalten. Seine Bootstrap-Datenbankgeheimnisse stammen weiterhin aus `/secrets` und niemals zirkulär aus OpenBao selbst.
+
+Die Node-RED-Allocation speichert ausschließlich relationale Daten von Node-RED-Flows. Sie wird nicht automatisch zum internen Node-RED-Storage. Flowdateien, Credentials und Context bleiben zunächst außerhalb dieser Allocation. Eine Änderung dieses Storage-Vertrags benötigt eine eigene Entscheidung.
+
+RALF Core ist nicht Teil dieses ersten realen Allocation-Satzes. Seine Allocation wird erst geplant, wenn Core implementiert ist und ein konkretes Schema beziehungsweise Migrationspaket vorliegt.
+
+### Isolation und Secret-Referenzen des Profils
+
+Jede der vier Allocations erhält eine eigene logische Datenbank, eine eigene `application_identity`, keine Rechte auf fremde Allocations und einen eigenen allocation-bezogenen Health-, Readiness-, Backup- und Restorevertrag. Gemeinsame Anwendungsrollen, Anwendungspasswörter oder Anwendungsschemata sind ausgeschlossen.
+
+Vorgesehene, noch nicht angelegte Secret-Referenzen:
+
+```text
+/secrets/database-service/providers/postgresql-main/administrative-password
+/secrets/database-service/allocations/gitea/application-password
+/secrets/database-service/allocations/openbao/application-password
+/secrets/database-service/allocations/semaphore/application-password
+/secrets/database-service/allocations/nodered/application-password
+```
+
+Diese Pfade sind nicht geheime Referenzen. Dieser Spezifikationsschritt erzeugt weder die Dateien noch Secretwerte, Datenbanken, Identitäten oder Rollen. Logische Datenbanknamen und konkrete PostgreSQL-Benutzernamen bleiben offen.
 
 ## Health und Readiness
 
@@ -239,18 +292,14 @@ Ein Restore für eine Allocation darf niemals stillschweigend andere Allocations
 
 ## Offene Entscheidungen
 
-1. Welche PostgreSQL-Major-Version wird Referenzversion?
-2. Wie wird PostgreSQL in der ersten Referenzumgebung betrieben?
-3. Welche Allocations werden im ersten realen Deployment angelegt?
-4. Wird zunächst nur RALF Core angelegt?
-5. Benötigt Gitea bereits im ersten Deployment eine Allocation?
-6. Welches Storage-Backend verwendet OpenBao?
-7. Welche Netzwerkgrenze gilt zwischen Consumer und PostgreSQL?
-8. Welche Dateieigentümer und Zugriffsmodi gelten unter `/secrets`?
-9. Wie erfolgt Secret-Rotation?
-10. Welche Ressourcenlimits gelten je Allocation?
-11. Wo werden logische Backups gespeichert und wie lange aufbewahrt?
-12. Welche Providererweiterungen sind im Basisprofil zulässig?
-13. Wie werden PostgreSQL-Major-Upgrades durchgeführt?
+1. Auf welchem Betriebssystem und in welcher Betriebsform läuft `postgresql-main`?
+2. Welche Netzwerkgrenze gilt zwischen Consumern und PostgreSQL?
+3. Welche Ressourcen gelten für Providerinstanz und Allocations?
+4. Wo werden logische Backups gespeichert und wie lange aufbewahrt?
+5. Welche Dateieigentümer und Zugriffsmodi gelten unter `/secrets`?
+6. Wie erfolgt Secret-Rotation?
+7. Welche konkreten Versionen von Gitea, OpenBao, Semaphore UI und Node-RED sind mit der gewählten 18.x-Version kompatibel?
+8. Welche Providererweiterungen sind im Basisprofil zulässig?
+9. Wie werden PostgreSQL-Major-Upgrades durchgeführt?
 
-**Nächste Entscheidung:** PostgreSQL-Referenzversion, erstes Deploymentprofil und tatsächlich anzulegende Allocations auswählen.
+**Nächster Schritt:** Einen konkreten, zunächst read-only geplanten Implementierungspfad für PostgreSQL 18, `postgresql-main`, vier isolierte Allocations und Secrets ausschließlich unter `/secrets` entwerfen.


### PR DESCRIPTION
## Zusammenfassung

- definiert PostgreSQL als Provider 001 hinter dem providerneutralen Database-Service-Vertrag
- trennt PostgreSQL Provider Instance und Database Allocation einschließlich ihrer Lebenszyklen
- legt PostgreSQL 18 als Referenz-Major und 18.4 als initial dokumentierten Minor-Stand fest
- verwendet zum Installationszeitpunkt die neueste stabile 18.x-Minor-Version; kein automatischer Wechsel auf PostgreSQL 19
- wählt `postgresql-main` mit dem Profil `shared-provider-with-isolated-logical-databases`
- wählt genau vier isolierte Allocations für Gitea, OpenBao, Semaphore UI und Node-RED
- hält RALF Core bis zu Implementierung und Migrationspaket aus dem ersten realen Allocation-Satz heraus
- dokumentiert PostgreSQL als deployment-spezifische OpenBao-Storage-Wahl
- begrenzt die Node-RED-Allocation auf relationale Flow-Anwendungsdaten
- hält `/secrets` als einzige externe Secrets-Wurzel fest

## Grenzen

- keine Installation und keine Infrastrukturmutation
- keine Datenbank-, Rollen-, Identitäts- oder Secretanlage
- keine Ports, IP-Adressen, Datenbanknamen oder PostgreSQL-Benutzernamen
- kein SQL und keine Implementierungsdateien
- OpenBao Integrated Storage bleibt für andere Installationen zulässig

## Prüfungen

- `git diff --check`
- Markdown-Struktur, Codeblöcke und interne Links
- ADR-Reihenfolge 0001 bis 0005
- exakt vier ausgewählte erste Allocations
- PostgreSQL-18-/18.x-Versionspolitik und Ausschluss automatischer Major-Upgrades
- getrennte Identitäten und Allocation-Isolation
- OpenBao- und Node-RED-Abgrenzung
- `/secrets`-Referenzen und Secrets-Ausschluss
- Suche nach Secretwerten, Connection Strings und SQL
- Dokumentations- und Dateigrenze