### PR TITLE
Add read-only PostgreSQL main deployment planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Die erste fachliche Spezifikation trennt den fähigkeitsorientierten RALF-Vertra
 - [ADR-0003: gemeinsam nutzbare Datenbankplattform](docs/decisions/ADR-0003-shared-database-platform.md)
 - [ADR-0004: PostgreSQL als erster Referenzprovider](docs/decisions/ADR-0004-postgresql-reference-provider.md)
 - [ADR-0005: erstes PostgreSQL-Deploymentprofil](docs/decisions/ADR-0005-first-postgresql-deployment-profile.md)
+- [ADR-0006: Laufzeitprofil für `postgresql-main`](docs/decisions/ADR-0006-postgresql-runtime-profile.md)
+- [Read-only Deploymentplan für `postgresql-main`](docs/operations/postgresql-main-deployment-plan.md)
 
 Der erste spezifizierte RALF-native Database Consumer ist **RALF Core**. Seine erste persistente Domäne **Conversation** speichert ausschließlich Unterhaltungen und geordnete Nachrichten. Conversation bleibt zunächst eine Core-Domäne und verwendet nur in der RALF-Core-Allocation einen fachlichen Repository-Vertrag:
 
@@ -29,12 +31,22 @@ Der erste spezifizierte RALF-native Database Consumer ist **RALF Core**. Seine e
 
 Externe Anwendungen wie Gitea oder optional OpenBao können eigene Allocations mit nativen Datenbankzugriffen erhalten; sie verwenden ConversationRepository nicht. Referenzstandard ist eine logische Datenbank mit eigenen Identitäten pro Consumer. Die verbindliche externe Secrets-Wurzel ist `/secrets`; im Repository stehen ausschließlich nicht geheime Referenzen, und `secrets/` bleibt ausgeschlossen.
 
-Es gibt weiterhin keine Implementierung. Insbesondere existieren noch kein SQL, keine Tabellen, PostgreSQL-Installation, Programmierschnittstelle, Modellruntime, Benutzerverwaltung, Weboberfläche oder Infrastruktur.
+Die erste Implementierung ist ausschließlich ein read-only Deploymentplaner. Es existieren weiterhin kein SQL, keine Tabellen, keine PostgreSQL-Installation, Programmierschnittstelle, Modellruntime, Benutzerverwaltung, Weboberfläche oder Infrastrukturmutation.
 
 Provider 001 beschreibt PostgreSQL als konkrete Referenz hinter dem providerneutralen Vertrag. Das erste deployment-spezifische Profil wählt PostgreSQL Major 18 und die gemeinsame Providerinstanz `postgresql-main`. Ihr initial dokumentierter Minor-Stand ist 18.4; installiert wird später die dann neueste stabile 18.x-Minor-Version. Ein automatischer Wechsel auf PostgreSQL 19 ist ausgeschlossen.
 
 Für die erste Referenzinstallation sind vier isolierte Allocations ausgewählt: Gitea, OpenBao, Semaphore UI und Node-RED. RALF Core erhält noch keine Allocation. OpenBao verwendet in diesem Deployment bewusst PostgreSQL; Node-RED nutzt seine Allocation nur für relationale Flow-Anwendungsdaten, nicht automatisch als internen Speicher.
 
-Der nächste kleine Schritt ist ein zunächst read-only geplanter Implementierungspfad. Vor jeder Mutation werden noch Betriebsform, Netzwerkgrenze, Ressourcen, Backupziel, Rechte unter `/secrets` und kompatible Anwendungsversionen festgelegt. PostgreSQL ist weiterhin nicht installiert.
+Der Planer liest die reale, nicht im Repository liegende Konfiguration ausschließlich aus `/secrets/database-service/providers/postgresql-main/deployment.toml`:
+
+```bash
+sudo python3 scripts/postgresql-main-plan.py \
+  plan \
+  --config /secrets/database-service/providers/postgresql-main/deployment.toml
+```
+
+Das Referenzprofil ist ein eigener unprivilegierter Ubuntu-26.04-LTS-LXC auf Proxmox, ohne Docker oder Podman. PostgreSQL 18 stammt später aus den offiziellen Ubuntu-Quellen; TLS, SCRAM-SHA-256, allocation-spezifische Netze, ein explizites externes Backupziel und Secrets ausschließlich unter `/secrets` sind verbindliche Planungsgrenzen. Der Planer besitzt keinen Applymodus und verändert weder `/secrets` noch Infrastruktur.
+
+Der nächste kleine Schritt nach Review und Merge ist ein getrenntes Apply-Konzept mit sichtbaren Mutationen, Recovery-Grenzen und eigener Freigabe. PostgreSQL ist weiterhin nicht installiert.
 
 RALF entsteht transparent durch Vibe Coding: Menschen bestimmen Ziele, Entscheidungen und Grenzen; Coding-Agenten unterstützen die Umsetzung in kleinen, überprüfbaren Schritten.

--- a/deploy/postgresql/postgresql-main.example.toml
+++ b/deploy/postgresql/postgresql-main.example.toml
@@ -1,0 +1,50 @@
+# Nicht geheimes, bewusst unvollständiges Beispiel.
+# Diese Datei wird niemals automatisch als reale Deploymentkonfiguration verwendet.
+schema_version = 1
+
+[provider]
+provider_instance_id = "postgresql-main"
+hostname = "postgresql-main"
+fqdn = "postgresql-main.example.internal"
+postgresql_major = 18
+
+[lxc]
+vmid = 0
+storage = ""
+bridge = ""
+ipv4_cidr = ""
+gateway = ""
+dns_servers = []
+cores = 4
+memory_mib = 8192
+swap_mib = 2048
+disk_gib = 100
+
+[backup]
+host_root = ""
+minimum_free_gib = 100
+protection_confirmed = false
+
+[[allocations]]
+allocation_id = "gitea"
+database_name = "gitea"
+application_identity = "gitea"
+allowed_client_cidrs = []
+
+[[allocations]]
+allocation_id = "openbao"
+database_name = "openbao"
+application_identity = "openbao"
+allowed_client_cidrs = []
+
+[[allocations]]
+allocation_id = "semaphore"
+database_name = "semaphore"
+application_identity = "semaphore"
+allowed_client_cidrs = []
+
+[[allocations]]
+allocation_id = "nodered"
+database_name = "nodered"
+application_identity = "nodered"
+allowed_client_cidrs = []

--- a/deploy/postgresql/version-matrix.toml
+++ b/deploy/postgresql/version-matrix.toml
@@ -1,0 +1,26 @@
+schema_version = 1
+checked_at = "2026-08-02"
+
+[postgresql]
+major = 18
+documented_minor = "18.4"
+package = "postgresql-18"
+update_policy = "latest-stable-18.x"
+
+[gitea]
+version = "1.27.1"
+postgresql_requirement = ">=12"
+
+[openbao]
+version = "2.6.1"
+postgresql_requirement = ">=9.5"
+storage_backend = "postgresql"
+
+[semaphore]
+version = "2.18.29"
+database_backend = "postgres"
+
+[nodered]
+version = "5.0.4"
+nodejs_reference = "24"
+database_usage = "flow_application_data_only"

--- a/docs/architecture/database-service.md
+++ b/docs/architecture/database-service.md
@@ -238,7 +238,7 @@ Der Database Service ist kein SQL-Proxy, allgemeiner CRUD-Dienst, Datei- oder Ob
 
 PostgreSQL ist als [Provider 001](../providers/postgresql.md) der erste konkrete Referenzprovider. Eine PostgreSQL Provider Instance ist ein betriebener Server beziehungsweise Cluster mit null oder mehr isolierten Allocations. Providerinstanz und Allocation besitzen getrennte [Lebenszyklen](../lifecycle/database-allocation.md); eine bereite Instanz macht eine einzelne Allocation nicht automatisch bereit.
 
-Der Referenzstandard verwendet eine logische Datenbank und eigene technische Identitäten pro Allocation. ADR-0005 legt PostgreSQL Major 18, die 18.x-Minor-Policy, `postgresql-main` und vier initiale Allocations fest. Paketquelle, Betriebsform, Netzwerkgrenze, Serverkonfiguration, konkrete Datenbanknamen, PostgreSQL-Benutzernamen, Port, Adresse und Secretwerte bleiben bis zum Folgeplan offen. [ADR-0004](../decisions/ADR-0004-postgresql-reference-provider.md) und ADR-0005 halten diese Grenzen fest.
+Der Referenzstandard verwendet eine logische Datenbank und eigene technische Identitäten pro Allocation. ADR-0005 legt PostgreSQL Major 18, die 18.x-Minor-Policy, `postgresql-main` und vier initiale Allocations fest. [ADR-0006](../decisions/ADR-0006-postgresql-runtime-profile.md) ergänzt den eigenen unprivilegierten Ubuntu-26.04-LTS-LXC, die offiziellen Ubuntu-Paketquellen, Referenzressourcen sowie TLS-, SCRAM-, Secret- und Backupgrenzen. Konkrete VMID, Storage, Bridge, Adresse, FQDN, DNS-Server, Consumer-CIDRs, Datenbanknamen, Anwendungsidentitäten und Backupziel bleiben lokale Deploymentangaben. [ADR-0004](../decisions/ADR-0004-postgresql-reference-provider.md) hält die allgemeine Providerentscheidung fest.
 
 ## Offene Entscheidungen
 
@@ -249,7 +249,7 @@ Der Referenzstandard verwendet eine logische Datenbank und eigene technische Ide
 5. Wie erfolgt Secret-Rotation?
 6. Welche Backups erfolgen pro Allocation und welche providerweit?
 7. Wie werden Ressourcenlimits pro Allocation abgebildet?
-8. Welche Netzwerkgrenzen gelten zwischen Consumer und Provider?
-9. Wie wird das in ADR-0005 gewählte Profil konkret betrieben und read-only geplant?
+8. Welche konkreten Netzwerkgrenzen gelten im Deployment innerhalb des TLS- und Allowlist-Vertrags?
+9. Wie werden Apply, Recovery und Einzelbestätigungen für die vollständig geplanten Mutationen begrenzt?
 
-**Nächster kleiner Schritt:** Einen ausschließlich read-only arbeitenden Deploymentplan für PostgreSQL 18, `postgresql-main` und die vier ausgewählten Allocations erstellen.
+**Nächster kleiner Schritt:** Einen getrennten Apply-Vertrag mit sichtbaren Mutationen, Recovery-Grenzen und eigener Freigabe spezifizieren; der vorhandene Deploymentplaner bleibt read-only.

--- a/docs/contracts/database-allocation-v0.1.md
+++ b/docs/contracts/database-allocation-v0.1.md
@@ -239,4 +239,4 @@ RALF Core erh채lt in diesem ersten realen Deployment keine Allocation. Seine sp�
 - allocation- und providerweite Backupbeziehung,
 - konkrete Consumer-Versionskompatibilit채t.
 
-**N채chster Schritt:** Einen zun채chst read-only geplanten Implementierungspfad ausarbeiten, ohne eine Providerinstanz oder Allocation anzulegen.
+**N채chster Schritt:** Der [read-only Deploymentplan](../operations/postgresql-main-deployment-plan.md) konkretisiert das erste Profil ohne Providerinstanz oder Allocation anzulegen. Danach wird ein getrennter Apply-Vertrag mit Recovery- und Freigabegrenzen spezifiziert.

--- a/docs/decisions/ADR-0003-shared-database-platform.md
+++ b/docs/decisions/ADR-0003-shared-database-platform.md
@@ -94,8 +94,8 @@ Zurückgestellt, weil OpenBao als eigener Database Consumer eine zirkuläre Boot
 - Secret-Rotation,
 - allocation- und providerweite Backups,
 - Ressourcen- und Netzwerkgrenzen,
-- konkrete Betriebs- und Netzwerkgrenzen des gewählten Referenzprofils.
+- konkrete lokale Werte innerhalb der durch ADR-0006 festgelegten Betriebs- und Netzwerkgrenzen.
 
 ## Nächster Schritt
 
-[ADR-0004](ADR-0004-postgresql-reference-provider.md) hat PostgreSQL als ersten konkreten Referenzprovider sowie die getrennten Provider- und Allocation-Lebenszyklen festgelegt. [ADR-0005](ADR-0005-first-postgresql-deployment-profile.md) wählt PostgreSQL Major 18, `postgresql-main` und vier initiale Allocations. Als Nächstes entsteht ausschließlich ein read-only Deploymentplan; es wird weiterhin keine PostgreSQL-Instanz, Datenbank, Identität oder Allocation angelegt.
+[ADR-0004](ADR-0004-postgresql-reference-provider.md) hat PostgreSQL als ersten konkreten Referenzprovider sowie die getrennten Provider- und Allocation-Lebenszyklen festgelegt. [ADR-0005](ADR-0005-first-postgresql-deployment-profile.md) wählt PostgreSQL Major 18, `postgresql-main` und vier initiale Allocations; [ADR-0006](ADR-0006-postgresql-runtime-profile.md) legt das Laufzeitprofil fest. Der read-only Deploymentplan ist nun vorhanden. Als Nächstes wird ein eigener Apply-Vertrag spezifiziert; es wird weiterhin keine PostgreSQL-Instanz, Datenbank, Identität oder Allocation angelegt.

--- a/docs/decisions/ADR-0004-postgresql-reference-provider.md
+++ b/docs/decisions/ADR-0004-postgresql-reference-provider.md
@@ -114,4 +114,4 @@ Verworfen als Zwang, weil Sicherheits-, Verfügbarkeits-, Versions-, Erweiterung
 
 ## Nächster Schritt
 
-ADR-0005 beantwortet Versions-, Profil- und Allocation-Auswahl. Als Nächstes entsteht ein konkreter, zunächst read-only geplanter Implementierungspfad. PostgreSQL, Datenbanken, Identitäten, Secrets und Netzwerkfreigaben bleiben bis zu einem separat bestätigten Apply unverändert.
+ADR-0005 beantwortet Versions-, Profil- und Allocation-Auswahl; ADR-0006 konkretisiert das Laufzeitprofil. Der [read-only Deploymentplan](../operations/postgresql-main-deployment-plan.md) validiert diese Entscheidungen, ohne Infrastruktur zu verändern. Als Nächstes wird ein eigener Apply-Vertrag mit sichtbaren Mutationen, Recovery-Grenzen und separater Freigabe spezifiziert. PostgreSQL, Datenbanken, Identitäten, Secrets und Netzwerkfreigaben bleiben bis zu einem solchen bestätigten Apply unverändert.

--- a/docs/decisions/ADR-0005-first-postgresql-deployment-profile.md
+++ b/docs/decisions/ADR-0005-first-postgresql-deployment-profile.md
@@ -107,18 +107,20 @@ Dieser Entscheidungsdurchlauf legt keine dieser Dateien an. Er dokumentiert wede
 - OpenBao und Node-RED besitzen die dokumentierten deployment-spezifischen Storage-Grenzen.
 - Die konkrete technische Umsetzung bleibt vollständig offen und benötigt einen neuen Plan.
 
-## Nicht entschieden
+## Fortschreibung durch ADR-0006
 
-- Betriebssystem und Betriebsform von `postgresql-main`,
-- Netzwerkgrenze,
-- CPU-, Speicher- und Storage-Ressourcen,
-- Backupziel und Retention,
-- Eigentümer und Dateirechte unter `/secrets`,
-- konkrete kompatible Versionen von Gitea, OpenBao, Semaphore UI und Node-RED,
+[ADR-0006](ADR-0006-postgresql-runtime-profile.md) entscheidet die bei Annahme dieses ADR noch offenen Punkte zu Betriebssystem, Betriebsform, Paketquelle, Referenzressourcen sowie den grundsätzlichen Netzwerk-, TLS-, SCRAM-, Secret- und Backupgrenzen. Der zugehörige [read-only Deploymentplan](../operations/postgresql-main-deployment-plan.md) setzt diese Grenzen ausschließlich als Validierung und Plandarstellung um.
+
+## Weiterhin nicht entschieden
+
+- konkrete VMID, Storage, Bridge, Adresse, FQDN, DNS-Server und Consumer-CIDRs,
+- konkretes externes Backupziel und Retention,
+- Consumer-Zugriffsmodell auf die unter `/secrets` verwahrten Dateien,
+- erneute Kompatibilitätsprüfung der versionierten Referenzmatrix unmittelbar vor Installation,
 - konkrete logische Datenbanknamen und PostgreSQL-Benutzernamen,
 - Secret-Rotation,
 - zulässige Erweiterungen und Detailkonfiguration.
 
 ## Nächster Schritt
 
-Als Nächstes wird ein konkreter, zunächst read-only geplanter Implementierungspfad für PostgreSQL 18, eine Providerinstanz, vier isolierte logische Allocations und Secrets ausschließlich unter `/secrets` entworfen. Vor der ersten Mutation werden alle unter „Nicht entschieden“ genannten Betriebsparameter festgelegt und der vollständige Plan ausdrücklich bestätigt.
+Der read-only Deploymentplan für PostgreSQL 18, eine Providerinstanz, vier isolierte logische Allocations und Secrets ausschließlich unter `/secrets` ist nun spezifiziert. Als Nächstes wird getrennt definiert, wie ein späterer Apply Mutationen, Recovery und Einzelbestätigungen sicher begrenzt. Bis dahin findet keine Mutation statt.

--- a/docs/decisions/ADR-0006-postgresql-runtime-profile.md
+++ b/docs/decisions/ADR-0006-postgresql-runtime-profile.md
@@ -1,0 +1,108 @@
+# ADR-0006: Laufzeitprofil für `postgresql-main`
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-02
+
+## Kontext
+
+ADR-0005 wählt PostgreSQL 18, die Providerinstanz `postgresql-main` und vier isolierte Allocations. Für einen reproduzierbaren, zunächst ausschließlich lesenden Deploymentplan müssen Betriebsform, Referenzressourcen, Paketquelle, Netzwerk- und Sicherheitsziele sowie die Backupgrenze konkretisiert werden.
+
+Der Plan darf noch keine Infrastruktur verändern. Deployment-spezifische Netz- und Proxmox-Werte bleiben außerhalb des Repositorys.
+
+## Entscheidung
+
+Das erste Referenzdeployment verwendet:
+
+| Eigenschaft | Entscheidung |
+| --- | --- |
+| Plattform | Proxmox VE |
+| Virtualisierung | eigener unprivilegierter LXC mit aktiviertem nesting |
+| Betriebssystem | Ubuntu Server 26.04 LTS |
+| Architektur | amd64/x86_64 |
+| Containerlaufzeit | weder Docker noch Podman |
+| Hostname | `postgresql-main` |
+| PostgreSQL-Paket | `postgresql-18` |
+| Paketquelle | offizielle Ubuntu-26.04-Quellen; keine zusätzliche PGDG-Quelle |
+| Major-Version | 18 |
+| Minor-Policy | neueste stabile 18.x-Version zum Installationszeitpunkt |
+
+Der read-only Planer muss sichtbar melden, wenn die offiziellen Quellen nicht die erwartete aktuelle 18.x-Version anbieten. Er führt selbst keine Onlineprüfung durch. Ein automatischer Wechsel auf PostgreSQL 19 ist ausgeschlossen; Major-Upgrades benötigen einen eigenen Plan und eine eigene Freigabe.
+
+## Referenzressourcen
+
+- 4 vCPU,
+- 8192 MiB RAM,
+- 2048 MiB Swap,
+- 100 GiB Root-Disk,
+- SSD oder vergleichbar geeigneter persistenter Storage.
+
+Dies sind Referenzwerte und keine universellen Mindestanforderungen. Eine lokale Deploymentkonfiguration darf sie überschreiben. Niedrigere Werte müssen im Plan als Abweichung erscheinen; fehlendes oder zu kleines Storage blockiert die Planung.
+
+## Netzwerk- und PostgreSQL-Sicherheitsgrenze
+
+Die Providerinstanz lauscht später ausschließlich auf ihrer konkret konfigurierten Adresse, nicht auf `0.0.0.0`. Remoteverbindungen sind auf TLS, SCRAM-SHA-256, die jeweilige logische Datenbank, deren eigene Anwendungsidentität und allocation-spezifische Client-CIDRs begrenzt. Eine leere Client-Allowlist blockiert Remote-Readiness.
+
+Lokale Administration erfolgt über Unix-Socket und Peer-Authentifizierung. Es gibt standardmäßig kein gespeichertes PostgreSQL-Superuserkennwort und keine Remote-Superuseranmeldung. Consumer erhalten keine Superuser-, Datenbankerstellungs-, Rollenerstellungs- oder Replikationsrechte und keine Rechte auf fremde Allocations.
+
+TLS verwendet eine dedizierte, deployment-spezifische CA und ein Serverzertifikat für den konfigurierten FQDN. Es gibt keine öffentliche ACME-CA und keinen automatischen Zugriff auf OPNsense. Erzeugung und Verteilung der TLS-Artefakte benötigen später eine eigene Freigabe.
+
+## Secrets-Grenze
+
+Die reale Deploymentkonfiguration und sämtliche Datenbank- sowie TLS-Geheimnisse liegen ausschließlich unter `/secrets` auf dem Proxmox-Host. Das Repository enthält nur ein nicht geheimes Beispiel und absolute Secretreferenzen.
+
+Der Planer liest ausschließlich Dateimetadaten und weder Secretwerte noch private Schlüssel. Fehlende Secrets werden als spätere Mutation angezeigt; der Planer erstellt `/secrets` oder Unterpfade nicht. Ein späterer temporärer Transfer in den LXC wäre ausschließlich über ein geschütztes tmpfs unter `/run/ralf-database-provision/` zulässig und ist nicht Bestandteil dieser Entscheidungsausführung.
+
+## Backupgrenze
+
+Das Backupziel wird in der lokalen Deploymentkonfiguration als absoluter Hostpfad ausdrücklich angegeben. Es besitzt keinen automatischen Standardwert, liegt weder im LXC-Dateisystem noch unter `/secrets` oder im Git-Repository und muss als verschlüsselt oder anderweitig angemessen geschützt bestätigt sein.
+
+Referenzstandard ist ein logisches Custom-Format pro Allocation, später sinngemäß mit `pg_dump --format=custom`. Backups werden zum Proxmox-Host gestreamt; es gibt keinen dauerhaften Backup-Mount im Datenbank-LXC. Retention und automatisches Löschen bleiben offen.
+
+## Begründung
+
+- Ein eigener unprivilegierter LXC begrenzt die Providerinstanz gegenüber Host und Consumern.
+- Ubuntu 26.04 LTS und dessen offizielle Quellen vermeiden für das Referenzprofil eine zusätzliche Paketquelle.
+- PostgreSQL 18 bleibt innerhalb der in ADR-0005 festgelegten Major-Grenze aktuell.
+- Explizite Proxmox-, Netzwerk-, Secret- und Backupwerte verhindern stille Infrastrukturannahmen.
+- TLS, SCRAM und allocation-spezifische Regeln bewahren die vereinbarte Isolation auch auf der nativen PostgreSQL-Datenebene.
+- Ein externes, allocation-bezogenes Backupziel unterstützt getrennte Wiederherstellung ohne dauerhaften Host-Mount im LXC.
+
+## Konsequenzen
+
+- Der Planer darf VMID, Storage und Bridge nur bei exakt eindeutiger Auswahl automatisch bestimmen.
+- IP-Adresse, Präfix, Gateway, FQDN, Consumer-Netze und Backupziel werden nie erraten.
+- Das Ubuntu-Template, die freie Storagekapazität und vorhandene Konflikte werden ausschließlich read-only geprüft.
+- Der Plan zeigt alle späteren LXC-, Paket-, TLS-, PostgreSQL-, Allocation-, Secret- und Backupmutationen, führt aber keine davon aus.
+- Gitea, OpenBao, Semaphore UI und Node-RED werden nicht installiert.
+- Der Node-RED-Datenbankvertrag bleibt auf relationale Flow-Anwendungsdaten begrenzt.
+
+## Sicherheitsfolgen
+
+Ein unprivilegierter LXC und getrennte Datenbankidentitäten reduzieren, beseitigen aber nicht die gemeinsame Fehler- und Ressourcendomäne der Providerinstanz. Insbesondere die hochsensible OpenBao-Allocation kann später eine dedizierte Instanz erfordern. Diese Platzierungsentscheidung bleibt sichtbar und separat freigabepflichtig.
+
+Secretwerte dürfen weder im Plan noch im Repository, in Logs, Prozessargumenten oder normalen Umgebungsvariablen erscheinen. Ein `PLAN_READY` bestätigt nur die Vollständigkeit und Widerspruchsfreiheit der Planung.
+
+## Verworfene Alternativen
+
+- **Docker oder Podman im LXC:** für das Referenzprofil nicht erforderlich und zusätzliche Betriebsgrenze.
+- **PGDG-Paketquelle:** nicht ausgewählt, solange das gewünschte 18.x-Paket aus den offiziellen Ubuntu-26.04-Quellen geeignet verfügbar ist.
+- **Listener auf allen Adressen:** wegen unnötig breiter Angriffsfläche verworfen.
+- **Globale Client-Allowlist:** wegen fehlender Allocation-Isolation verworfen.
+- **Automatisches Backupziel:** wegen deployment-spezifischer Storage- und Schutzanforderungen verworfen.
+- **Secrets im Repository oder dauerhaft im LXC:** wegen Offenlegungs- und Lebenszyklusrisiken verworfen.
+- **Sofortiger Apply-Modus:** bis zum getrennten Mutations-, Recovery- und Freigabevertrag zurückgestellt.
+
+## Offene Punkte
+
+- konkrete VMID, Storage, Bridge, Adresse, FQDN, Gateway und Consumer-CIDRs,
+- konkretes verfügbares Ubuntu-26.04-amd64-Template,
+- tatsächliche 18.x-Paketversion in den offiziellen Ubuntu-Quellen zum Installationszeitpunkt,
+- Eigentümermodell für Consumerzugriffe auf Secretdateien,
+- Erzeugung, Rotation und Verteilung von Passwörtern und TLS-Artefakten,
+- Backup-Retention und Wiederherstellungstest,
+- Ressourcenlimits innerhalb der Providerinstanz,
+- Apply-Transaktionsgrenzen und Recovery nach Teilerfolgen.
+
+## Nächster Schritt
+
+Nach Review und Merge wird ein getrenntes, weiterhin ausdrücklich freizugebendes Apply-Konzept entworfen. Der aktuelle Planer bleibt strikt read-only; keine Infrastruktur wird durch diese Entscheidung verändert.

--- a/docs/lifecycle/database-allocation.md
+++ b/docs/lifecycle/database-allocation.md
@@ -183,4 +183,4 @@ PostgreSQL-spezifische SQLSTATE-Werte bleiben intern im Provideradapter. Sie wer
 - Nachweis fehlender Rechte auf fremde Allocations,
 - Grenzen und Verfahren eines späteren Rollbacks.
 
-**Nächster Schritt:** Das in ADR-0005 gewählte Profil ausschließlich read-only planen; noch keine Allocation anlegen oder verändern.
+**Nächster Schritt:** Der [read-only Deploymentplan](../operations/postgresql-main-deployment-plan.md) bildet das in ADR-0005 und ADR-0006 gewählte Profil ohne Mutation ab. Danach wird ein getrennter Apply-Vertrag spezifiziert; noch keine Allocation wird angelegt oder verändert.

--- a/docs/operations/postgresql-main-deployment-plan.md
+++ b/docs/operations/postgresql-main-deployment-plan.md
@@ -1,0 +1,153 @@
+# Read-only Deploymentplan für `postgresql-main`
+
+## Zweck und Grenze
+
+`scripts/postgresql-main-plan.py` erstellt einen service-spezifischen, ausschließlich lesenden Bereitstellungsplan für die erste PostgreSQL-Providerinstanz des Database Service. Er validiert lokale Planungsdaten, paketierte Referenzstände und den vorhandenen Proxmox-Zustand. Anschließend beschreibt er alle Mutationen, die ein späterer, getrennt freizugebender Bereitstellungsschritt benötigen würde.
+
+Der Planer besitzt ausschließlich den Modus `plan`. Er erstellt keinen LXC, installiert keine Pakete, konfiguriert PostgreSQL nicht und legt weder Datenbanken, Identitäten, TLS-Artefakte, Secrets noch Backups an. Es gibt keinen `apply`-, `create`-, `install`-, `provision`-, `delete`- oder `restore`-Modus.
+
+## Referenzprofil
+
+| Eigenschaft | Referenzwert |
+| --- | --- |
+| Plattform | Proxmox VE |
+| Virtualisierung | eigener unprivilegierter LXC, nesting aktiviert |
+| Betriebssystem | Ubuntu Server 26.04 LTS, amd64/x86_64 |
+| Containerlaufzeit | kein Docker oder Podman |
+| Hostname | `postgresql-main` |
+| Paketquelle | offizielle Ubuntu-26.04-Quellen, keine PGDG-Quelle |
+| Paket | `postgresql-18` |
+| Versionspolitik | neueste stabile 18.x-Minor-Version; kein automatischer Wechsel auf PostgreSQL 19 |
+| CPU | 4 vCPU |
+| RAM | 8192 MiB |
+| Swap | 2048 MiB |
+| Root-Disk | 100 GiB auf SSD oder vergleichbar geeignetem persistentem Storage |
+
+Die Ressourcenwerte sind das Referenzprofil, keine allgemeinen Mindestanforderungen. Niedrigere Werte erzeugen sichtbare Warnungen. Fehlendes Storage, zu wenig freier Speicher oder uneindeutige Infrastrukturwerte blockieren den Plan.
+
+## Deploymentkonfiguration
+
+Die reale Konfiguration wird ausschließlich aus folgendem Pfad gelesen:
+
+```text
+/secrets/database-service/providers/postgresql-main/deployment.toml
+```
+
+Sie enthält deployment-spezifische, aber keine geheimen Angaben. Das Repository enthält mit [`deploy/postgresql/postgresql-main.example.toml`](../../deploy/postgresql/postgresql-main.example.toml) nur ein offensichtlich unvollständiges Beispiel. Der Planer verwendet dieses Beispiel niemals automatisch.
+
+Die Konfiguration wird streng validiert. Unbekannte Schlüssel, eine andere Schema-Version, ein anderer Provider, eine andere PostgreSQL-Major-Version oder eine von genau `gitea`, `openbao`, `semaphore` und `nodered` abweichende Allocation-Menge werden abgelehnt. VMID, Storage, Bridge, IPv4-Konfiguration, FQDN, Consumer-Allowlists und Backupziel müssen explizit angegeben oder nach den dokumentierten Eindeutigkeitsregeln lesend ermittelt werden können.
+
+`vmid = 0` fordert die nächste freie VMID an. Ein leeres Storage oder eine leere Bridge ist nur dann zulässig, wenn exakt ein geeigneter Kandidat vorhanden ist. Mehrdeutigkeit ist ein Blocker. Der Planer erfindet keine IP-Adresse, kein Gateway, keinen DNS-Wert und kein Backupziel. DNS-Server werden als kanonische IP-Adressen explizit angegeben; eine leere Liste blockiert den Plan.
+
+Leere `allowed_client_cidrs` sind als noch unvollständiger Planungsstand zulässig, blockieren aber Remote-Readiness. Globale Freigaben wie `0.0.0.0/0` oder `::/0` und nicht kanonische CIDRs werden abgelehnt.
+
+Das externe Backupziel ist verpflichtend. Zusätzlich bestätigt `protection_confirmed`, dass der Zielbereich verschlüsselt oder anderweitig angemessen geschützt ist; ohne diese Bestätigung bleibt der Plan blockiert. `minimum_free_gib` hält die deployment-spezifisch verlangte freie Kapazität fest.
+
+## Versionsmatrix
+
+[`deploy/postgresql/version-matrix.toml`](../../deploy/postgresql/version-matrix.toml) ist eine versionierte, offline gelesene Referenzmatrix mit Stichtag 2. August 2026:
+
+- PostgreSQL 18, initial dokumentiert 18.4, Paket `postgresql-18`, Policy `latest-stable-18.x`,
+- Gitea 1.27.1 mit dokumentierter PostgreSQL-Anforderung `>=12`,
+- OpenBao 2.6.1 mit PostgreSQL-Storage und dokumentierter Anforderung `>=9.5`,
+- Semaphore UI 2.18.29 mit Backend `postgres`,
+- Node-RED 5.0.4 mit Node.js-Referenz 24 und ausschließlich relationalen Flow-Anwendungsdaten.
+
+Die Matrix installiert nichts und führt keine Onlineprüfung aus. Unmittelbar vor einer späteren Installation muss erneut geprüft werden, welche stabile 18.x-Version die offiziellen Ubuntu-26.04-Quellen tatsächlich anbieten und ob alle vorgesehenen Anwendungsversionen dazu kompatibel sind. Semaphore dokumentiert PostgreSQL-Unterstützung, aber keine hier festgelegte maximale PostgreSQL-Version. Node-RED erhält nicht automatisch einen internen PostgreSQL-Speicher; dafür ist später ein konkreter PostgreSQL-Node oder ein eigener Flow-Vertrag erforderlich.
+
+## Aufruf
+
+```bash
+sudo python3 scripts/postgresql-main-plan.py \
+  plan \
+  --config /secrets/database-service/providers/postgresql-main/deployment.toml
+```
+
+Andere Konfigurationspfade werden von der Kommandozeile bewusst abgelehnt. Tests verwenden ausschließlich direkte, temporäre Eingaben und Mock-Probes.
+
+## Read-only Prüfungen
+
+Der Planer darf nur fest definierte, begrenzte Argumentlisten für lesende Proxmox- und Hostprüfungen verwenden. Er liest:
+
+- Proxmox-Version,
+- vorhandene Container und den Zustand einer gegebenenfalls belegten VMID,
+- Storage-Status und freie Kapazität,
+- Linux-Bridges, Adressen und Routen,
+- verfügbare Ubuntu-Container-Templates,
+- Metadaten der Deploymentkonfiguration, Secretreferenzen, TLS-Pfade und des Backupziels,
+- den lokalen Git-Commit und die paketierte Versionsmatrix.
+
+Externe Aufrufe besitzen feste Argumentlisten, kurze Zeitlimits und begrenzte Ausgaben. Es gibt kein `shell=True`, keinen Netzwerkscan, keine PostgreSQL-Verbindung und keine Online-Versionsabfrage.
+
+## Secrets- und TLS-Vertrag
+
+`/secrets` bleibt die einzige Secrets-Wurzel. Der Planer prüft vorhandene Pfade ausschließlich per Dateimetadaten. Er liest keine Secretwerte, berechnet keine Inhalts-Hashes und gibt keine Inhalte aus.
+
+Geplante Allocation-Referenzen sind:
+
+```text
+/secrets/database-service/allocations/gitea/application-password
+/secrets/database-service/allocations/openbao/application-password
+/secrets/database-service/allocations/semaphore/application-password
+/secrets/database-service/allocations/nodered/application-password
+```
+
+TLS wird später über eine dedizierte CA und ein Serverzertifikat für den konfigurierten FQDN bereitgestellt. Die geplanten Referenzen liegen unter `/secrets/database-service/providers/postgresql-main/pki/`. Der Planer erzeugt oder liest weder Schlüssel noch Zertifikatsinhalte. Eine neue CA darf erst nach eigener ausdrücklicher Freigabe entstehen; öffentliche ACME-Zertifikate und ein automatischer OPNsense-Zugriff sind nicht vorgesehen.
+
+Zielmetadaten eines späteren Apply wären `root:root` mit Modus `0700` für Secretverzeichnisse und `0600` für Passwortdateien sowie private Schlüssel. Symlinks, unsichere Rechte, unerwartete Eigentümer oder leere vorhandene Passwortdateien werden als Konflikt gemeldet. Fehlende Pfade werden nur als später anzulegende Artefakte angezeigt.
+
+Ein späterer Apply dürfte Klartextwerte nur kurzfristig über `/run/ralf-database-provision/` auf einem geschützten tmpfs in den LXC übertragen und müsste sie unmittelbar nach der jeweiligen Identitätsanlage entfernen. Dieser Mechanismus ist noch nicht implementiert.
+
+## PostgreSQL-Zielvertrag
+
+Der Plan beschreibt folgenden späteren Sicherheitszustand:
+
+- lokale Administration über Unix-Socket und Peer-Authentifizierung,
+- kein gespeichertes PostgreSQL-Superuserkennwort als Standard,
+- keine Remote-Superuseranmeldung,
+- `password_encryption = scram-sha-256`,
+- Remotezugriff ausschließlich per TLS auf die konkrete Provideradresse,
+- kein Listener auf `0.0.0.0`,
+- pro Allocation eine eigene `hostssl`-Grenze für eigene Datenbank, Identität und Clientnetze,
+- SCRAM-SHA-256 für Remote-Authentifizierung,
+- normale Anwendungsidentitäten ohne Superuser-, Datenbankerstellungs-, Rollenerstellungs- oder Replikationsrechte,
+- keine Consumer-übergreifenden Anwendungsobjekte über globale `PUBLIC`-Rechte.
+
+Für `application_managed` dürfen Anwendungen Objekte und Migrationen ausschließlich in ihrer eigenen logischen Datenbank verwalten. Die konkrete SQL- und `public`-Schema-Umsetzung gehört in einen späteren Apply-Schritt.
+
+## Backupvertrag
+
+Referenzstandard ist ein logisches PostgreSQL-Custom-Format pro Allocation, später sinngemäß mit `pg_dump --format=custom`. Die Daten sollen vom LXC zum Proxmox-Host gestreamt werden; im Datenbank-LXC ist kein dauerhafter Backup-Mount vorgesehen.
+
+Unter dem explizit konfigurierten Host-Root wäre später folgende Struktur anzulegen:
+
+```text
+postgresql-main/
+├── gitea/
+├── openbao/
+├── semaphore/
+└── nodered/
+```
+
+Backupdateien wären `root:root` und `0600`. Der Planer legt weder Verzeichnisse noch Backups an. Automatische Retention oder Löschung gehört nicht zu diesem Schritt.
+
+## Planausgabe und Blocker
+
+Die Ausgabe enthält Repository und Matrix, Proxmox-Ziel, Netzwerk, PostgreSQL-Sicherheitsvertrag, jede Allocation, Secret- und TLS-Metadaten, Backupziel, spätere Mutationen sowie ausdrücklich ausgeschlossenen Umfang. Secretinhalte erscheinen nie.
+
+Typische Blocker sind:
+
+- fehlende oder ungültige reale Konfiguration,
+- belegte oder nicht eindeutig ermittelbare VMID,
+- uneindeutiges oder fehlendes Storage beziehungsweise Bridge,
+- fehlendes Ubuntu-26.04-amd64-Template,
+- zu wenig freier Storage,
+- leere Client-Allowlist,
+- unsichere bestehende Secret- oder TLS-Metadaten,
+- fehlendes, ungeeignetes oder unbestätigt geschütztes Backupziel.
+
+Der letzte Ausgabewert ist genau `PLAN_READY` oder `PLAN_BLOCKED`. `PLAN_READY` ist ausschließlich eine Planungsbewertung und keine Freigabe oder Ausführung.
+
+## Nächster Schritt
+
+Nach Review und Merge kann ein getrennt entworfener Apply-Vertrag die bereits vollständig sichtbaren Mutationen, Transaktionsgrenzen, Recovery-Strategien und Einzelbestätigungen spezifizieren. Bis dahin bleibt jede Infrastruktur unverändert.

--- a/docs/providers/postgresql.md
+++ b/docs/providers/postgresql.md
@@ -292,14 +292,13 @@ Ein Restore für eine Allocation darf niemals stillschweigend andere Allocations
 
 ## Offene Entscheidungen
 
-1. Auf welchem Betriebssystem und in welcher Betriebsform läuft `postgresql-main`?
-2. Welche Netzwerkgrenze gilt zwischen Consumern und PostgreSQL?
-3. Welche Ressourcen gelten für Providerinstanz und Allocations?
-4. Wo werden logische Backups gespeichert und wie lange aufbewahrt?
-5. Welche Dateieigentümer und Zugriffsmodi gelten unter `/secrets`?
-6. Wie erfolgt Secret-Rotation?
-7. Welche konkreten Versionen von Gitea, OpenBao, Semaphore UI und Node-RED sind mit der gewählten 18.x-Version kompatibel?
-8. Welche Providererweiterungen sind im Basisprofil zulässig?
-9. Wie werden PostgreSQL-Major-Upgrades durchgeführt?
+1. Welche lokalen VMID-, Storage-, Bridge-, Adress-, FQDN-, DNS- und Allowlistwerte werden bestätigt?
+2. Wie erhalten Consumer kontrolliert Zugriff auf ihre Dateien unter `/secrets`?
+3. Wie erfolgt Secret-Rotation?
+4. Wie lange werden logische Backups aufbewahrt und regelmäßig wiederherstellbar geprüft?
+5. Welche Ressourcenlimits gelten innerhalb der gemeinsamen Providerinstanz?
+6. Welche Providererweiterungen sind im Basisprofil zulässig?
+7. Wie werden PostgreSQL-Major-Upgrades durchgeführt?
+8. Welche Apply-, Recovery- und Einzelbestätigungsgrenzen gelten für die geplanten Mutationen?
 
-**Nächster Schritt:** Einen konkreten, zunächst read-only geplanten Implementierungspfad für PostgreSQL 18, `postgresql-main`, vier isolierte Allocations und Secrets ausschließlich unter `/secrets` entwerfen.
+**Nächster Schritt:** Der [read-only Deploymentplan](../operations/postgresql-main-deployment-plan.md) ist vorhanden. Nun wird ein getrennter Apply-Vertrag mit sichtbaren Mutationen, Recovery-Grenzen und eigener Freigabe spezifiziert.

--- a/scripts/postgresql-main-plan.py
+++ b/scripts/postgresql-main-plan.py
@@ -1,0 +1,1250 @@
+#!/usr/bin/env python3
+"""Read-only deployment planner for the postgresql-main reference instance."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import datetime as dt
+import ipaddress
+import os
+import pathlib
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tomllib
+from collections.abc import Callable, Mapping, Sequence
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+REAL_CONFIG_PATH = pathlib.Path(
+    "/secrets/database-service/providers/postgresql-main/deployment.toml"
+)
+EXAMPLE_CONFIG_PATH = REPO_ROOT / "deploy/postgresql/postgresql-main.example.toml"
+VERSION_MATRIX_PATH = REPO_ROOT / "deploy/postgresql/version-matrix.toml"
+
+PROVIDER_INSTANCE_ID = "postgresql-main"
+PROVIDER_HOSTNAME = "postgresql-main"
+POSTGRESQL_MAJOR = 18
+EXPECTED_ALLOCATIONS = ("gitea", "openbao", "semaphore", "nodered")
+REFERENCE_CORES = 4
+REFERENCE_MEMORY_MIB = 8192
+REFERENCE_DISK_GIB = 100
+OUTPUT_LIMIT = 65_536
+COMMAND_TIMEOUT_SECONDS = 8
+
+SECRET_ROOT = pathlib.Path("/secrets")
+PROVIDER_SECRET_ROOT = SECRET_ROOT / "database-service/providers/postgresql-main"
+ALLOCATION_SECRET_ROOT = SECRET_ROOT / "database-service/allocations"
+
+MUTATION_PLAN = (
+    "Unprivilegierten Ubuntu-26.04-LXC postgresql-main anlegen",
+    "Ubuntu-Pakete kontrolliert aktualisieren",
+    "PostgreSQL 18 aus den offiziellen Ubuntu-26.04-Quellen installieren",
+    "Dedizierte Provider-TLS-Artefakte nach eigener Freigabe bereitstellen",
+    "PostgreSQL auf SCRAM, TLS und die konkrete Provideradresse begrenzen",
+    "Vier isolierte logische Datenbanken anlegen",
+    "Vier isolierte Anwendungsidentitäten mit minimalen Rechten anlegen",
+    "Secretwerte ausschließlich unter /secrets erzeugen",
+    "Provider- und Allocation-Health sowie Readiness prüfen",
+    "Initiale leere logische Backups im Custom-Format erzeugen und prüfen",
+)
+
+EXCLUDED_SCOPE = (
+    "Gitea-Installation",
+    "OpenBao-Installation",
+    "Semaphore-Installation",
+    "Node-RED-Installation",
+    "RALF Core",
+    "pgvector",
+    "Hochverfügbarkeit",
+    "Replikation",
+    "Docker oder Podman",
+    "automatischer PostgreSQL-Major-Wechsel",
+    "keine reale Mutation im Planmodus",
+)
+
+
+class PlannerError(Exception):
+    """Base class for safe planner failures."""
+
+
+class ConfigurationError(PlannerError):
+    """The local deployment configuration is invalid."""
+
+
+class MatrixError(PlannerError):
+    """The packaged version matrix is invalid."""
+
+
+class ProbeError(PlannerError):
+    """A read-only probe failed or violated the command allowlist."""
+
+
+@dataclasses.dataclass(frozen=True)
+class ProviderConfig:
+    provider_instance_id: str
+    hostname: str
+    fqdn: str
+    postgresql_major: int
+
+
+@dataclasses.dataclass(frozen=True)
+class LxcConfig:
+    vmid: int
+    storage: str
+    bridge: str
+    ipv4_interface: ipaddress.IPv4Interface
+    gateway: ipaddress.IPv4Address
+    dns_servers: tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...]
+    cores: int
+    memory_mib: int
+    swap_mib: int
+    disk_gib: int
+
+
+@dataclasses.dataclass(frozen=True)
+class BackupConfig:
+    host_root: pathlib.Path
+    minimum_free_gib: int
+    protection_confirmed: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class AllocationConfig:
+    allocation_id: str
+    database_name: str
+    application_identity: str
+    allowed_client_cidrs: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class DeploymentConfig:
+    provider: ProviderConfig
+    lxc: LxcConfig
+    backup: BackupConfig
+    allocations: tuple[AllocationConfig, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class VersionMatrix:
+    checked_at: str
+    postgresql: Mapping[str, object]
+    applications: Mapping[str, Mapping[str, str]]
+
+
+@dataclasses.dataclass(frozen=True)
+class CommandResult:
+    stdout: str
+    stderr: str
+    returncode: int
+
+
+@dataclasses.dataclass(frozen=True)
+class StorageInfo:
+    name: str
+    status: str
+    available_bytes: int
+
+
+@dataclasses.dataclass
+class ProxmoxState:
+    pve_version: str = "unbekannt"
+    vmid: int | None = None
+    vmid_source: str = "unbekannt"
+    storage: str | None = None
+    storage_source: str = "unbekannt"
+    storage_available_bytes: int | None = None
+    bridge: str | None = None
+    bridge_source: str = "unbekannt"
+    template: str | None = None
+    host_addresses_checked: bool = False
+    host_routes_checked: bool = False
+    warnings: list[str] = dataclasses.field(default_factory=list)
+    blockers: list[str] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass(frozen=True)
+class PathCheck:
+    path: pathlib.Path
+    state: str
+    metadata: str
+    conflict: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
+class BackupCheck:
+    path: pathlib.Path
+    state: str
+    free_bytes: int | None
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+@dataclasses.dataclass
+class PlanReport:
+    sections: list[tuple[str, list[str]]] = dataclasses.field(default_factory=list)
+    warnings: list[str] = dataclasses.field(default_factory=list)
+    blockers: list[str] = dataclasses.field(default_factory=list)
+
+    def add_section(self, title: str, lines: Sequence[str]) -> None:
+        self.sections.append((title, list(lines)))
+
+    def render(self) -> str:
+        output: list[str] = []
+        for title, lines in self.sections:
+            output.append(f"== {title} ==")
+            output.extend(lines)
+            output.append("")
+        output.append("== WARNUNGEN ==")
+        output.extend(f"WARNUNG: {item}" for item in self.warnings)
+        if not self.warnings:
+            output.append("keine")
+        output.append("")
+        output.append("== BLOCKER ==")
+        output.extend(f"BLOCKER: {item}" for item in self.blockers)
+        if not self.blockers:
+            output.append("keine")
+        output.append("")
+        output.append("PLAN_BLOCKED" if self.blockers else "PLAN_READY")
+        return "\n".join(output) + "\n"
+
+
+def _expect_table(value: object, context: str) -> Mapping[str, object]:
+    if not isinstance(value, dict):
+        raise ConfigurationError(f"{context} muss eine TOML-Tabelle sein")
+    return value
+
+
+def _check_keys(
+    table: Mapping[str, object],
+    *,
+    allowed: set[str],
+    required: set[str],
+    context: str,
+    error_type: type[PlannerError] = ConfigurationError,
+) -> None:
+    unknown = sorted(set(table) - allowed)
+    missing = sorted(required - set(table))
+    if unknown:
+        raise error_type(f"{context}: unbekannte Schlüssel: {', '.join(unknown)}")
+    if missing:
+        raise error_type(f"{context}: fehlende Schlüssel: {', '.join(missing)}")
+
+
+def _require_string(value: object, context: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ConfigurationError(f"{context} muss eine Zeichenkette sein")
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ConfigurationError(f"{context} enthält Steuerzeichen")
+    if not allow_empty and not value:
+        raise ConfigurationError(f"{context} darf nicht leer sein")
+    return value
+
+
+def _require_int(value: object, context: str, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ConfigurationError(f"{context} muss eine Ganzzahl sein")
+    if value < minimum:
+        raise ConfigurationError(f"{context} muss mindestens {minimum} sein")
+    return value
+
+
+def _require_bool(value: object, context: str) -> bool:
+    if not isinstance(value, bool):
+        raise ConfigurationError(f"{context} muss true oder false sein")
+    return value
+
+
+def validate_fqdn(value: object) -> str:
+    fqdn = _require_string(value, "provider.fqdn")
+    if fqdn != fqdn.lower():
+        raise ConfigurationError("provider.fqdn muss kleingeschrieben sein")
+    try:
+        fqdn.encode("ascii")
+    except UnicodeEncodeError as exc:
+        raise ConfigurationError("provider.fqdn muss ASCII sein") from exc
+    if any(token in fqdn for token in ("://", "/", ":", "@", "*")):
+        raise ConfigurationError("provider.fqdn darf weder Schema, Port, Pfad, Zugangsdaten noch Wildcard enthalten")
+    if fqdn.endswith(".") or len(fqdn) > 253:
+        raise ConfigurationError("provider.fqdn ist nicht kanonisch")
+    labels = fqdn.split(".")
+    if len(labels) < 2:
+        raise ConfigurationError("provider.fqdn benötigt mindestens zwei Labels")
+    label_re = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+    if any(not label_re.fullmatch(label) for label in labels):
+        raise ConfigurationError("provider.fqdn enthält ein ungültiges Label")
+    try:
+        ipaddress.ip_address(fqdn)
+    except ValueError:
+        return fqdn
+    raise ConfigurationError("provider.fqdn darf keine IP-Adresse sein")
+
+
+def validate_name(value: object, context: str) -> str:
+    name = _require_string(value, context)
+    if not re.fullmatch(r"[a-z][a-z0-9_]{0,62}", name):
+        raise ConfigurationError(
+            f"{context} muss kleingeschrieben, höchstens 63 Zeichen lang und ein PostgreSQL-sicherer Bezeichner sein"
+        )
+    return name
+
+
+def validate_ipv4_interface(value: object) -> ipaddress.IPv4Interface:
+    raw = _require_string(value, "lxc.ipv4_cidr")
+    try:
+        interface = ipaddress.ip_interface(raw)
+    except ValueError as exc:
+        raise ConfigurationError("lxc.ipv4_cidr ist keine gültige Hostadresse mit Präfix") from exc
+    if not isinstance(interface, ipaddress.IPv4Interface):
+        raise ConfigurationError("lxc.ipv4_cidr muss IPv4 verwenden")
+    network = interface.network
+    if interface.ip in (network.network_address, network.broadcast_address):
+        raise ConfigurationError("lxc.ipv4_cidr darf weder Netzwerk- noch Broadcastadresse verwenden")
+    if interface.ip.is_multicast or interface.ip.is_loopback or interface.ip.is_unspecified:
+        raise ConfigurationError("lxc.ipv4_cidr verwendet eine unzulässige Adresse")
+    return interface
+
+
+def validate_gateway(value: object, interface: ipaddress.IPv4Interface) -> ipaddress.IPv4Address:
+    raw = _require_string(value, "lxc.gateway")
+    try:
+        gateway = ipaddress.ip_address(raw)
+    except ValueError as exc:
+        raise ConfigurationError("lxc.gateway ist keine gültige IPv4-Adresse") from exc
+    if not isinstance(gateway, ipaddress.IPv4Address):
+        raise ConfigurationError("lxc.gateway muss IPv4 verwenden")
+    if gateway not in interface.network or gateway in (
+        interface.network.network_address,
+        interface.network.broadcast_address,
+    ):
+        raise ConfigurationError("lxc.gateway muss eine Hostadresse im Netz von lxc.ipv4_cidr sein")
+    if gateway.is_multicast or gateway.is_loopback or gateway.is_unspecified:
+        raise ConfigurationError("lxc.gateway verwendet eine unzulässige Adresse")
+    return gateway
+
+
+def validate_cidrs(value: object, context: str) -> tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]:
+    if not isinstance(value, list):
+        raise ConfigurationError(f"{context} muss eine Liste sein")
+    result: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        raw = _require_string(item, f"{context}[{index}]")
+        try:
+            network = ipaddress.ip_network(raw, strict=True)
+        except ValueError as exc:
+            raise ConfigurationError(f"{context}[{index}] ist keine kanonische CIDR") from exc
+        if raw != str(network):
+            raise ConfigurationError(f"{context}[{index}] ist nicht kanonisch")
+        if network.prefixlen == 0:
+            raise ConfigurationError(f"{context} darf keine globale Freigabe enthalten")
+        if raw in seen:
+            raise ConfigurationError(f"{context} enthält ein Duplikat")
+        seen.add(raw)
+        result.append(network)
+    return tuple(result)
+
+
+def validate_dns_servers(
+    value: object,
+) -> tuple[ipaddress.IPv4Address | ipaddress.IPv6Address, ...]:
+    if not isinstance(value, list):
+        raise ConfigurationError("lxc.dns_servers muss eine Liste sein")
+    result: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    seen: set[str] = set()
+    for index, item in enumerate(value):
+        raw = _require_string(item, f"lxc.dns_servers[{index}]")
+        try:
+            address = ipaddress.ip_address(raw)
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"lxc.dns_servers[{index}] ist keine gültige IP-Adresse"
+            ) from exc
+        if raw != str(address):
+            raise ConfigurationError(f"lxc.dns_servers[{index}] ist nicht kanonisch")
+        if address.is_unspecified or address.is_loopback or address.is_multicast:
+            raise ConfigurationError(
+                f"lxc.dns_servers[{index}] verwendet eine unzulässige Adresse"
+            )
+        if raw in seen:
+            raise ConfigurationError("lxc.dns_servers enthält ein Duplikat")
+        seen.add(raw)
+        result.append(address)
+    return tuple(result)
+
+
+def _read_toml(path: pathlib.Path, error_type: type[PlannerError]) -> Mapping[str, object]:
+    try:
+        info = path.lstat()
+    except FileNotFoundError as exc:
+        raise error_type(f"Datei fehlt: {path}") from exc
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise error_type(f"Datei muss regulär und darf kein Symlink sein: {path}")
+    try:
+        with path.open("rb") as handle:
+            value = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise error_type(f"TOML kann nicht gelesen werden: {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise error_type(f"TOML-Wurzel ist ungültig: {path}")
+    return value
+
+
+def ensure_no_symlink_components(path: pathlib.Path, root: pathlib.Path) -> None:
+    """Reject existing symlinks from the allowed root through the target path."""
+    absolute_path = pathlib.Path(os.path.abspath(path))
+    absolute_root = pathlib.Path(os.path.abspath(root))
+    try:
+        relative = absolute_path.relative_to(absolute_root)
+    except ValueError as exc:
+        raise ConfigurationError(f"Pfad liegt nicht unter {absolute_root}: {absolute_path}") from exc
+    candidates = [absolute_root]
+    current = absolute_root
+    for part in relative.parts:
+        current /= part
+        candidates.append(current)
+    for candidate in candidates:
+        try:
+            info = candidate.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(info.st_mode):
+            raise ConfigurationError(f"Symlink-Komponente ist unzulässig: {candidate}")
+
+
+def load_config(path: pathlib.Path) -> DeploymentConfig:
+    root = _read_toml(path, ConfigurationError)
+    _check_keys(
+        root,
+        allowed={"schema_version", "provider", "lxc", "backup", "allocations"},
+        required={"schema_version", "provider", "lxc", "backup", "allocations"},
+        context="Wurzel",
+    )
+    if _require_int(root["schema_version"], "schema_version") != 1:
+        raise ConfigurationError("schema_version muss 1 sein")
+
+    provider_table = _expect_table(root["provider"], "provider")
+    _check_keys(
+        provider_table,
+        allowed={"provider_instance_id", "hostname", "fqdn", "postgresql_major"},
+        required={"provider_instance_id", "hostname", "fqdn", "postgresql_major"},
+        context="provider",
+    )
+    provider = ProviderConfig(
+        provider_instance_id=_require_string(
+            provider_table["provider_instance_id"], "provider.provider_instance_id"
+        ),
+        hostname=_require_string(provider_table["hostname"], "provider.hostname"),
+        fqdn=validate_fqdn(provider_table["fqdn"]),
+        postgresql_major=_require_int(
+            provider_table["postgresql_major"], "provider.postgresql_major"
+        ),
+    )
+    if provider.provider_instance_id != PROVIDER_INSTANCE_ID:
+        raise ConfigurationError(f"provider.provider_instance_id muss {PROVIDER_INSTANCE_ID} sein")
+    if provider.hostname != PROVIDER_HOSTNAME:
+        raise ConfigurationError(f"provider.hostname muss {PROVIDER_HOSTNAME} sein")
+    if provider.postgresql_major != POSTGRESQL_MAJOR:
+        raise ConfigurationError("provider.postgresql_major muss 18 sein")
+
+    lxc_table = _expect_table(root["lxc"], "lxc")
+    lxc_keys = {
+        "vmid",
+        "storage",
+        "bridge",
+        "ipv4_cidr",
+        "gateway",
+        "dns_servers",
+        "cores",
+        "memory_mib",
+        "swap_mib",
+        "disk_gib",
+    }
+    _check_keys(lxc_table, allowed=lxc_keys, required=lxc_keys, context="lxc")
+    vmid = _require_int(lxc_table["vmid"], "lxc.vmid")
+    if vmid != 0 and not 100 <= vmid <= 999_999_999:
+        raise ConfigurationError("lxc.vmid muss 0 oder eine gültige explizite VMID sein")
+    interface = validate_ipv4_interface(lxc_table["ipv4_cidr"])
+    gateway = validate_gateway(lxc_table["gateway"], interface)
+    lxc = LxcConfig(
+        vmid=vmid,
+        storage=_require_string(lxc_table["storage"], "lxc.storage", allow_empty=True),
+        bridge=_require_string(lxc_table["bridge"], "lxc.bridge", allow_empty=True),
+        ipv4_interface=interface,
+        gateway=gateway,
+        dns_servers=validate_dns_servers(lxc_table["dns_servers"]),
+        cores=_require_int(lxc_table["cores"], "lxc.cores", minimum=1),
+        memory_mib=_require_int(lxc_table["memory_mib"], "lxc.memory_mib", minimum=1),
+        swap_mib=_require_int(lxc_table["swap_mib"], "lxc.swap_mib", minimum=0),
+        disk_gib=_require_int(lxc_table["disk_gib"], "lxc.disk_gib", minimum=1),
+    )
+
+    backup_table = _expect_table(root["backup"], "backup")
+    backup_keys = {"host_root", "minimum_free_gib", "protection_confirmed"}
+    _check_keys(backup_table, allowed=backup_keys, required=backup_keys, context="backup")
+    backup_path = pathlib.Path(_require_string(backup_table["host_root"], "backup.host_root"))
+    if not backup_path.is_absolute():
+        raise ConfigurationError("backup.host_root muss ein absoluter Pfad sein")
+    backup = BackupConfig(
+        host_root=backup_path,
+        minimum_free_gib=_require_int(
+            backup_table["minimum_free_gib"], "backup.minimum_free_gib", minimum=1
+        ),
+        protection_confirmed=_require_bool(
+            backup_table["protection_confirmed"], "backup.protection_confirmed"
+        ),
+    )
+
+    allocation_values = root["allocations"]
+    if not isinstance(allocation_values, list):
+        raise ConfigurationError("allocations muss eine Liste von Tabellen sein")
+    allocations: list[AllocationConfig] = []
+    allocation_keys = {
+        "allocation_id",
+        "database_name",
+        "application_identity",
+        "allowed_client_cidrs",
+    }
+    for index, raw_allocation in enumerate(allocation_values):
+        table = _expect_table(raw_allocation, f"allocations[{index}]")
+        _check_keys(
+            table,
+            allowed=allocation_keys,
+            required=allocation_keys,
+            context=f"allocations[{index}]",
+        )
+        allocations.append(
+            AllocationConfig(
+                allocation_id=_require_string(
+                    table["allocation_id"], f"allocations[{index}].allocation_id"
+                ),
+                database_name=validate_name(
+                    table["database_name"], f"allocations[{index}].database_name"
+                ),
+                application_identity=validate_name(
+                    table["application_identity"],
+                    f"allocations[{index}].application_identity",
+                ),
+                allowed_client_cidrs=validate_cidrs(
+                    table["allowed_client_cidrs"],
+                    f"allocations[{index}].allowed_client_cidrs",
+                ),
+            )
+        )
+    ids = [allocation.allocation_id for allocation in allocations]
+    if len(ids) != len(set(ids)):
+        raise ConfigurationError("allocations enthält eine doppelte allocation_id")
+    if set(ids) != set(EXPECTED_ALLOCATIONS) or len(ids) != len(EXPECTED_ALLOCATIONS):
+        raise ConfigurationError(
+            "allocations muss exakt gitea, openbao, semaphore und nodered enthalten"
+        )
+    database_names = [allocation.database_name for allocation in allocations]
+    identities = [allocation.application_identity for allocation in allocations]
+    if len(database_names) != len(set(database_names)):
+        raise ConfigurationError("database_name muss pro Allocation eindeutig sein")
+    if len(identities) != len(set(identities)):
+        raise ConfigurationError("application_identity muss pro Allocation eindeutig sein")
+    allocations.sort(key=lambda item: EXPECTED_ALLOCATIONS.index(item.allocation_id))
+    return DeploymentConfig(provider=provider, lxc=lxc, backup=backup, allocations=tuple(allocations))
+
+
+def load_version_matrix(path: pathlib.Path = VERSION_MATRIX_PATH) -> VersionMatrix:
+    root = _read_toml(path, MatrixError)
+    expected_sections = {
+        "schema_version",
+        "checked_at",
+        "postgresql",
+        "gitea",
+        "openbao",
+        "semaphore",
+        "nodered",
+    }
+    _check_keys(
+        root,
+        allowed=expected_sections,
+        required=expected_sections,
+        context="Versionsmatrix",
+        error_type=MatrixError,
+    )
+    if root["schema_version"] != 1:
+        raise MatrixError("Versionsmatrix: schema_version muss 1 sein")
+    checked = root["checked_at"]
+    if isinstance(checked, dt.date):
+        checked_at = checked.isoformat()
+    elif isinstance(checked, str) and re.fullmatch(r"\d{4}-\d{2}-\d{2}", checked):
+        checked_at = checked
+    else:
+        raise MatrixError("Versionsmatrix: checked_at ist ungültig")
+
+    specs: dict[str, tuple[set[str], Mapping[str, object]]] = {}
+    for name in ("postgresql", "gitea", "openbao", "semaphore", "nodered"):
+        value = root[name]
+        if not isinstance(value, dict):
+            raise MatrixError(f"Versionsmatrix: {name} muss eine Tabelle sein")
+        specs[name] = (set(value), value)
+    expected_keys = {
+        "postgresql": {"major", "documented_minor", "package", "update_policy"},
+        "gitea": {"version", "postgresql_requirement"},
+        "openbao": {"version", "postgresql_requirement", "storage_backend"},
+        "semaphore": {"version", "database_backend"},
+        "nodered": {"version", "nodejs_reference", "database_usage"},
+    }
+    for name, (keys, _value) in specs.items():
+        if keys != expected_keys[name]:
+            raise MatrixError(f"Versionsmatrix: unerwartete Schlüssel in {name}")
+    postgresql = specs["postgresql"][1]
+    if postgresql != {
+        "major": 18,
+        "documented_minor": "18.4",
+        "package": "postgresql-18",
+        "update_policy": "latest-stable-18.x",
+    }:
+        raise MatrixError("Versionsmatrix: PostgreSQL-Referenzstand ist unerwartet")
+    application_expected = {
+        "gitea": {"version": "1.27.1", "postgresql_requirement": ">=12"},
+        "openbao": {
+            "version": "2.6.1",
+            "postgresql_requirement": ">=9.5",
+            "storage_backend": "postgresql",
+        },
+        "semaphore": {"version": "2.18.29", "database_backend": "postgres"},
+        "nodered": {
+            "version": "5.0.4",
+            "nodejs_reference": "24",
+            "database_usage": "flow_application_data_only",
+        },
+    }
+    applications: dict[str, Mapping[str, str]] = {}
+    for name, expected in application_expected.items():
+        actual = specs[name][1]
+        if actual != expected:
+            raise MatrixError(f"Versionsmatrix: Referenzstand für {name} ist unerwartet")
+        applications[name] = {key: str(value) for key, value in actual.items()}
+    return VersionMatrix(
+        checked_at=checked_at,
+        postgresql=postgresql,
+        applications=applications,
+    )
+
+
+def _allowed_command(arguments: Sequence[str]) -> bool:
+    args = tuple(arguments)
+    if args == ("pveversion",):
+        return True
+    if args == ("pct", "list"):
+        return True
+    if len(args) == 3 and args[:2] in {
+        ("pct", "status"),
+        ("pct", "config"),
+        ("pct", "pending"),
+    } and args[2].isdigit():
+        return True
+    if args == ("pvesm", "status", "--content", "rootdir"):
+        return True
+    if args in {
+        ("ip", "link", "show", "type", "bridge"),
+        ("ip", "address", "show"),
+        ("ip", "route", "show"),
+        ("pveam", "available", "--section", "system"),
+    }:
+        return True
+    return False
+
+
+class CommandRunner:
+    """Execute only explicitly allowlisted, read-only host probes."""
+
+    def __init__(
+        self,
+        executor: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        self._executor = executor
+
+    def run(self, arguments: Sequence[str]) -> CommandResult:
+        args = list(arguments)
+        if not _allowed_command(args):
+            raise ProbeError(f"nicht erlaubter externer Aufruf: {' '.join(args)}")
+        try:
+            completed = self._executor(
+                args,
+                check=False,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=COMMAND_TIMEOUT_SECONDS,
+                env={"PATH": "/usr/sbin:/usr/bin:/sbin:/bin", "LC_ALL": "C"},
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ProbeError(f"read-only Aufruf fehlgeschlagen: {' '.join(args)}: {exc}") from exc
+        stdout = completed.stdout or ""
+        stderr = completed.stderr or ""
+        if len(stdout.encode()) > OUTPUT_LIMIT or len(stderr.encode()) > OUTPUT_LIMIT:
+            raise ProbeError(f"read-only Aufruf lieferte zu viel Ausgabe: {' '.join(args)}")
+        if completed.returncode != 0:
+            diagnostic = " ".join(stderr.strip().split())[:500]
+            raise ProbeError(
+                f"read-only Aufruf meldete Fehler: {' '.join(args)}"
+                + (f": {diagnostic}" if diagnostic else "")
+            )
+        return CommandResult(stdout=stdout, stderr=stderr, returncode=completed.returncode)
+
+
+def _parse_pct_ids(output: str) -> set[int]:
+    result: set[int] = set()
+    for line in output.splitlines():
+        fields = line.split()
+        if fields and fields[0].isdigit():
+            result.add(int(fields[0]))
+    return result
+
+
+def _parse_size(value: str) -> int:
+    if value.isdigit():
+        return int(value)
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)([KMGT])", value, re.IGNORECASE)
+    if not match:
+        raise ValueError(value)
+    units = {"K": 1, "M": 2, "G": 3, "T": 4}
+    return int(float(match.group(1)) * (1024 ** units[match.group(2).upper()]))
+
+
+def _parse_storages(output: str) -> list[StorageInfo]:
+    result: list[StorageInfo] = []
+    for line in output.splitlines():
+        fields = line.split()
+        if not fields or fields[0].lower() == "name" or len(fields) < 6:
+            continue
+        try:
+            available = _parse_size(fields[5])
+        except ValueError:
+            continue
+        result.append(StorageInfo(name=fields[0], status=fields[2], available_bytes=available))
+    return result
+
+
+def _parse_bridges(output: str) -> list[str]:
+    result: list[str] = []
+    for line in output.splitlines():
+        match = re.match(r"^\d+:\s+([^:@]+)(?:@[^:]+)?:", line.strip())
+        if match:
+            result.append(match.group(1))
+    return sorted(set(result))
+
+
+def _parse_templates(output: str) -> list[str]:
+    candidates: list[str] = []
+    for line in output.splitlines():
+        for field in line.split():
+            lowered = field.lower()
+            if "ubuntu-26.04" in lowered and "amd64" in lowered:
+                candidates.append(field)
+    return sorted(set(candidates))
+
+
+def _next_free_vmid(used: set[int]) -> int:
+    vmid = 100
+    while vmid in used:
+        vmid += 1
+    return vmid
+
+
+def collect_proxmox_state(config: DeploymentConfig, runner: CommandRunner) -> ProxmoxState:
+    state = ProxmoxState()
+
+    def probe(arguments: Sequence[str], label: str) -> str | None:
+        try:
+            return runner.run(arguments).stdout
+        except ProbeError as exc:
+            state.blockers.append(f"{label}: {exc}")
+            return None
+
+    pve_version = probe(["pveversion"], "Proxmox-Version nicht lesbar")
+    if pve_version is not None:
+        state.pve_version = " ".join(pve_version.strip().split()) or "unbekannt"
+
+    pct_output = probe(["pct", "list"], "Containerliste nicht lesbar")
+    used_ids = _parse_pct_ids(pct_output or "")
+    if config.lxc.vmid == 0:
+        if pct_output is None:
+            state.blockers.append("VMID 0 kann ohne lesbare Containerliste nicht aufgelöst werden")
+        else:
+            state.vmid = _next_free_vmid(used_ids)
+            state.vmid_source = "read-only aus pct list ermittelt"
+    else:
+        state.vmid = config.lxc.vmid
+        state.vmid_source = "explizite Konfiguration"
+        if config.lxc.vmid in used_ids:
+            state.blockers.append(f"VMID {config.lxc.vmid} ist bereits durch einen LXC belegt")
+            for action in ("status", "config", "pending"):
+                probe(
+                    ["pct", action, str(config.lxc.vmid)],
+                    f"Belegungsdiagnose pct {action} fehlgeschlagen",
+                )
+
+    storage_output = probe(
+        ["pvesm", "status", "--content", "rootdir"],
+        "Storagezustand nicht lesbar",
+    )
+    storages = [item for item in _parse_storages(storage_output or "") if item.status == "active"]
+    selected_storage: StorageInfo | None = None
+    if config.lxc.storage:
+        state.storage_source = "explizite Konfiguration"
+        selected_storage = next((item for item in storages if item.name == config.lxc.storage), None)
+        if selected_storage is None:
+            state.blockers.append(f"konfiguriertes Storage {config.lxc.storage} ist nicht als aktives rootdir-Storage verfügbar")
+    elif len(storages) == 1:
+        selected_storage = storages[0]
+        state.storage_source = "eindeutig read-only ermittelt"
+    elif not storages:
+        state.blockers.append("kein geeignetes aktives rootdir-Storage gefunden")
+    else:
+        state.blockers.append(
+            "Storage ist mehrdeutig; explizite Auswahl erforderlich: "
+            + ", ".join(item.name for item in storages)
+        )
+    if selected_storage is not None:
+        state.storage = selected_storage.name
+        state.storage_available_bytes = selected_storage.available_bytes
+        required = config.lxc.disk_gib * 1024**3
+        if selected_storage.available_bytes < required:
+            state.blockers.append(
+                f"Storage {selected_storage.name} besitzt weniger freien Speicher als die geplanten {config.lxc.disk_gib} GiB"
+            )
+
+    bridge_output = probe(["ip", "link", "show", "type", "bridge"], "Bridges nicht lesbar")
+    bridges = _parse_bridges(bridge_output or "")
+    if config.lxc.bridge:
+        state.bridge_source = "explizite Konfiguration"
+        if config.lxc.bridge in bridges:
+            state.bridge = config.lxc.bridge
+        else:
+            state.blockers.append(f"konfigurierte Bridge {config.lxc.bridge} ist nicht vorhanden")
+    elif len(bridges) == 1:
+        state.bridge = bridges[0]
+        state.bridge_source = "eindeutig read-only ermittelt"
+    elif not bridges:
+        state.blockers.append("keine geeignete Bridge gefunden")
+    else:
+        state.blockers.append("Bridge ist mehrdeutig; explizite Auswahl erforderlich: " + ", ".join(bridges))
+
+    address_output = probe(["ip", "address", "show"], "Hostadressen nicht lesbar")
+    if address_output is not None:
+        state.host_addresses_checked = True
+        address_pattern = re.compile(rf"\binet\s+{re.escape(str(config.lxc.ipv4_interface.ip))}/")
+        if address_pattern.search(address_output):
+            state.blockers.append(
+                f"Provideradresse {config.lxc.ipv4_interface.ip} ist bereits auf dem Proxmox-Host konfiguriert"
+            )
+    route_output = probe(["ip", "route", "show"], "Hostrouten nicht lesbar")
+    if route_output is not None:
+        state.host_routes_checked = True
+
+    template_output = probe(
+        ["pveam", "available", "--section", "system"],
+        "Templatekatalog nicht lesbar",
+    )
+    templates = _parse_templates(template_output or "")
+    if len(templates) == 1:
+        state.template = templates[0]
+    elif not templates:
+        state.blockers.append("kein eindeutiges Ubuntu-26.04-amd64-Template gefunden")
+    else:
+        state.blockers.append("Ubuntu-26.04-amd64-Template ist mehrdeutig: " + ", ".join(templates))
+
+    if config.lxc.cores < REFERENCE_CORES:
+        state.warnings.append(
+            f"{config.lxc.cores} vCPU liegen unter dem Referenzprofil von {REFERENCE_CORES} vCPU"
+        )
+    if config.lxc.memory_mib < REFERENCE_MEMORY_MIB:
+        state.warnings.append(
+            f"{config.lxc.memory_mib} MiB RAM liegen unter dem Referenzprofil von {REFERENCE_MEMORY_MIB} MiB"
+        )
+    if config.lxc.disk_gib < REFERENCE_DISK_GIB:
+        state.warnings.append(
+            f"{config.lxc.disk_gib} GiB Root-Disk liegen unter dem Referenzprofil von {REFERENCE_DISK_GIB} GiB"
+        )
+    return state
+
+
+def _path_under(path: pathlib.Path, root: pathlib.Path) -> bool:
+    try:
+        path.resolve(strict=False).relative_to(root.resolve(strict=False))
+        return True
+    except ValueError:
+        return False
+
+
+def inspect_path(
+    path: pathlib.Path,
+    *,
+    kind: str,
+    expected_mode: int,
+    require_nonempty: bool,
+    lstat_function: Callable[[pathlib.Path], os.stat_result] = os.lstat,
+) -> PathCheck:
+    try:
+        info = lstat_function(path)
+    except FileNotFoundError:
+        return PathCheck(path=path, state="FEHLT_GEPLANT", metadata="nicht vorhanden")
+    mode = stat.S_IMODE(info.st_mode)
+    metadata = f"uid={info.st_uid} gid={info.st_gid} mode={mode:04o}"
+    if stat.S_ISLNK(info.st_mode):
+        return PathCheck(path, "KONFLIKT", metadata, "Symlink ist unzulässig")
+    if kind == "directory" and not stat.S_ISDIR(info.st_mode):
+        return PathCheck(path, "KONFLIKT", metadata, "erwartetes Verzeichnis ist nicht vorhanden")
+    if kind == "file" and not stat.S_ISREG(info.st_mode):
+        return PathCheck(path, "KONFLIKT", metadata, "erwartete reguläre Datei ist nicht vorhanden")
+    if info.st_uid != 0 or info.st_gid != 0:
+        return PathCheck(path, "KONFLIKT", metadata, "Eigentümer muss root:root sein")
+    if mode != expected_mode:
+        return PathCheck(
+            path,
+            "KONFLIKT",
+            metadata,
+            f"Modus muss {expected_mode:04o} sein",
+        )
+    if require_nonempty and info.st_size == 0:
+        return PathCheck(path, "KONFLIKT", metadata, "Datei darf nicht leer sein")
+    return PathCheck(path=path, state="OK", metadata=metadata)
+
+
+def inspect_secret_contract() -> tuple[PathCheck, ...]:
+    checks: list[PathCheck] = []
+    directories = [
+        SECRET_ROOT,
+        SECRET_ROOT / "database-service",
+        SECRET_ROOT / "database-service/providers",
+        PROVIDER_SECRET_ROOT,
+        PROVIDER_SECRET_ROOT / "pki",
+        ALLOCATION_SECRET_ROOT,
+        *(ALLOCATION_SECRET_ROOT / allocation for allocation in EXPECTED_ALLOCATIONS),
+    ]
+    for path in directories:
+        checks.append(
+            inspect_path(
+                path,
+                kind="directory",
+                expected_mode=0o700,
+                require_nonempty=False,
+            )
+        )
+    checks.append(
+        inspect_path(
+            REAL_CONFIG_PATH,
+            kind="file",
+            expected_mode=0o600,
+            require_nonempty=True,
+        )
+    )
+    secret_files = [
+        PROVIDER_SECRET_ROOT / "administrative-password",
+        *(ALLOCATION_SECRET_ROOT / allocation / "application-password" for allocation in EXPECTED_ALLOCATIONS),
+        PROVIDER_SECRET_ROOT / "pki/ca.key",
+        PROVIDER_SECRET_ROOT / "pki/server.key",
+    ]
+    public_files = [
+        PROVIDER_SECRET_ROOT / "pki/ca.crt",
+        PROVIDER_SECRET_ROOT / "pki/server.crt",
+    ]
+    for path in secret_files:
+        checks.append(
+            inspect_path(path, kind="file", expected_mode=0o600, require_nonempty=True)
+        )
+    for path in public_files:
+        checks.append(
+            inspect_path(path, kind="file", expected_mode=0o644, require_nonempty=True)
+        )
+    return tuple(checks)
+
+
+def inspect_backup_target(config: BackupConfig, repo_root: pathlib.Path = REPO_ROOT) -> BackupCheck:
+    path = config.host_root
+    blockers: list[str] = []
+    warnings: list[str] = []
+    if _path_under(path, SECRET_ROOT):
+        blockers.append("Backupziel darf nicht unter /secrets liegen")
+    if _path_under(path, repo_root):
+        blockers.append("Backupziel darf nicht im Git-Repository liegen")
+    for forbidden_root in (pathlib.Path("/var/lib/lxc"), pathlib.Path("/var/lib/vz/private")):
+        if _path_under(path, forbidden_root):
+            blockers.append("Backupziel darf nicht innerhalb eines LXC-Dateisystems liegen")
+    try:
+        info = path.lstat()
+    except FileNotFoundError:
+        blockers.append(f"Backupziel fehlt: {path}")
+        return BackupCheck(path, "KONFLIKT", None, tuple(blockers), tuple(warnings))
+    if stat.S_ISLNK(info.st_mode):
+        blockers.append("Backupziel darf kein Symlink sein")
+    elif not stat.S_ISDIR(info.st_mode):
+        blockers.append("Backupziel muss ein Verzeichnis sein")
+    if not os.access(path, os.W_OK):
+        blockers.append("Backupziel ist für den späteren Root-Prozess nicht schreibbar")
+    free_bytes: int | None = None
+    if not blockers or stat.S_ISDIR(info.st_mode):
+        try:
+            free_bytes = shutil.disk_usage(path).free
+        except OSError as exc:
+            blockers.append(f"freier Speicher des Backupziels ist nicht lesbar: {exc}")
+    if free_bytes is not None and free_bytes < config.minimum_free_gib * 1024**3:
+        blockers.append(
+            f"Backupziel besitzt weniger als die konfigurierten {config.minimum_free_gib} GiB freien Speicher"
+        )
+    if not config.protection_confirmed:
+        blockers.append("Schutz oder Verschlüsselung des Backupziels ist nicht bestätigt")
+    return BackupCheck(
+        path=path,
+        state="OK" if not blockers else "KONFLIKT",
+        free_bytes=free_bytes,
+        blockers=tuple(blockers),
+        warnings=tuple(warnings),
+    )
+
+
+def read_git_commit(repo_root: pathlib.Path = REPO_ROOT) -> str:
+    git_entry = repo_root / ".git"
+    if git_entry.is_file():
+        content = git_entry.read_text(encoding="utf-8").strip()
+        if not content.startswith("gitdir: "):
+            return "unbekannt"
+        git_dir = (repo_root / content.removeprefix("gitdir: ")).resolve()
+    else:
+        git_dir = git_entry
+    try:
+        head = (git_dir / "HEAD").read_text(encoding="ascii").strip()
+    except OSError:
+        return "unbekannt"
+    if re.fullmatch(r"[0-9a-f]{40}", head):
+        return head
+    if not head.startswith("ref: "):
+        return "unbekannt"
+    reference = head.removeprefix("ref: ")
+    ref_path = git_dir / reference
+    try:
+        value = ref_path.read_text(encoding="ascii").strip()
+        if re.fullmatch(r"[0-9a-f]{40}", value):
+            return value
+    except OSError:
+        pass
+    try:
+        packed = (git_dir / "packed-refs").read_text(encoding="ascii")
+    except OSError:
+        return "unbekannt"
+    for line in packed.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and fields[1] == reference and re.fullmatch(r"[0-9a-f]{40}", fields[0]):
+            return fields[0]
+    return "unbekannt"
+
+
+def _format_bytes(value: int | None) -> str:
+    if value is None:
+        return "unbekannt"
+    return f"{value / 1024**3:.1f} GiB"
+
+
+def build_plan(
+    config: DeploymentConfig,
+    matrix: VersionMatrix,
+    proxmox: ProxmoxState,
+    secret_checks: Sequence[PathCheck],
+    backup: BackupCheck,
+    git_commit: str,
+) -> PlanReport:
+    report = PlanReport()
+    report.warnings.extend(proxmox.warnings)
+    report.blockers.extend(proxmox.blockers)
+    report.warnings.extend(backup.warnings)
+    report.blockers.extend(backup.blockers)
+    for check in secret_checks:
+        if check.conflict:
+            report.blockers.append(f"{check.path}: {check.conflict}")
+    for allocation in config.allocations:
+        if not allocation.allowed_client_cidrs:
+            report.blockers.append(
+                f"Allocation {allocation.allocation_id}: leere Client-Allowlist blockiert Remote-Readiness"
+            )
+    if not config.lxc.dns_servers:
+        report.blockers.append(
+            "lxc.dns_servers ist leer; der Planer errät keinen deployment-spezifischen DNS-Server"
+        )
+
+    report.add_section(
+        "REPOSITORY UND MATRIX",
+        [
+            f"Git-Commit: {git_commit}",
+            f"Matrix-Stichtag: {matrix.checked_at}",
+            "PostgreSQL: Major 18, initial dokumentiert 18.4, Policy latest-stable-18.x",
+            "Gitea: 1.27.1, PostgreSQL-Anforderung >=12",
+            "OpenBao: 2.6.1, PostgreSQL-Anforderung >=9.5, Storage postgresql",
+            "Semaphore UI: 2.18.29, Datenbankbackend postgres, keine hier festgelegte Maximalversion",
+            "Node-RED: 5.0.4, Node.js-Referenz 24, Nutzung flow_application_data_only",
+            "Matrix ist offline und führt keine Onlineprüfung oder Installation aus.",
+        ],
+    )
+    report.add_section(
+        "PROXMOX",
+        [
+            f"Plattformstatus: {proxmox.pve_version}",
+            f"VMID: {proxmox.vmid if proxmox.vmid is not None else 'unaufgelöst'} ({proxmox.vmid_source})",
+            "Hostname: postgresql-main",
+            f"Template: {proxmox.template or 'unaufgelöst'}",
+            f"Storage: {proxmox.storage or 'unaufgelöst'} ({proxmox.storage_source})",
+            f"Storage frei: {_format_bytes(proxmox.storage_available_bytes)}",
+            f"Bridge: {proxmox.bridge or 'unaufgelöst'} ({proxmox.bridge_source})",
+            f"Ressourcen: {config.lxc.cores} vCPU, {config.lxc.memory_mib} MiB RAM, {config.lxc.swap_mib} MiB Swap, {config.lxc.disk_gib} GiB Root-Disk",
+            "Betriebsform: eigener unprivilegierter Ubuntu-26.04-LTS-LXC, amd64/x86_64, nesting aktiviert",
+            "Docker/Podman: nicht verwendet",
+        ],
+    )
+    report.add_section(
+        "NETZWERK",
+        [
+            f"Provider-IP: {config.lxc.ipv4_interface}",
+            f"FQDN: {config.provider.fqdn}",
+            f"Gateway: {config.lxc.gateway}",
+            "DNS-Server: "
+            + (", ".join(map(str, config.lxc.dns_servers)) or "LEER / BLOCKER"),
+            f"Listenerziel: {config.lxc.ipv4_interface.ip} (kein 0.0.0.0)",
+            "Keine ungefragte Netzwerkerkennung oder Erreichbarkeitsprobe.",
+            *(
+                f"{allocation.allocation_id} Client-Allowlist: "
+                + (", ".join(map(str, allocation.allowed_client_cidrs)) or "LEER")
+                for allocation in config.allocations
+            ),
+        ],
+    )
+    report.add_section(
+        "POSTGRESQL-ZIELVERTRAG",
+        [
+            "Paketquelle: offizielle Ubuntu-26.04-Quellen; keine PGDG-Quelle",
+            "Paket: postgresql-18",
+            "Version: aktuelle stabile 18.x-Version; kein automatischer Wechsel auf PostgreSQL 19",
+            "Paketverfügbarkeit: vor Installation gegen die offiziellen Ubuntu-Quellen erneut prüfen",
+            "Administration: lokal über Unix-Socket und Peer-Authentifizierung",
+            "Superuser: kein gespeichertes Standardkennwort und keine Remote-Anmeldung",
+            "password_encryption: scram-sha-256",
+            "Remotezugriff: ausschließlich TLS, konkrete Provideradresse und allocation-eigene hostssl-Regeln",
+            "Authentifizierung: ausschließlich scram-sha-256",
+            "Anwendungsrechte: LOGIN, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, NOREPLICATION",
+            "application_managed: Objekterzeugung ausschließlich in der eigenen logischen Datenbank",
+            "PUBLIC: keine Consumer-übergreifenden Anwendungsobjekte; Detailkonfiguration folgt separat",
+            f"TLS-Anforderung: Serverzertifikat muss {config.provider.fqdn} enthalten",
+            "TLS-CA: dediziert, nicht öffentliches ACME, Erzeugung nur nach eigener Freigabe",
+            "Kein automatischer Zugriff auf OPNsense.",
+        ],
+    )
+
+    allocation_lines: list[str] = []
+    for allocation in config.allocations:
+        application = matrix.applications[allocation.allocation_id]
+        version = application["version"]
+        secret_path = ALLOCATION_SECRET_ROOT / allocation.allocation_id / "application-password"
+        backup_path = backup.path / PROVIDER_INSTANCE_ID / allocation.allocation_id
+        allocation_lines.extend(
+            [
+                f"[{allocation.allocation_id}]",
+                f"  Datenbankname: {allocation.database_name}",
+                f"  Anwendungsversion: {version}",
+                f"  Anwendungsidentität: {allocation.application_identity}",
+                "  Schema-Lebenszyklus: application_managed",
+                "  Client-Allowlist: "
+                + (", ".join(map(str, allocation.allowed_client_cidrs)) or "LEER / BLOCKER"),
+                f"  Secret-Referenz: {secret_path}",
+                f"  Backupziel geplant: {backup_path}",
+            ]
+        )
+        if allocation.allocation_id == "openbao":
+            allocation_lines.append(
+                "  Hinweis: PostgreSQL ist deployment-spezifisch gewählt; Sensitivität hoch; dedizierte Instanz bleibt möglich."
+            )
+        if allocation.allocation_id == "nodered":
+            allocation_lines.append(
+                "  Hinweis: nur relationale Flow-Anwendungsdaten; kein interner Node-RED-Storage, keine Flowdateien, Credentials oder Context."
+            )
+            allocation_lines.append(
+                "  Folgeentscheidung: konkreten PostgreSQL-Node oder eigenen Flow-Vertrag auswählen."
+            )
+    report.add_section("ALLOCATIONS", allocation_lines)
+
+    secret_lines = [
+        "Der Planer liest keine Secretwerte und gibt keine Inhalts-Hashes aus.",
+        "Zielmetadaten: Verzeichnisse root:root 0700, Passwortdateien und private Schlüssel root:root 0600.",
+        "Temporärer späterer Transfer: /run/ralf-database-provision auf tmpfs, root:root 0700; Dateien 0600; sofortige Entfernung.",
+    ]
+    secret_lines.extend(
+        f"{check.path}: {check.state}; {check.metadata}" for check in secret_checks
+    )
+    report.add_section("SECRETS UND TLS-METADATEN", secret_lines)
+
+    report.add_section(
+        "BACKUP",
+        [
+            f"Host-Root: {backup.path}",
+            f"Status: {backup.state}",
+            f"Freier Speicher: {_format_bytes(backup.free_bytes)}",
+            f"Konfiguriertes Minimum: {config.backup.minimum_free_gib} GiB",
+            f"Schutz bestätigt: {'ja' if config.backup.protection_confirmed else 'nein'}",
+            "Format: logisches PostgreSQL-Custom-Format pro Allocation (pg_dump --format=custom)",
+            "Transport: später vom LXC zum Proxmox-Host streamen; kein dauerhafter Backup-Mount im LXC",
+            "Zieldateien: root:root 0600",
+            "Keine automatische Retention oder Löschung in diesem Schritt.",
+        ],
+    )
+    report.add_section("GEPLANTE SPÄTERE MUTATIONEN", list(MUTATION_PLAN))
+    report.add_section("AUSDRÜCKLICH NICHT ENTHALTEN", list(EXCLUDED_SCOPE))
+    return report
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only Deploymentplaner für postgresql-main"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    plan = subparsers.add_parser("plan", help="read-only Plan erzeugen")
+    plan.add_argument("--config", required=True, type=pathlib.Path)
+    return parser
+
+
+def run_plan(
+    config_path: pathlib.Path,
+    *,
+    runner: CommandRunner | None = None,
+    require_real_path: bool = True,
+    matrix_path: pathlib.Path = VERSION_MATRIX_PATH,
+) -> tuple[int, str]:
+    if require_real_path and config_path.absolute() != REAL_CONFIG_PATH:
+        raise ConfigurationError(
+            f"reale Deploymentkonfiguration muss exakt {REAL_CONFIG_PATH} sein; das Repository-Beispiel wird nicht verwendet"
+        )
+    if require_real_path:
+        ensure_no_symlink_components(config_path, SECRET_ROOT)
+    config = load_config(config_path)
+    matrix = load_version_matrix(matrix_path)
+    proxmox = collect_proxmox_state(config, runner or CommandRunner())
+    secrets = inspect_secret_contract()
+    backup = inspect_backup_target(config.backup)
+    report = build_plan(config, matrix, proxmox, secrets, backup, read_git_commit())
+    rendered = report.render()
+    return (3 if report.blockers else 0), rendered
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = create_parser()
+    args = parser.parse_args(argv)
+    if args.command != "plan":
+        parser.error("nur der read-only Modus plan ist verfügbar")
+    try:
+        code, output = run_plan(args.config)
+    except PlannerError as exc:
+        print(f"PLAN_ERROR: {exc}", file=sys.stderr)
+        return 2
+    print(output, end="")
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_postgresql_main_plan.py
+++ b/tests/test_postgresql_main_plan.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+import builtins
+import importlib.util
+import io
+import os
+import pathlib
+import stat
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stderr
+from unittest import mock
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parents[1] / "scripts/postgresql-main-plan.py"
+SPEC = importlib.util.spec_from_file_location("postgresql_main_plan", SCRIPT)
+assert SPEC and SPEC.loader
+planner = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = planner
+SPEC.loader.exec_module(planner)
+
+
+def allocation_block(allocation_id: str, allowed: str = '"10.20.0.0/16"') -> str:
+    return f'''[[allocations]]
+allocation_id = "{allocation_id}"
+database_name = "{allocation_id}"
+application_identity = "{allocation_id}"
+allowed_client_cidrs = [{allowed}]
+'''
+
+
+def config_text(
+    backup_root: pathlib.Path,
+    *,
+    vmid: int = 200,
+    storage: str = "local-lvm",
+    bridge: str = "vmbr0",
+    fqdn: str = "postgresql-main.example.internal",
+    ipv4_cidr: str = "10.10.0.10/24",
+    gateway: str = "10.10.0.1",
+    major: int = 18,
+    provider_id: str = "postgresql-main",
+    allocations: tuple[str, ...] = planner.EXPECTED_ALLOCATIONS,
+    allowed: str = '"10.20.0.0/16"',
+    extra: str = "",
+    protection_confirmed: bool = True,
+) -> str:
+    allocation_text = "\n".join(allocation_block(item, allowed) for item in allocations)
+    protected = "true" if protection_confirmed else "false"
+    return f'''schema_version = 1
+{extra}
+[provider]
+provider_instance_id = "{provider_id}"
+hostname = "postgresql-main"
+fqdn = "{fqdn}"
+postgresql_major = {major}
+
+[lxc]
+vmid = {vmid}
+storage = "{storage}"
+bridge = "{bridge}"
+ipv4_cidr = "{ipv4_cidr}"
+gateway = "{gateway}"
+dns_servers = ["10.10.0.53"]
+cores = 4
+memory_mib = 8192
+swap_mib = 2048
+disk_gib = 100
+
+[backup]
+host_root = "{backup_root}"
+minimum_free_gib = 1
+protection_confirmed = {protected}
+
+{allocation_text}
+'''
+
+
+class FakeRunner:
+    def __init__(self, overrides: dict[tuple[str, ...], str] | None = None) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.outputs = {
+            ("pveversion",): "pve-manager/9.0/test\n",
+            ("pct", "list"): "VMID Status Lock Name\n",
+            (
+                "pvesm",
+                "status",
+                "--content",
+                "rootdir",
+            ): "Name Type Status Total Used Available %\nlocal-lvm lvmthin active 300000000000 100000000000 200000000000 33%\n",
+            ("ip", "link", "show", "type", "bridge"): "2: vmbr0: <BROADCAST,UP> mtu 1500 state UP\n",
+            ("ip", "address", "show"): "1: lo: <LOOPBACK>\n    inet 127.0.0.1/8 scope host lo\n",
+            ("ip", "route", "show"): "default via 10.10.0.1 dev vmbr0\n",
+            (
+                "pveam",
+                "available",
+                "--section",
+                "system",
+            ): "system ubuntu-26.04-standard_26.04-1_amd64.tar.zst\n",
+            ("pct", "status", "200"): "status: running\n",
+            ("pct", "config", "200"): "hostname: existing\n",
+            ("pct", "pending", "200"): "\n",
+        }
+        if overrides:
+            self.outputs.update(overrides)
+
+    def run(self, arguments):
+        key = tuple(arguments)
+        self.calls.append(key)
+        if key not in self.outputs:
+            raise planner.ProbeError(f"missing fake output for {key}")
+        return planner.CommandResult(self.outputs[key], "", 0)
+
+
+class PlannerTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.temporary.name)
+        self.backup = self.root / "backup"
+        self.backup.mkdir()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_config(self, text: str | None = None) -> pathlib.Path:
+        path = self.root / "deployment.toml"
+        path.write_text(text or config_text(self.backup), encoding="utf-8")
+        return path
+
+    def load(self, **kwargs):
+        return planner.load_config(self.write_config(config_text(self.backup, **kwargs)))
+
+
+class ConfigurationTests(PlannerTestCase):
+    def test_valid_complete_configuration(self) -> None:
+        config = self.load()
+        self.assertEqual(config.provider.provider_instance_id, "postgresql-main")
+        self.assertEqual([item.allocation_id for item in config.allocations], list(planner.EXPECTED_ALLOCATIONS))
+
+    def test_missing_configuration(self) -> None:
+        with self.assertRaises(planner.ConfigurationError):
+            planner.load_config(self.root / "missing.toml")
+
+    def test_repository_example_is_never_automatic(self) -> None:
+        with self.assertRaises(planner.ConfigurationError) as context:
+            planner.run_plan(self.write_config(), runner=FakeRunner(), require_real_path=True)
+        self.assertIn(str(planner.REAL_CONFIG_PATH), str(context.exception))
+        self.assertNotEqual(planner.EXAMPLE_CONFIG_PATH, planner.REAL_CONFIG_PATH)
+
+    def test_unknown_key(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "unbekannte Schlüssel"):
+            planner.load_config(self.write_config(config_text(self.backup, extra="surprise = true")))
+
+    def test_wrong_schema_version(self) -> None:
+        text = config_text(self.backup).replace("schema_version = 1", "schema_version = 2")
+        with self.assertRaisesRegex(planner.ConfigurationError, "schema_version muss 1"):
+            planner.load_config(self.write_config(text))
+
+    def test_wrong_postgresql_major(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "postgresql_major muss 18"):
+            self.load(major=19)
+
+    def test_wrong_provider_id(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "provider_instance_id"):
+            self.load(provider_id="other")
+
+    def test_missing_allocation(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "muss exakt"):
+            self.load(allocations=("gitea", "openbao", "semaphore"))
+
+    def test_additional_allocation(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "muss exakt"):
+            self.load(allocations=(*planner.EXPECTED_ALLOCATIONS, "extra"))
+
+    def test_duplicate_allocation(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "doppelte"):
+            self.load(allocations=("gitea", "openbao", "semaphore", "nodered", "gitea"))
+
+    def test_invalid_database_name(self) -> None:
+        text = config_text(self.backup).replace('database_name = "gitea"', 'database_name = "Bad-Name"')
+        with self.assertRaisesRegex(planner.ConfigurationError, "database_name"):
+            planner.load_config(self.write_config(text))
+
+    def test_invalid_identity_name(self) -> None:
+        text = config_text(self.backup).replace('application_identity = "gitea"', 'application_identity = "1gitea"')
+        with self.assertRaisesRegex(planner.ConfigurationError, "application_identity"):
+            planner.load_config(self.write_config(text))
+
+    def test_invalid_ip(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "ipv4_cidr"):
+            self.load(ipv4_cidr="10.10.0.0/24")
+
+    def test_gateway_must_match_network(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "gateway"):
+            self.load(gateway="10.11.0.1")
+
+    def test_invalid_dns_server(self) -> None:
+        text = config_text(self.backup).replace(
+            'dns_servers = ["10.10.0.53"]', 'dns_servers = ["127.0.0.1"]'
+        )
+        with self.assertRaisesRegex(planner.ConfigurationError, "dns_servers"):
+            planner.load_config(self.write_config(text))
+
+    def test_empty_dns_list_is_plan_blocker(self) -> None:
+        text = config_text(self.backup).replace(
+            'dns_servers = ["10.10.0.53"]', "dns_servers = []"
+        )
+        config = planner.load_config(self.write_config(text))
+        report = planner.build_plan(
+            config,
+            planner.load_version_matrix(),
+            ready_proxmox(),
+            (),
+            ready_backup(self.backup),
+            "a" * 40,
+        )
+        self.assertTrue(
+            any("lxc.dns_servers ist leer" in blocker for blocker in report.blockers)
+        )
+
+    def test_invalid_fqdn(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "fqdn"):
+            self.load(fqdn="HTTPS://Bad/Path")
+
+    def test_global_client_allowlist(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "globale Freigabe"):
+            self.load(allowed='"0.0.0.0/0"')
+
+    def test_noncanonical_client_cidr(self) -> None:
+        with self.assertRaisesRegex(planner.ConfigurationError, "kanonische CIDR"):
+            self.load(allowed='"10.20.0.1/16"')
+
+    def test_missing_backup_target_value(self) -> None:
+        text = config_text(self.backup).replace(f'host_root = "{self.backup}"', 'host_root = ""')
+        with self.assertRaisesRegex(planner.ConfigurationError, "backup.host_root"):
+            planner.load_config(self.write_config(text))
+
+    def test_empty_client_allowlists_are_valid_input_but_plan_blocker(self) -> None:
+        config = self.load(allowed="")
+        report = planner.build_plan(
+            config,
+            planner.load_version_matrix(),
+            ready_proxmox(),
+            (),
+            ready_backup(self.backup),
+            "a" * 40,
+        )
+        self.assertEqual(len([item for item in report.blockers if "Client-Allowlist" in item]), 4)
+        self.assertTrue(report.render().endswith("PLAN_BLOCKED\n"))
+
+
+class MatrixTests(PlannerTestCase):
+    def test_version_matrix_is_complete(self) -> None:
+        matrix = planner.load_version_matrix()
+        self.assertEqual(matrix.checked_at, "2026-08-02")
+        self.assertEqual(matrix.postgresql["documented_minor"], "18.4")
+        self.assertEqual(set(matrix.applications), set(planner.EXPECTED_ALLOCATIONS))
+
+    def test_modified_matrix_is_rejected(self) -> None:
+        source = planner.VERSION_MATRIX_PATH.read_text(encoding="utf-8").replace('version = "1.27.1"', 'version = "9.9.9"')
+        path = self.root / "matrix.toml"
+        path.write_text(source, encoding="utf-8")
+        with self.assertRaises(planner.MatrixError):
+            planner.load_version_matrix(path)
+
+
+class SecretTests(PlannerTestCase):
+    def test_parent_symlink_is_rejected_before_config_read(self) -> None:
+        secret_root = self.root / "secrets"
+        target = self.root / "target"
+        target.mkdir()
+        secret_root.symlink_to(target, target_is_directory=True)
+        with self.assertRaisesRegex(planner.ConfigurationError, "Symlink-Komponente"):
+            planner.ensure_no_symlink_components(
+                secret_root / "database-service/deployment.toml", secret_root
+            )
+
+    def test_missing_path_is_only_reported_and_not_created(self) -> None:
+        missing = self.root / "does-not-exist"
+        check = planner.inspect_path(
+            missing, kind="directory", expected_mode=0o700, require_nonempty=False
+        )
+        self.assertEqual(check.state, "FEHLT_GEPLANT")
+        self.assertFalse(missing.exists())
+
+    def test_symlink_is_conflict(self) -> None:
+        target = self.root / "target"
+        target.write_text("not-a-secret", encoding="utf-8")
+        link = self.root / "link"
+        link.symlink_to(target)
+        check = planner.inspect_path(link, kind="file", expected_mode=0o600, require_nonempty=True)
+        self.assertEqual(check.state, "KONFLIKT")
+        self.assertIn("Symlink", check.conflict or "")
+
+    def test_unsafe_mode_is_conflict(self) -> None:
+        path = self.root / "metadata-only"
+        path.write_text("not-a-secret", encoding="utf-8")
+        path.chmod(0o644)
+        check = planner.inspect_path(path, kind="file", expected_mode=0o600, require_nonempty=True)
+        self.assertEqual(check.state, "KONFLIKT")
+        self.assertIn("0600", check.conflict or "")
+
+    def test_secret_content_is_never_opened(self) -> None:
+        fake_stat = types.SimpleNamespace(
+            st_mode=stat.S_IFREG | 0o600,
+            st_uid=0,
+            st_gid=0,
+            st_size=32,
+        )
+        with mock.patch.object(builtins, "open", side_effect=AssertionError("content read")):
+            check = planner.inspect_path(
+                pathlib.Path("/secrets/example"),
+                kind="file",
+                expected_mode=0o600,
+                require_nonempty=True,
+                lstat_function=lambda _path: fake_stat,
+            )
+        self.assertEqual(check.state, "OK")
+
+
+class ProxmoxTests(PlannerTestCase):
+    def test_free_vmid_is_detected(self) -> None:
+        config = self.load(vmid=0)
+        state = planner.collect_proxmox_state(config, FakeRunner())
+        self.assertEqual(state.vmid, 100)
+        self.assertFalse(state.blockers)
+
+    def test_occupied_vmid_is_blocker_and_diagnosed(self) -> None:
+        runner = FakeRunner({("pct", "list"): "VMID Status Lock Name\n200 running - existing\n"})
+        state = planner.collect_proxmox_state(self.load(vmid=200), runner)
+        self.assertTrue(any("bereits" in item for item in state.blockers))
+        self.assertIn(("pct", "status", "200"), runner.calls)
+        self.assertIn(("pct", "config", "200"), runner.calls)
+        self.assertIn(("pct", "pending", "200"), runner.calls)
+
+    def test_unique_storage_is_selected(self) -> None:
+        state = planner.collect_proxmox_state(self.load(storage=""), FakeRunner())
+        self.assertEqual(state.storage, "local-lvm")
+
+    def test_ambiguous_storage_is_blocker(self) -> None:
+        output = "Name Type Status Total Used Available %\na dir active 300G 1G 299G 1%\nb dir active 300G 1G 299G 1%\n"
+        state = planner.collect_proxmox_state(
+            self.load(storage=""),
+            FakeRunner({("pvesm", "status", "--content", "rootdir"): output}),
+        )
+        self.assertTrue(any("mehrdeutig" in item for item in state.blockers))
+
+    def test_unique_bridge_is_selected(self) -> None:
+        state = planner.collect_proxmox_state(self.load(bridge=""), FakeRunner())
+        self.assertEqual(state.bridge, "vmbr0")
+
+    def test_missing_bridge_is_blocker(self) -> None:
+        state = planner.collect_proxmox_state(
+            self.load(), FakeRunner({("ip", "link", "show", "type", "bridge"): ""})
+        )
+        self.assertTrue(any("Bridge" in item for item in state.blockers))
+
+    def test_template_is_required(self) -> None:
+        state = planner.collect_proxmox_state(
+            self.load(), FakeRunner({("pveam", "available", "--section", "system"): ""})
+        )
+        self.assertTrue(any("Template" in item for item in state.blockers))
+
+    def test_insufficient_storage_is_blocker(self) -> None:
+        output = "Name Type Status Total Used Available %\nlocal-lvm lvmthin active 100G 99G 1G 99%\n"
+        state = planner.collect_proxmox_state(
+            self.load(), FakeRunner({("pvesm", "status", "--content", "rootdir"): output})
+        )
+        self.assertTrue(any("weniger freien Speicher" in item for item in state.blockers))
+
+    def test_reference_resource_deviation_warns_but_does_not_block(self) -> None:
+        text = config_text(self.backup).replace("cores = 4", "cores = 2").replace("memory_mib = 8192", "memory_mib = 4096").replace("disk_gib = 100", "disk_gib = 50")
+        config = planner.load_config(self.write_config(text))
+        state = planner.collect_proxmox_state(config, FakeRunner())
+        self.assertEqual(len(state.warnings), 3)
+
+
+class BackupTests(PlannerTestCase):
+    def test_valid_backup_target(self) -> None:
+        check = planner.inspect_backup_target(self.load().backup, self.root / "repository")
+        self.assertEqual(check.state, "OK")
+
+    def test_missing_backup_target_is_blocker(self) -> None:
+        missing = self.root / "missing"
+        config = self.load()
+        backup = dataclasses_replace(config.backup, host_root=missing)
+        check = planner.inspect_backup_target(backup, self.root / "repository")
+        self.assertTrue(check.blockers)
+
+    def test_unprotected_backup_target_is_blocker(self) -> None:
+        check = planner.inspect_backup_target(self.load(protection_confirmed=False).backup, self.root / "repository")
+        self.assertTrue(any("Schutz" in item for item in check.blockers))
+
+    def test_backup_inside_repository_is_blocker(self) -> None:
+        repository = self.root
+        check = planner.inspect_backup_target(self.load().backup, repository)
+        self.assertTrue(any("Git-Repository" in item for item in check.blockers))
+
+
+class MutationBoundaryTests(PlannerTestCase):
+    def test_command_runner_rejects_mutations(self) -> None:
+        runner = planner.CommandRunner()
+        for args in (["pct", "create", "200"], ["apt-get", "install", "postgresql-18"], ["systemctl", "start", "postgresql"]):
+            with self.assertRaises(planner.ProbeError):
+                runner.run(args)
+
+    def test_allowed_command_uses_fixed_list_and_bounded_runtime(self) -> None:
+        calls = []
+
+        def executor(args, **kwargs):
+            calls.append((args, kwargs))
+            return subprocess.CompletedProcess(args, 0, "version\n", "")
+
+        result = planner.CommandRunner(executor).run(["pveversion"])
+        self.assertEqual(result.stdout, "version\n")
+        self.assertEqual(calls[0][0], ["pveversion"])
+        self.assertEqual(calls[0][1]["timeout"], planner.COMMAND_TIMEOUT_SECONDS)
+        self.assertNotIn("shell", calls[0][1])
+
+    def test_parser_has_only_plan_mode(self) -> None:
+        parser = planner.create_parser()
+        choices = next(action.choices for action in parser._actions if isinstance(action, planner.argparse._SubParsersAction))
+        self.assertEqual(set(choices), {"plan"})
+        with redirect_stderr(io.StringIO()), self.assertRaises(SystemExit):
+            parser.parse_args(["apply"])
+
+    def test_source_has_no_mutating_or_network_executor(self) -> None:
+        source = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotIn("shell" + "=True", source)
+        self.assertNotRegex(source, r"\b(?:requests|socket|urllib)\b")
+        self.assertNotRegex(source, r"subprocess\.(?:Popen|call|check_call|check_output)")
+        self.assertNotRegex(source, r"\bdef\s+(?:apply|create|install|provision|delete|restore)\b")
+
+    def test_planning_creates_no_files(self) -> None:
+        config_path = self.write_config()
+        before = sorted(path.relative_to(self.root) for path in self.root.rglob("*"))
+        config = planner.load_config(config_path)
+        planner.build_plan(
+            config,
+            planner.load_version_matrix(),
+            ready_proxmox(),
+            (),
+            ready_backup(self.backup),
+            "a" * 40,
+        )
+        after = sorted(path.relative_to(self.root) for path in self.root.rglob("*"))
+        self.assertEqual(before, after)
+
+
+class OutputTests(PlannerTestCase):
+    def test_complete_plan_output(self) -> None:
+        config = self.load()
+        report = planner.build_plan(
+            config,
+            planner.load_version_matrix(),
+            ready_proxmox(),
+            (),
+            ready_backup(self.backup),
+            "a" * 40,
+        )
+        output = report.render()
+        self.assertTrue(output.endswith("PLAN_READY\n"))
+        for allocation in planner.EXPECTED_ALLOCATIONS:
+            self.assertIn(f"[{allocation}]", output)
+        allocation_section = output.split("== ALLOCATIONS ==", 1)[1].split("== SECRETS", 1)[0]
+        self.assertNotIn("[ralf", allocation_section.lower())
+        self.assertIn("nur relationale Flow-Anwendungsdaten", output)
+        self.assertIn("PostgreSQL ist deployment-spezifisch gewählt", output)
+        self.assertIn("DNS-Server: 10.10.0.53", output)
+        self.assertIn("/secrets/database-service/allocations/gitea/application-password", output)
+        self.assertIn("keine reale Mutation im Planmodus", output)
+
+    def test_secret_text_cannot_leak_through_metadata_plan(self) -> None:
+        marker = "TOP-SECRET-CONTENT"
+        secret_file = self.root / "secret"
+        secret_file.write_text(marker, encoding="utf-8")
+        secret_file.chmod(0o600)
+        check = planner.inspect_path(secret_file, kind="file", expected_mode=0o600, require_nonempty=True)
+        output = planner.build_plan(
+            self.load(),
+            planner.load_version_matrix(),
+            ready_proxmox(),
+            (check,),
+            ready_backup(self.backup),
+            "a" * 40,
+        ).render()
+        self.assertNotIn(marker, output)
+
+
+def dataclasses_replace(instance, **changes):
+    return planner.dataclasses.replace(instance, **changes)
+
+
+def ready_proxmox():
+    return planner.ProxmoxState(
+        pve_version="pve-manager/9.0/test",
+        vmid=200,
+        vmid_source="test",
+        storage="local-lvm",
+        storage_source="test",
+        storage_available_bytes=200 * 1024**3,
+        bridge="vmbr0",
+        bridge_source="test",
+        template="ubuntu-26.04-standard_26.04-1_amd64.tar.zst",
+        host_addresses_checked=True,
+        host_routes_checked=True,
+    )
+
+
+def ready_backup(path: pathlib.Path):
+    return planner.BackupCheck(path, "OK", 200 * 1024**3, (), ())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Zweck

Ergänzt den ersten service-spezifischen, ausschließlich read-only arbeitenden Deploymentplaner für die PostgreSQL-Providerinstanz `postgresql-main` mit genau vier Allocations: `gitea`, `openbao`, `semaphore` und `nodered`.

## Inhalt

- strikte lokale TOML-Konfiguration ausschließlich aus `/secrets/database-service/providers/postgresql-main/deployment.toml`
- bewusst unvollständige, nicht automatisch verwendete Beispielkonfiguration
- versionierte Offline-Matrix für PostgreSQL 18.4/18.x und die vier Consumer-Referenzstände
- read-only Proxmox-, Storage-, Bridge-, Template-, Netzwerk-, Secretmetadaten- und Backupzielprüfungen
- deterministische Ausgabe mit Referenzressourcen, TLS-/SCRAM-Vertrag, Allocation-Isolation, geplanten späteren Mutationen und vollständigen Blockern
- ADR-0006 und Operationsdokumentation für den unprivilegierten Ubuntu-26.04-LTS-LXC
- 48 Unit-Tests für Validierung, Proxmox-Mocks, Secrets-Metadaten, Planausgabe und Mutationsfreiheit

## Sicherheitsgrenze

- kein `apply`- oder anderer mutierender Modus
- keine PostgreSQL-, Paket- oder Netzwerkverbindung
- kein LXC, keine Datenbank, keine Rolle, kein Zertifikat und kein Backup wird angelegt
- Secretwerte werden weder gelesen noch ausgegeben; `/secrets` und `secrets/` bleiben unverändert
- keine externe Python-Runtime-Abhängigkeit

## Prüfungen

- `python3 -m compileall`: erfolgreich
- vollständige Python-Suite: 48 Tests erfolgreich
- `git diff --check`: erfolgreich
- Markdown-Struktur und interne Links: erfolgreich
- ADR-Reihenfolge 0001 bis 0006: erfolgreich
- Versionsmatrix und exakt vier Allocations: erfolgreich
- statische Prüfung auf Dateimutationen, Netzwerkimporte und `shell=True`: erfolgreich
- CLI-Prüfung: ausschließlich `plan`; kein Applymodus
- Secrets-Ausschluss: erfolgreich

Es wurde keine reale Deploymentkonfiguration angelegt und keine Infrastruktur verändert.
