### PR TITLE
Implement mocked PostgreSQL main apply and resume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Die erste fachliche Spezifikation trennt den fähigkeitsorientierten RALF-Vertra
 - [ADR-0005: erstes PostgreSQL-Deploymentprofil](docs/decisions/ADR-0005-first-postgresql-deployment-profile.md)
 - [ADR-0006: Laufzeitprofil für `postgresql-main`](docs/decisions/ADR-0006-postgresql-runtime-profile.md)
 - [ADR-0007: Apply- und Recovery-Grenzen](docs/decisions/ADR-0007-postgresql-apply-and-recovery-boundaries.md)
+- [ADR-0008: Provisionierungsimplementierung](docs/decisions/ADR-0008-postgresql-provisioning-implementation.md)
 - [Read-only Deploymentplan für `postgresql-main`](docs/operations/postgresql-main-deployment-plan.md)
 - [Apply-Vertrag für `postgresql-main`](docs/operations/postgresql-main-apply-contract.md)
 - [Recovery-Vertrag für die Provisionierung](docs/recovery/postgresql-main-provisioning-recovery.md)
+- [Lokale Apply-/Resume-Implementierung](docs/operations/postgresql-main-apply-implementation.md)
 
 Der erste spezifizierte RALF-native Database Consumer ist **RALF Core**. Seine erste persistente Domäne **Conversation** speichert ausschließlich Unterhaltungen und geordnete Nachrichten. Conversation bleibt zunächst eine Core-Domäne und verwendet nur in der RALF-Core-Allocation einen fachlichen Repository-Vertrag:
 
@@ -34,7 +36,7 @@ Der erste spezifizierte RALF-native Database Consumer ist **RALF Core**. Seine e
 
 Externe Anwendungen wie Gitea oder optional OpenBao können eigene Allocations mit nativen Datenbankzugriffen erhalten; sie verwenden ConversationRepository nicht. Referenzstandard ist eine logische Datenbank mit eigenen Identitäten pro Consumer. Die verbindliche externe Secrets-Wurzel ist `/secrets`; im Repository stehen ausschließlich nicht geheime Referenzen, und `secrets/` bleibt ausgeschlossen.
 
-Die erste Implementierung ist ausschließlich ein read-only Deploymentplaner. Es existieren weiterhin kein SQL, keine Tabellen, keine PostgreSQL-Installation, Programmierschnittstelle, Modellruntime, Benutzerverwaltung, Weboberfläche oder Infrastrukturmutation.
+Der read-only Deploymentplaner wird durch einen getrennten, hashgebundenen Host-/Gast-Provisionierungspfad ergänzt. Der Code ist ausschließlich mit lokalen Fakes und temporären Dateisystemen geprüft; es wurden weder PostgreSQL noch ein LXC oder reale Datenbankobjekte angelegt.
 
 Provider 001 beschreibt PostgreSQL als konkrete Referenz hinter dem providerneutralen Vertrag. Das erste deployment-spezifische Profil wählt PostgreSQL Major 18 und die gemeinsame Providerinstanz `postgresql-main`. Ihr initial dokumentierter Minor-Stand ist 18.4; installiert wird später die dann neueste stabile 18.x-Minor-Version. Ein automatischer Wechsel auf PostgreSQL 19 ist ausgeschlossen.
 
@@ -50,10 +52,12 @@ sudo python3 scripts/postgresql-main-plan.py \
 
 Die Ausgabe ist standardmäßig Text. Mit `--format json` liefert derselbe read-only Lauf eine kanonische maschinenlesbare Planrepräsentation. Text und JSON zeigen denselben deterministischen Plan-SHA-256; der Erzeugungszeitpunkt selbst beeinflusst den Hash nicht.
 
-Das Referenzprofil ist ein eigener unprivilegierter Ubuntu-26.04-LTS-LXC auf Proxmox, ohne Docker oder Podman. PostgreSQL 18 stammt später aus den offiziellen Ubuntu-Quellen; TLS, SCRAM-SHA-256, allocation-spezifische Netze, ein explizites externes Backupziel und Secrets ausschließlich unter `/secrets` sind verbindliche Planungsgrenzen. Der Planer besitzt keinen Applymodus und verändert weder `/secrets` noch Infrastruktur.
+Das Referenzprofil ist ein eigener unprivilegierter Ubuntu-26.04-LTS-LXC auf Proxmox, ohne Docker oder Podman. PostgreSQL 18 stammt später aus den offiziellen Ubuntu-Quellen; TLS, SCRAM-SHA-256, allocation-spezifische Netze, ein explizites externes Backupziel und Secrets ausschließlich unter `/secrets` sind verbindliche Grenzen. Der eigenständige Planer besitzt weiterhin keinen Applymodus und verändert weder `/secrets` noch Infrastruktur.
 
-Apply- und Recovery-Vertrag verlangen später `PLAN_READY`, eine ausdrückliche Nutzerfreigabe für den exakten Plan-Hash, erneute read-only Prüfung unmittelbar vor der ersten Mutation und phasenweise Verifikation. Ein Teilerfolg wird nicht automatisch zurückgerollt und darf nur über einen gesondert hashgebundenen Resume fortgesetzt werden.
+Der getrennte Deploypfad verlangt `PLAN_READY`, eine ausdrückliche Nutzerfreigabe für den exakten Plan-Hash, erneute read-only Prüfung unmittelbar vor der ersten Mutation und phasenweise Verifikation. Ein Teilerfolg wird nicht automatisch zurückgerollt und darf nur über einen gesondert hashgebundenen Resume fortgesetzt werden. Seine produktiven Befehle sind real verwendbar, wurden in diesem Meilenstein aber nicht ausgeführt.
 
-Es gibt weiterhin keinen Apply- oder Resumecode, keine reale Deploymentkonfiguration und keine Infrastrukturmutation. Der nächste kleine Schritt nach Review und Merge kann die Zustandsmaschine ausschließlich lokal mit Mocks entwerfen. PostgreSQL ist weiterhin nicht installiert.
+Die Erstprovisionierung bestätigt nur `provider_status = ready` und `allocation_configuration = verified`. Bis ein realer Consumer aus seinem freigegebenen Netz TLS/SCRAM erfolgreich nachweist, bleibt `allocation_readiness = consumer_validation_pending`.
+
+Es gibt weiterhin keine reale Deploymentkonfiguration und keine Infrastrukturmutation. Nach Review und Merge wird als nächster Schritt die Konfiguration kontrolliert unter `/secrets` angelegt und genau ein realer read-only Plan geprüft. Ein Apply benötigt danach eine neue, ausdrückliche Freigabe des konkreten Hashs. PostgreSQL ist weiterhin nicht installiert.
 
 RALF entsteht transparent durch Vibe Coding: Menschen bestimmen Ziele, Entscheidungen und Grenzen; Coding-Agenten unterstützen die Umsetzung in kleinen, überprüfbaren Schritten.

--- a/deploy/postgresql/pki-policy.toml
+++ b/deploy/postgresql/pki-policy.toml
@@ -1,0 +1,14 @@
+schema_version = 1
+
+[ca]
+key_algorithm = "rsa"
+key_bits = 4096
+validity_days = 3650
+digest = "sha256"
+
+[server]
+key_algorithm = "rsa"
+key_bits = 3072
+validity_days = 397
+digest = "sha256"
+extended_key_usage = ["serverAuth"]

--- a/docs/decisions/ADR-0007-postgresql-apply-and-recovery-boundaries.md
+++ b/docs/decisions/ADR-0007-postgresql-apply-and-recovery-boundaries.md
@@ -42,7 +42,7 @@ Die technische Hashbestätigung ergänzt die ausdrückliche Nutzerfreigabe, erse
 
 Die stabile Reihenfolge lautet:
 
-1. `planned`: Plan neu prüfen, ausschließlich sichere Marker-Elternpfade anlegen, Hash binden und Marker anlegen.
+1. `planned`: Plan neu prüfen, vorhandene sichere Konfigurations- und Marker-Eltern revalidieren, Hash binden und Marker anlegen.
 2. `secret_directories_ready`: Marker-Eltern revalidieren und ausschließlich PKI- sowie Allocation-Verzeichnisse ergänzen.
 3. `secrets_ready`: genau vier Anwendungskennwörter exklusiv erzeugen.
 4. `pki_ready`: dedizierte interne Provider-PKI erzeugen.
@@ -53,7 +53,7 @@ Die stabile Reihenfolge lautet:
 9. `postgresql_installed`: ausschließlich PostgreSQL Major 18 installieren und prüfen.
 10. `postgresql_configured`: Peer, TLS, SCRAM, Listener und HBA begrenzen.
 11. `allocations_created`: vier logische Datenbanken mit getrennten Eigentümern und Login-Identitäten anlegen.
-12. `readiness_verified`: Provider- und Allocation-Isolation positiv und negativ prüfen.
+12. `readiness_verified`: Providerzustand sowie lokale Allocation-Konfiguration und Isolation prüfen; Consumer-Konnektivität bleibt bis zum externen Nachweis ausstehend.
 13. `backups_verified`: vier initiale logische Backups erzeugen und technisch prüfen.
 14. `completed`: Abschlussmarker schreiben und temporäre Gastgeheimnisse bereinigen.
 
@@ -63,7 +63,7 @@ Jede Phase wird erst nach ihrer vollständigen read-only Verifikation atomar als
 
 Der Marker liegt unter `/secrets/database-service/providers/postgresql-main/provisioning-state.json`, ist `root:root`, `0600`, symlinkfrei und enthält ausschließlich nicht geheime Identitäten, Hashes, Phasen, Zeitstempel, VMID, Artefakthashes und Fehlerstatus.
 
-Da dieser Marker ohne Elternpfade nicht crashfest angelegt werden kann, darf Phase 1 ausschließlich `/secrets`, `database-service`, `providers` und `postgresql-main` als sichere `root:root`-Verzeichnisse `0700` vorbereiten. Phase 2 revalidiert sie und ergänzt erst dann PKI- und Allocation-Verzeichnisse. Diese explizite Ausnahme verhindert einen unmarkierten Secret- oder Infrastruktur-Teilerfolg.
+Da die reale Deploymentkonfiguration vor Apply bereits unter dem Providerpfad liegen muss, setzt Phase 1 die vorhandenen `/secrets`-, `database-service`-, `providers`- und `postgresql-main`-Eltern als sichere `root:root`-Verzeichnisse `0700` voraus und validiert sie read-only. Sie legt keinen fehlenden Elternpfad an. Phase 2 ergänzt erst nach Markeranlage PKI- und Allocation-Verzeichnisse.
 
 Er darf keine Secretwerte, Kennworthashes, privaten Schlüssel oder Connection Strings enthalten. Er wird bei jeder bestätigten Phasenänderung atomar ersetzt und bleibt nach `completed` als historische Provisionierungsevidenz erhalten.
 
@@ -71,7 +71,7 @@ Er darf keine Secretwerte, Kennworthashes, privaten Schlüssel oder Connection S
 
 Persistente Secret- und PKI-Erzeugung ist ausschließlich unter `/secrets` erlaubt. Es entstehen genau vier allocation-eigene Anwendungskennwörter; kein dauerhaftes Remote-Superuserkennwort wird erzeugt. Vorhandene Dateien werden niemals automatisch überschrieben.
 
-Die interne CA verbleibt auf dem Proxmox-Host. Das Serverzertifikat bindet den bestätigten FQDN und die Provider-IP. Laufzeiten und Rotation werden in einer späteren versionierten PKI-Policy entschieden.
+Die interne CA verbleibt auf dem Proxmox-Host. Das Serverzertifikat bindet den bestätigten FQDN und die Provider-IP. Die erste versionierte PKI-Policy ist durch ADR-0008 präzisiert; Rotation bleibt ein eigener Vorgang.
 
 Temporäre Gastkopien dürfen ausschließlich geschützt unter `/run/ralf-database-provision/` liegen und müssen bei Erfolg sowie Fehler entfernt werden. Diese Sicherheitsbereinigung ist kein Rollback. Der notwendige installierte Server-Key ist die einzige vorgesehene persistente Gastkopie eines privaten Schlüssels.
 
@@ -116,7 +116,7 @@ Temporäre Secretkopien, unveröffentlichte temporäre Dateien, offene Deskripto
 ## Konsequenzen
 
 - Der Planer erhält Text- und JSON-Ausgabe sowie einen deterministischen Plan-SHA-256, bleibt aber vollständig read-only.
-- Ein späterer Apply muss exakt die dokumentierte Reihenfolge und Mutationsallowlist implementieren.
+- Die Implementierung muss exakt die dokumentierte Reihenfolge und Mutationsallowlist einhalten; ADR-0008 dokumentiert die lokale Umsetzung.
 - Jeder Apply- und Resume-Hash ist nur für den unmittelbar neu erhobenen Zustand relevant.
 - Warnungen bleiben sichtbar; Blocker sind technisch nicht überstimmbar.
 - Recovery benötigt zusätzliche Planung statt automatischer Rücknahme.
@@ -150,15 +150,13 @@ Verworfen, weil Zeitablauf und Teilerfolg den tatsächlichen Zustand gegenüber 
 
 ## Offene Punkte
 
-- konkrete Implementierung des atomaren Markers,
-- Passwortentropie und sichere Generierungstechnik,
-- versionierte PKI-Laufzeiten und Rotationspolitik,
-- kontrollierte Paketdienststarttechnik während Installation,
-- exakte PostgreSQL-Rechteabbildung für NOLOGIN-Eigentümer und Login-Anwendungen,
-- technisches Schema des Resume-Plans und seiner Hashbindung,
+- reale Validierung der implementierten Marker- und Resume-Grenzen,
+- spätere Secret- und PKI-Rotationspolitik,
+- reale Validierung der kontrollierten Paketdienststarttechnik,
+- Consumer-seitiger TLS-/SCRAM-Readiness-Nachweis,
 - Gestaltung eines getrennten, ausdrücklich freizugebenden Rebootpfads,
 - spätere Wartungs-, Rotations- und Deprovisionierungsverträge.
 
-## Nächster Schritt
+## Präzisierung durch ADR-0008
 
-Nach Review und Merge kann ein weiterer lokaler Meilenstein die Marker-, Apply- und Resume-Logik ausschließlich mit Mocks und ohne reale Infrastrukturmutation entwerfen. Vor jeder echten Mutation bleiben ein vollständiger read-only Plan und eine neue ausdrückliche Hashfreigabe erforderlich.
+ADR-0008 setzt diese Grenzen mit gemeinsam genutzter Planlogik, Host-/Gasttrennung, atomarem Teilfortschritt und vollständig gemockten Mutationsphasen um. Vor jeder echten Mutation bleiben ein vollständiger realer read-only Plan und eine neue ausdrückliche Hashfreigabe erforderlich.

--- a/docs/decisions/ADR-0008-postgresql-provisioning-implementation.md
+++ b/docs/decisions/ADR-0008-postgresql-provisioning-implementation.md
@@ -1,0 +1,83 @@
+# ADR-0008: Host-/Gast-Implementierung der PostgreSQL-Provisionierung
+
+- **Status:** Angenommen
+- **Datum:** 2026-08-06
+
+## Kontext
+
+ADR-0007 bindet jede Provisionierung an einen unmittelbar neu berechneten `PLAN_READY`-Hash, trennt normalen Apply und Resume und verbietet automatischen Rollback. Der nächste Schritt benötigt real verwendbaren Code, darf aber noch keine reale Konfiguration, Secrets oder Infrastruktur verändern.
+
+## Entscheidung
+
+`postgresql-main` erhält einen getrennten Python-Host-/Gast-Pfad ausschließlich mit der Standardbibliothek. Planer und Deploypfad verwenden dieselbe importierte Planlogik. Mutierende Läufe halten eine exklusive Prozesssperre und schreiben Planevidenz sowie Marker atomar. Jede mehrteilige Phase besitzt persistenten Einzelteilfortschritt.
+
+Hostcode begrenzt Proxmox-Aufrufe, sichere Hostdateien, Secret- und PKI-Erzeugung, Bundletransfer und Backupstreaming. Gastcode begrenzt Ubuntu-, PostgreSQL-, TLS-, HBA-, Rollen-, Allocation- und lokale Verifikationsschritte. Produktive Testschalter und freie Befehlsübergabe sind ausgeschlossen.
+
+## Hash- und Freigabegrenze
+
+Apply lädt alle Inputs und Beobachtungen unmittelbar neu, verlangt sauberen getrackten Repositoryzustand und vergleicht den bestätigten Plan-SHA-256 vor jeder Mutation. Resume besitzt einen eigenen, erneut berechneten SHA-256. Eine Abweichung blockiert ohne Mutation.
+
+## Sperre und Marker
+
+Die Sperre liegt auf `/run/lock/ralf-postgresql-main.lock` und verwendet nicht blockierendes `fcntl.flock`. Der Marker unter `/secrets` bindet Repository-, Plan-, Konfigurations-, Matrix- und Artefakthashes, Phase, offene Einzelmutation, geordneten Teilfortschritt, VMID, öffentliche Zertifikatfingerprints, Backupevidenz und nicht geheime Fehlerklassen.
+
+## Secrets und PKI
+
+Genau vier Kennwörter entstehen mit mindestens 384 Bit Entropie ausschließlich unter `/secrets`. Secretwerte erscheinen nicht in Plan, Marker, Log, argv oder normaler Umgebung. Die PKI-Policy verwendet RSA 4096/3650 Tage für die interne CA und RSA 3072/397 Tage für den TLS-Server mit SHA-256 und `serverAuth`. Der Server-SAN bindet exakt FQDN und IPv4-Adresse; der CA-Key verlässt den Host nicht.
+
+## Provisionierungsgrenzen
+
+Der Produktionspfad modelliert genau einen unprivilegierten Ubuntu-26.04-LXC, genau einen Start, Ubuntu-Pakete für PostgreSQL Major 18, Peer-Administration, TLS, SCRAM-SHA-256, vier isolierte logische Datenbanken mit NOLOGIN-Eigentümern und getrennten Loginrollen sowie vier allocation-bezogene Custom-Format-Backups. PGDG, PostgreSQL 19, Docker, breite HBA-Regeln, automatische Reboots, Retries und Rollbacks sind ausgeschlossen.
+
+## Readiness-Korrektur
+
+Die Erstprovisionierung kann ohne laufende Consumer keine positive Verbindung aus deren späteren Quellnetzen beweisen. Sie darf deshalb nur Provider-Readiness und lokal verifizierte Allocation-Konfiguration melden. `allocation_readiness` bleibt `consumer_validation_pending`, bis die jeweilige Consumerinstallation TLS/SCRAM aus einer freigegebenen Quelle bestätigt.
+
+## Recovery
+
+Vor jeder Einzelmutation wird das geplante Element atomar markiert; nach der Mutation wird es erst nach Verifikation bestätigt. Resume prüft bestätigte Phasen und Einzelteile read-only und setzt nur an der ersten offenen Grenze fort. Temporäre Gast-Secrets werden auch bei Fehlern bereinigt und bei einem bestätigten Resume identisch neu bereitgestellt, wenn sie für die Fortsetzung erforderlich sind. Persistente Artefakte werden weder automatisch gelöscht noch zurückgesetzt.
+
+## Sicherheitsfolgen
+
+- Symlinks und unsichere Metadaten blockieren sicherheitsrelevante Hostpfade.
+- Kritische Dateien werden exklusiv oder atomar mit Datei- und Verzeichnis-fsync veröffentlicht.
+- PostgreSQL-Geheimnisse gelangen nur über Standardinput in lokale administrative SQL-Ausführung.
+- Ein Bereinigungsfehler wird zusätzlich zur ursprünglichen Fehlerklasse sichtbar.
+- Backups werden vor atomarer Veröffentlichung technisch geprüft.
+
+## Konsequenzen
+
+- Der Code ist real verwendbar, aber noch nicht für eine reale Ausführung freigegeben.
+- Fault Injection muss jede persistente Einzelgrenze abdecken.
+- Ein benötigter Containerreboot bleibt ein eigener Planungs- und Freigabeschritt.
+- Echte Consumer-Readiness wird erst bei der jeweiligen Consumerinstallation erreicht.
+
+## Verworfene Alternativen
+
+### Zweite Planung im Deployer
+
+Verworfen, weil Plan und Ausführung sonst voneinander abweichen könnten.
+
+### Shellskripte mit zusammengesetzten Befehlen
+
+Verworfen, weil feste Argumentlisten, Standardinput für Secrets und injizierbare Backends klarere Sicherheitsgrenzen bieten.
+
+### Ein ungeteilter Gastlauf
+
+Verworfen, weil ein Crash zwischen Allocations oder Konfigurationsschritten nicht eindeutig fortsetzbar wäre.
+
+### Consumer-Readiness lokal behaupten
+
+Verworfen, weil ein lokaler Administrationsnachweis keine reale Verbindung aus dem vorgesehenen Consumer-Netz ersetzt.
+
+### Automatischer Rollback
+
+Verworfen gemäß ADR-0007, weil er Secrets, PKI, Datenbanken oder Backupevidenz zerstören könnte.
+
+## Nicht ausgeführt
+
+Es wurden kein realer Proxmox-Plan, Apply oder Resume-Apply ausgeführt. `/secrets`, LXC, PostgreSQL, Netzwerke und Consumer blieben unverändert.
+
+## Nächster Schritt
+
+Die reale Deploymentkonfiguration wird kontrolliert unter `/secrets` angelegt und anschließend ausschließlich read-only geplant. Erst ein separat geprüfter und ausdrücklich bestätigter `PLAN_READY`-Hash darf die erste reale Mutation freigeben.

--- a/docs/operations/postgresql-main-apply-contract.md
+++ b/docs/operations/postgresql-main-apply-contract.md
@@ -2,9 +2,9 @@
 
 ## Status und Geltungsbereich
 
-Dieses Dokument spezifiziert einen zukünftigen, streng begrenzten Apply für die PostgreSQL-Providerinstanz `postgresql-main` mit exakt den Allocations `gitea`, `openbao`, `semaphore` und `nodered`.
+Dieses Dokument spezifiziert den streng begrenzten Apply für die PostgreSQL-Providerinstanz `postgresql-main` mit exakt den Allocations `gitea`, `openbao`, `semaphore` und `nodered`.
 
-Es ist kein Apply implementiert. Der bestehende Planer bleibt read-only. Dieses Dokument autorisiert weder eine Infrastrukturmutation noch das Erstellen von `/secrets`, einer realen Deploymentkonfiguration, eines LXC, von PostgreSQL, Datenbanken, Identitäten, Zertifikaten oder Backups.
+Der Vertrag ist durch einen getrennten Host-/Gast-Pfad implementiert und ausschließlich lokal mit Fakes und temporären Dateisystemen geprüft. Der bestehende Planer bleibt read-only. Dieses Dokument autorisiert noch keine reale Infrastrukturmutation und keine Ausführung gegen das echte `/secrets` oder Proxmox.
 
 ## Plan ist die einzige Zielquelle
 
@@ -64,7 +64,7 @@ Nicht gebunden oder ausgegeben werden Secretwerte, Inhalts-Hashes von Secrets, P
 
 ## Spätere Freigabegrenze
 
-Der vorgesehene zukünftige Aufruf lautet:
+Der implementierte, noch nicht real ausgeführte Aufruf lautet:
 
 ```bash
 sudo python3 scripts/postgresql-main-deploy.py \
@@ -73,9 +73,7 @@ sudo python3 scripts/postgresql-main-deploy.py \
   --confirm-plan-sha256 <64-HEX-ZEICHEN>
 ```
 
-Dieser Befehl existiert noch nicht.
-
-Unmittelbar vor der ersten Mutation muss ein späterer Apply:
+Unmittelbar vor der ersten Mutation muss Apply:
 
 1. die reale Konfiguration erneut und symlinksicher laden,
 2. die versionierte Matrix erneut laden,
@@ -132,7 +130,7 @@ Der Marker enthält niemals Secretwerte, Kennworthashes, private Schlüssel oder
 
 | Position | Markerphase nach Erfolg | Mutation | Verifikation vor Fortschritt |
 | --- | --- | --- | --- |
-| 1 | `planned` | Planbindung, minimale Marker-Eltern und Marker | Hash, Markerinhalt und Metadaten stimmen. |
+| 1 | `planned` | vorhandene Konfigurations- und Marker-Eltern revalidieren, Planbindung und Marker | Hash, Markerinhalt und Metadaten stimmen. |
 | 2 | `secret_directories_ready` | Marker-Eltern revalidieren und übrige erlaubte `/secrets`-Verzeichnisse ergänzen | Jeder Pfad ist echtes `root:root`-Verzeichnis `0700`. |
 | 3 | `secrets_ready` | vier Anwendungskennwörter | Genau vier reguläre, nicht leere Dateien `root:root` `0600`; keine Ausgabe. |
 | 4 | `pki_ready` | dedizierte Provider-PKI | Schlüssel und Zertifikate besitzen richtige Metadaten; SAN bindet FQDN und IP. |
@@ -143,7 +141,7 @@ Der Marker enthält niemals Secretwerte, Kennworthashes, private Schlüssel oder
 | 9 | `postgresql_installed` | PostgreSQL 18 installieren | Paket, Major-Version und genau ein erwarteter Cluster sind nachgewiesen. |
 | 10 | `postgresql_configured` | TLS-, SCRAM-, Peer- und HBA-Konfiguration | Effektive Konfiguration besitzt keine breite oder schwache Regel. |
 | 11 | `allocations_created` | vier Datenbanken und getrennte Identitäten | Exakte Objekte und minimale Attribute sind nachgewiesen. |
-| 12 | `readiness_verified` | Isolation und Providerzustand prüfen | Positive und negative Tests sind vollständig erfolgreich. |
+| 12 | `readiness_verified` | Providerzustand und lokale Allocation-Konfiguration prüfen | Provider ist ready; Konfiguration und Isolation sind verifiziert, Consumer-Konnektivität bleibt ausstehend. |
 | 13 | `backups_verified` | vier initiale Backups | Archive existieren geschützt, sind neu und technisch geprüft. |
 | 14 | `completed` | Marker abschließen und temporäre Secrets bereinigen | Keine Gastlaufzeit-Secrets; alle Abschlussprüfungen weiterhin grün. |
 
@@ -151,7 +149,7 @@ Ein späterer Implementierungsplan darf diese Reihenfolge nicht stillschweigend 
 
 ## Phase 1: Apply-Zustand vorbereiten
 
-Der Markerpfad kann nicht atomar angelegt werden, wenn seine Eltern fehlen. Deshalb gilt als enge technische Reihenfolgeauflösung: Phase 1 darf ausschließlich die vier Marker-Eltern `/secrets`, `/secrets/database-service`, `/secrets/database-service/providers` und `/secrets/database-service/providers/postgresql-main` symlinksicher als `root:root` `0700` anlegen. Diese Pfade dienen noch nicht als Secretdateien und werden in Phase 2 vollständig revalidiert. Keine andere Verzeichnis- oder Dateianlage ist in Phase 1 erlaubt.
+Die reale Deploymentkonfiguration liegt vor dem Apply bereits unter `/secrets/database-service/providers/postgresql-main/deployment.toml`. Daher müssen die vier Marker-Eltern `/secrets`, `/secrets/database-service`, `/secrets/database-service/providers` und `/secrets/database-service/providers/postgresql-main` schon als symlinkfreie `root:root`-Verzeichnisse `0700` existieren. Phase 1 validiert sie ausschließlich read-only und legt weder einen fehlenden Elternpfad noch die Konfiguration an.
 
 Danach sind ausschließlich der vollständige erneute read-only Preflight, der exakte Hashvergleich, die atomare Neuanlage des Provisionierungsmarkers und das Speichern des kanonischen Plans sowie nicht geheimer Artefakthashes als Evidenz erlaubt.
 
@@ -160,7 +158,7 @@ Vor Übergang zu `planned` wird geprüft:
 - Marker war zuvor nicht vorhanden,
 - Plan ist `PLAN_READY`,
 - bestätigter und neu berechneter Hash stimmen überein,
-- jeder neu angelegte Marker-Elternpfad ist ein echtes `root:root`-Verzeichnis `0700`,
+- jeder vorhandene Marker-Elternpfad ist ein echtes `root:root`-Verzeichnis `0700`,
 - gespeicherte Evidenz reproduziert dieselben Hashes,
 - Marker ist regulär, `root:root`, `0600` und enthält keine unerlaubten Felder.
 
@@ -181,7 +179,7 @@ Später dürfen exakt folgende Verzeichnisse angelegt werden:
 /secrets/database-service/allocations/nodered
 ```
 
-Die vier Marker-Eltern aus Phase 1 werden nicht erneut angelegt, sondern read-only validiert. Phase 2 darf ausschließlich das PKI-Verzeichnis, den Allocation-Stamm und die vier Allocation-Verzeichnisse ergänzen. Jeder Pfad ist `root:root` und `0700`. Symlinks, Traversierung, Auflösung außerhalb `/secrets` sowie gruppen- oder weltzugängliche Komponenten sind Konflikte. Vor `secret_directories_ready` werden alle Komponenten erneut per Metadaten geprüft.
+Die vier vorhandenen Marker-Eltern werden erneut read-only validiert. Phase 2 darf ausschließlich das PKI-Verzeichnis, den Allocation-Stamm und die vier Allocation-Verzeichnisse ergänzen. Jeder Pfad ist `root:root` und `0700`. Symlinks, Traversierung, Auflösung außerhalb `/secrets` sowie gruppen- oder weltzugängliche Komponenten sind Konflikte. Vor `secret_directories_ready` werden alle Komponenten erneut per Metadaten geprüft.
 
 ## Phase 3: Anwendungskennwörter erzeugen
 
@@ -211,7 +209,7 @@ Vorgesehene Hostpfade:
 
 Die interne CA gilt ausschließlich für diesen Provider. Ihr privater Schlüssel verbleibt auf dem Proxmox-Host. Das Serverzertifikat bindet den bestätigten FQDN und die bestätigte Provider-IP. Private Schlüssel sind `root:root` `0600`; öffentliche Zertifikate sind höchstens `0644`.
 
-Es gibt keine automatische System-Trust-Installation, öffentliche ACME-Anfrage oder OPNsense-Änderung. Zertifikatslaufzeiten werden erst in einer versionierten PKI-Policy entschieden. Vor `pki_ready` sind Metadaten, Zertifikatskette, SAN und Übereinstimmung von Server-Key und Serverzertifikat zu prüfen, ohne private Inhalte zu protokollieren.
+Es gibt keine automatische System-Trust-Installation, öffentliche ACME-Anfrage oder OPNsense-Änderung. Die versionierte [PKI-Policy](../../deploy/postgresql/pki-policy.toml) legt RSA 4096 und 3650 Tage für die CA sowie RSA 3072 und 397 Tage für das Serverzertifikat fest. Vor `pki_ready` werden Metadaten, Zertifikatskette, SAN und Übereinstimmung von Server-Key und Serverzertifikat geprüft, ohne private Inhalte zu protokollieren.
 
 ## Phase 5: LXC anlegen
 
@@ -307,20 +305,31 @@ Die Anwendung darf ausschließlich in ihrer logischen Datenbank eigene Schemaobj
 
 Vor `allocations_created` müssen Objektmenge, Eigentum, Loginstatus, Rollenattribute und fehlende Fremdrechte vollständig bestätigt sein. Ein vorhandener unerwarteter Zustand wird nicht korrigiert oder gelöscht, sondern als Konflikt gemeldet.
 
-## Phase 12: Isolation und Providerzustand prüfen
+## Phase 12: Providerzustand und lokale Allocation-Konfiguration prüfen
 
-Für jede Allocation sind später nachzuweisen:
+Für jede Allocation sind lokal administrativ nachzuweisen:
 
-- TLS-Verbindung zur eigenen Datenbank erfolgreich,
-- SCRAM-Anmeldung, aktueller Benutzer und aktuelle Datenbank korrekt,
-- Lese- und Schreibtest erfolgreich und Testobjekt unmittelbar entfernt,
-- Verbindung zu jeder fremden Allocation abgelehnt,
+- Datenbank, Eigentümer, Login- und NOLOGIN-Rollen besitzen exakt die vorgesehenen Attribute,
+- der gespeicherte Passwortverifier verwendet SCRAM-SHA-256, ohne ihn auszugeben,
+- `SET ROLE` sowie Lese- und Schreibtest in der eigenen Datenbank sind erfolgreich; das Testobjekt wird unmittelbar entfernt,
+- keine Anwendungsidentität besitzt `CONNECT` auf eine fremde Allocation,
 - `CREATEDB`, `CREATEROLE`, Superuser- und Replikationsrechte abgelehnt,
-- Klartextverbindung abgelehnt.
+- HBA und Serverkonfiguration erlauben ausschließlich TLS/SCRAM aus den geplanten Allowlists.
 
-Kennwörter werden nur aus geschützten temporären Passwortdateien gelesen.
+Kennwörter werden bei der Anlage nur aus geschützten temporären Passwortdateien gelesen. Eine echte TLS-/SCRAM-Anmeldung aus einem Consumer-Netz gehört ausdrücklich nicht zu dieser lokalen Prüfung.
 
-Providerweit werden aktiver Dienst, Major-Version, TLS, SCRAM, Listener ausschließlich auf der Provider-IP, Unix-Socket, lokale Peer-Administration, sichere Daten- und Konfigurationsmetadaten sowie das Fehlen fehlgeschlagener Units geprüft. Erst die vollständige positive und negative Testmatrix erlaubt `readiness_verified`.
+Providerweit werden aktiver Dienst, Major-Version, TLS, SCRAM, Listener ausschließlich auf der Provider-IP, Unix-Socket, lokale Peer-Administration, sichere Daten- und Konfigurationsmetadaten sowie das Fehlen fehlgeschlagener Units geprüft.
+
+Ohne laufende Consumer ist kein positiver Verbindungsnachweis aus deren späteren Quellnetzen möglich. Nach erfolgreicher Phase gilt deshalb ausschließlich:
+
+```text
+provider_status = ready
+allocation_configuration = verified
+consumer_connectivity = pending
+allocation_readiness = consumer_validation_pending
+```
+
+Die spätere Consumerinstallation muss TLS/SCRAM aus einer ausdrücklich erlaubten Quelle positiv nachweisen, bevor eine Allocation als `ready` bezeichnet werden darf.
 
 ## Phase 13: Initiale Backups
 
@@ -374,6 +383,6 @@ Nicht als Bereinigung zulässig sind das Löschen einer Datenbank, Identität, e
 
 Normaler Apply und Resume bleiben getrennte Befehls- und Freigabegrenzen. Die vollständige Zustands- und Recovery-Matrix steht in [PostgreSQL Provisioning Recovery](../recovery/postgresql-main-provisioning-recovery.md).
 
-## Noch nicht implementiert
+## Implementierungsstand
 
-Es existieren weder `scripts/postgresql-main-deploy.py` noch Apply-, Resume-, Secret-, PKI-, LXC-, Paket-, PostgreSQL-, Allocation- oder Backupcode. Der nächste Implementierungsschritt darf erst nach Review dieses Vertrags einen weiter begrenzten lokalen Mock- oder Dry-Run-Entwurf festlegen; eine reale Mutation benötigt danach erneut einen vollständigen Plan und ausdrückliche Freigabe.
+Host-/Gast-Pfad, atomarer Marker mit Einzelteilfortschritt, exklusive Sperre, Secret- und PKI-Erzeugung, LXC-Befehlsbau, Gastphasen, allocation-bezogene Backups und hashgebundener Resume sind implementiert. [Implementierungsdetails und lokale Prüfgrenzen](postgresql-main-apply-implementation.md) sind separat dokumentiert. Noch wurden weder reale Deploymentkonfiguration noch reale Infrastruktur verändert.

--- a/docs/operations/postgresql-main-apply-contract.md
+++ b/docs/operations/postgresql-main-apply-contract.md
@@ -301,6 +301,13 @@ Später werden exakt `gitea`, `openbao`, `semaphore` und `nodered` angelegt. Jed
 - keine Superuser-, `CREATEDB`-, `CREATEROLE`- oder Replikationsrechte,
 - keine Rechte auf fremde Datenbanken.
 
+Die Loginidentität wird zwar ausschließlich ihrer eigenen Eigentümerrolle
+zugeordnet, darf deren Privilegien aber weder erben noch per `SET ROLE`
+aktivieren. Die für anwendungseigene Migrationen erforderlichen Rechte auf dem
+eigenen Anwendungsschema werden stattdessen direkt und begrenzt erteilt. Damit
+kann die Anwendung Schemaobjekte verwalten, aber nicht in die
+Datenbankeigentümerrolle wechseln oder die Datenbank selbst löschen.
+
 Die Anwendung darf ausschließlich in ihrer logischen Datenbank eigene Schemaobjekte erzeugen und migrieren, aber die Datenbank nicht löschen. Die exakte PostgreSQL-Rechteabbildung wird erst im Apply-Implementierungs-PR festgelegt und mit positiven sowie negativen Tests belegt.
 
 Vor `allocations_created` müssen Objektmenge, Eigentum, Loginstatus, Rollenattribute und fehlende Fremdrechte vollständig bestätigt sein. Ein vorhandener unerwarteter Zustand wird nicht korrigiert oder gelöscht, sondern als Konflikt gemeldet.

--- a/docs/operations/postgresql-main-apply-implementation.md
+++ b/docs/operations/postgresql-main-apply-implementation.md
@@ -1,0 +1,101 @@
+# Implementierung des `postgresql-main`-Apply-/Resume-Pfads
+
+## Status und Grenze
+
+Der Host-/Gast-Pfad setzt den [Apply-Vertrag](postgresql-main-apply-contract.md) und die [Recovery-Matrix](../recovery/postgresql-main-provisioning-recovery.md) technisch um. Er wurde ausschließlich mit lokalen Fakes, Fault Injection, temporären Dateisystemen und einer lokalen OpenSSL-Prüfung getestet. In diesem Meilenstein wurden weder ein realer Plan noch `apply` oder `resume-apply` gegen Proxmox ausgeführt; das echte `/secrets` blieb unverändert.
+
+## Gemeinsame Planquelle
+
+`scripts/postgresql-main-plan.py` bleibt eine eigenständige read-only CLI. `scripts/postgresql-main-deploy.py` importiert dieselbe Planfunktion direkt und parst keine formatierte Ausgabe. Unmittelbar vor Apply werden Konfiguration, Versionsmatrix, Git-Commit, sauberer getrackter Repositoryzustand, Proxmox-Beobachtungen, Secretmetadaten und Backupziel erneut geprüft. Ausschließlich `PLAN_READY` plus exakte Übereinstimmung mit `--confirm-plan-sha256` öffnet die Mutationsgrenze.
+
+Die Host-CLI enthält nur:
+
+```text
+apply
+resume-plan
+resume-apply
+```
+
+Es gibt kein `--force`, `--yes`, Überspringen von Prüfungen, Reset, Rollback oder produktives Testbackend.
+
+## Exklusive Ausführung und sichere Dateien
+
+Mutierende Läufe halten für ihre gesamte Dauer eine nicht blockierende `fcntl.flock`-Sperre auf `/run/lock/ralf-postgresql-main.lock`. Marker und kanonische Planevidenz liegen unter `/secrets/database-service/providers/postgresql-main/`, sind `root:root` `0600` und werden mit symlinksicheren, fsync-gestützten Dateifunktionen veröffentlicht.
+
+Die zentralen Dateifunktionen verwenden nach Möglichkeit `dir_fd`, `O_NOFOLLOW`, `O_EXCL` und `O_CLOEXEC`. Sicherheitsrelevante Veröffentlichungen fsyncen Datei und Elternverzeichnis. Unsichere vorhandene Metadaten werden nicht repariert, sondern blockieren.
+
+## Marker und Einzelteilfortschritt
+
+Der Marker bindet Operation, Repository-Commit, Plan-, Konfigurations-, Matrix- und Skripthashes, VMID, abgeschlossene Phasen, offene Einzelmutation, öffentliche Zertifikatfingerprints, Backupevidenz und nicht geheime Fehlerklassen. Secretwerte, Secret-Inhaltshashes, private Schlüssel und Connection Strings sind ausgeschlossen.
+
+Mehrteilige Phasen führen geordneten Fortschritt für:
+
+- sechs erlaubte Secretverzeichnisse,
+- vier Anwendungskennwörter,
+- zehn Gastbundle-Artefakte,
+- Ubuntu-Update und -Validierung,
+- Paketinstallation und -Validierung,
+- TLS, PostgreSQL-Einstellungen, HBA, Start und Validierung,
+- vier Allocations,
+- Provider plus vier lokale Allocation-Prüfungen,
+- vier Backups.
+
+Vor jeder persistenten Einzelmutation wird `in_progress_phase` samt Element atomar gespeichert. Erst nach erfolgreicher Verifikation wird das Element bestätigt. Ein Fehlerbericht lädt stets den neuesten persistenten Marker; er kann keinen neueren Fortschritt mit einem älteren In-Memory-Zustand überschreiben.
+
+## Secrets und PKI
+
+Genau vier ASCII-Anwendungskennwörter mit mindestens 384 Bit Zufallsentropie entstehen exklusiv unter `/secrets/database-service/allocations/<id>/application-password`, `root:root` `0600`. Sie werden weder ausgegeben noch gehasht und gelangen nicht in Argumente oder normale Umgebungsvariablen. SQL mit einem Kennwort wird ausschließlich im Speicher erzeugt und über Standardinput an lokales `psql` übergeben.
+
+Die versionierte [PKI-Policy](../../deploy/postgresql/pki-policy.toml) verwendet:
+
+- CA: RSA 4096, SHA-256, 3650 Tage, kritische CA- und Key-Usage-Grenzen,
+- Server: RSA 3072, SHA-256, 397 Tage, `serverAuth`, exakt FQDN und IPv4-Adresse als SAN.
+
+OpenSSL wird nur mit festen Argumentlisten aufgerufen. CA-Key und Server-Key bleiben `0600`; nur der Server-Key gelangt kontrolliert in das PostgreSQL-TLS-Verzeichnis. Der Marker speichert ausschließlich SHA-256-Fingerprints der öffentlichen Zertifikate.
+
+## Host- und Gasttrennung
+
+Der Host besitzt eine kleine Backendgrenze für feste read-only und mutierende Proxmox-Aufrufe, Bundletransfer, Gastphasen und Backupstreams. Tests injizieren ein lokales Fake-Backend direkt; die produktive CLI besitzt dafür keinen Schalter.
+
+Der Host baut genau einen begrenzten `pct create` für den bestätigten unprivilegierten Ubuntu-26.04-LXC mit ausschließlich `nesting=1` und genau einen `pct start`. Nach jedem Schritt wird die geplante Konfiguration beziehungsweise der Status geprüft. Es gibt keinen automatischen zweiten Versuch, Stop, Reboot oder Destroy.
+
+Das Gastprogramm akzeptiert ausschließlich `classify`, eine fest benannte `apply-phase`, interne Phasenverifikation und Sicherheitsbereinigung. Es akzeptiert weder freie Befehle noch freie Phasennamen.
+
+## Ubuntu und PostgreSQL
+
+Die Gastbasis verlangt UID 0, Ubuntu 26.04 und amd64/x86_64. Sie lehnt Paketmanagerkonflikte und PGDG-Quellen ab, führt kontrolliertes Ubuntu-Update und Full-Upgrade aus und pausiert bei `/var/run/reboot-required` mit `PROVISIONING_PAUSED_REBOOT_REQUIRED`. Es erfolgt kein automatischer Reboot.
+
+Die Installation akzeptiert ausschließlich Ubuntu-Pakete `postgresql-18` und `postgresql-client-18`. Eine temporäre, konfliktprüfende `policy-rc.d` verhindert unkontrollierten Paketdienststart. Danach muss genau der gestoppte Cluster `18/main` existieren; PostgreSQL 19, weitere Major-Versionen oder zusätzliche Cluster sind Konflikte.
+
+Vor dem Start werden TLS, `listen_addresses` auf die bestätigte Provider-IP, `scram-sha-256`, TLS mindestens 1.2 und eine vollständig deterministische HBA installiert. HBA erlaubt lokale Peer-Administration für `postgres`, lehnt sonstige lokale Zugriffe ab und enthält pro Allocation nur eigene Datenbank, Loginidentität, begrenzte IPv4-CIDRs, `hostssl` und SCRAM. Breite Netze, `hostssl all all`, Remote-`trust`, `md5` und Klartextkennwortauthentifizierung sind ausgeschlossen.
+
+## Allocations und Readiness
+
+Für `gitea`, `openbao`, `semaphore` und `nodered` entstehen jeweils:
+
+- eine eigene UTF-8-Datenbank,
+- eine abgeleitete NOLOGIN-Eigentümerrolle `<application_identity>_owner`,
+- eine getrennte LOGIN-Anwendungsrolle ohne Superuser-, CREATEDB-, CREATEROLE- oder Replikationsrecht,
+- Mitgliedschaft ausschließlich in der eigenen Eigentümerrolle,
+- entzogenes globales `PUBLIC CONNECT` und keine Fremddatenbankrechte.
+
+Lokale administrative Prüfungen bestätigen Rollenattribute, Eigentum, SET-ROLE-Schreib-/Lesetest, HBA, TLS, SCRAM und fehlende Fremdrechte. Ohne laufende Consumer kann jedoch keine Verbindung aus deren späteren Quellnetzen bestätigt werden. Der Marker meldet daher:
+
+```text
+provider_status = ready
+allocation_configuration = verified
+consumer_connectivity = pending
+allocation_readiness = consumer_validation_pending
+```
+
+## Backups, Resume und Fehler
+
+Jede Allocation wird als PostgreSQL-Custom-Format direkt vom Gast in eine exklusive temporäre Hostdatei gestreamt. Nach fsync und erfolgreichem `pg_restore --list` wird sie atomar veröffentlicht. Der Marker bindet Pfad, Größe und SHA-256; Inhalte werden nicht ausgegeben. Ein Resume überspringt nur exakt passende bestätigte Archive und überschreibt keinen Namen.
+
+`resume-plan` prüft Marker, Originalplan, Repository- und Skripthashes sowie alle abgeschlossenen Phasen read-only und bindet die exakt nächste Mutation an `resume_sha256`. `resume-apply` berechnet diesen Zustand erneut. Bestätigte Einzelmutationen werden nicht wiederholt. Nach Fehlerbereinigung dürfen ausschließlich fehlende flüchtige Gast-Secretkopien identisch wieder bereitgestellt werden.
+
+Es gibt keinen automatischen Rollback und keinen automatischen Retry. Persistente Secrets, PKI, LXC, Pakete, Datenbanken, Rollen und Backups bleiben erhalten. Sicherheitsbereinigung entfernt nur temporäre Secretkopien, unveröffentlichte temporäre Dateien und eigene Hilfsressourcen. Ein Bereinigungsfehler wird zusätzlich gemeldet und verdeckt nicht die ursprüngliche Fehlerklasse.
+
+## Nächster Schritt
+
+Nach Review und Merge wird die reale Deploymentkonfiguration kontrolliert unter `/secrets` angelegt. Danach folgt genau ein realer read-only Plan. Erst nach Prüfung von Hash, Netzwerk, Ressourcen, Backupziel und Blockern darf ein einzelner Apply erneut ausdrücklich freigegeben werden.

--- a/docs/operations/postgresql-main-apply-implementation.md
+++ b/docs/operations/postgresql-main-apply-implementation.md
@@ -79,6 +79,12 @@ Für `gitea`, `openbao`, `semaphore` und `nodered` entstehen jeweils:
 - Mitgliedschaft ausschließlich in der eigenen Eigentümerrolle,
 - entzogenes globales `PUBLIC CONNECT` und keine Fremddatenbankrechte.
 
+Die Rollenmitgliedschaft wird mit deaktivierter Vererbung und ohne
+`SET ROLE`-Möglichkeit erteilt. `USAGE` und `CREATE` auf dem eigenen
+Anwendungsschema gehen direkt an die Loginrolle. Dadurch erhält sie die für
+anwendungseigene Migrationen benötigten Rechte, ohne die Datenbank als
+Eigentümer löschen zu können.
+
 Lokale administrative Prüfungen bestätigen Rollenattribute, Eigentum, SET-ROLE-Schreib-/Lesetest, HBA, TLS, SCRAM und fehlende Fremdrechte. Ohne laufende Consumer kann jedoch keine Verbindung aus deren späteren Quellnetzen bestätigt werden. Der Marker meldet daher:
 
 ```text

--- a/docs/recovery/postgresql-main-provisioning-recovery.md
+++ b/docs/recovery/postgresql-main-provisioning-recovery.md
@@ -32,7 +32,7 @@ Ein Teilzustand ohne gültigen Marker wird niemals adoptiert. Er benötigt eine 
 
 ## Normaler Apply und Resume
 
-Ein normaler Apply ist bei vorhandenem Marker oder irgendeinem Zielartefakt gesperrt. Der spätere read-only Resume-Aufruf lautet:
+Ein normaler Apply ist bei vorhandenem Marker oder irgendeinem Zielartefakt gesperrt. Der implementierte read-only Resume-Aufruf lautet:
 
 ```bash
 sudo python3 scripts/postgresql-main-deploy.py \
@@ -40,7 +40,7 @@ sudo python3 scripts/postgresql-main-deploy.py \
   --config /secrets/database-service/providers/postgresql-main/deployment.toml
 ```
 
-Der spätere mutierende Resume-Aufruf lautet:
+Der implementierte, noch nicht real ausgeführte mutierende Resume-Aufruf lautet:
 
 ```bash
 sudo python3 scripts/postgresql-main-deploy.py \
@@ -48,8 +48,6 @@ sudo python3 scripts/postgresql-main-deploy.py \
   --config /secrets/database-service/providers/postgresql-main/deployment.toml \
   --confirm-resume-sha256 <64-HEX-ZEICHEN>
 ```
-
-Keiner dieser Befehle ist implementiert.
 
 Der Resume-Plan bindet mindestens ursprünglichen `plan_sha256`, Markerhash, aktuelle read-only Beobachtungen, letzte bestätigte Phase, bereits abgeschlossene Mutationen, nächste zulässige Mutation sowie bestehende Konflikte. `--confirm-resume-sha256` bestätigt exakt diesen Resume-Plan und nicht pauschal den ursprünglichen Apply.
 
@@ -82,7 +80,7 @@ Jede Abweichung zwischen Marker und Wirklichkeit ergibt `RESUME_CONFLICT`, bevor
 | `postgresql_installed` | Major 18 und genau ein erwarteter Cluster; Remotezugriff noch nicht breit | Phase 10: geplante Sicherheitskonfiguration einspielen | Pakete deinstallieren, Cluster löschen oder Installationsversuch blind wiederholen |
 | `postgresql_configured` | effektive Peer-, TLS-, SCRAM-, Listener- und HBA-Grenzen stimmen | Phase 11: exakt vier Allocations anlegen | Konfiguration zurücksetzen oder breite Übergangsregel aktivieren |
 | `allocations_created` | vier Datenbanken, NOLOGIN-Eigentümer und getrennte Login-Identitäten stimmen | Phase 12: vollständige positive und negative Isolationstests ausführen | Datenbanken, Rollen oder Secrets löschen beziehungsweise neu anlegen |
-| `readiness_verified` | Provider- und Allocation-Readiness vollständig nachgewiesen | Phase 13: vier neue, eindeutige Backups erzeugen und prüfen | Readiness überspringen oder fremde/alte Backups als initial bestätigen |
+| `readiness_verified` | Provider ready; lokale Allocation-Konfiguration und Isolation verifiziert; Consumer-Konnektivität ausstehend | Phase 13: vier neue, eindeutige Backups erzeugen und prüfen | Consumer-Readiness vor echtem Quellnetz-Nachweis behaupten oder fremde/alte Backups bestätigen |
 | `backups_verified` | vier neue geprüfte Archive mit sicheren Metadaten | Phase 14: Abschluss erneut prüfen, temporäre Secrets entfernen, Marker abschließen | Backups entfernen, überschreiben oder unvalidiert ersetzen |
 | `completed` | Abschlussmarker, keine temporären Gastsecrets, gesamter Zielzustand konsistent | keine Provisionierungsmutation; nur read-only Status oder eigener Wartungsplan | Provisionierung erneut starten oder Marker als allgemeine Wartungsfreigabe verwenden |
 
@@ -162,6 +160,6 @@ Folgende Handlungen benötigen immer einen neuen, eigenen destruktiven oder roti
 
 Der künftige Provisionierungscode darf keine dieser Entscheidungen aus einem Fehlerzustand ableiten.
 
-## Noch nicht implementiert
+## Implementierungsstand
 
-Es existiert kein Resume-, Recovery- oder Applycode. Dieses Dokument ist ausschließlich der überprüfbare Vertrag für einen späteren, erneut separat beauftragten Implementierungsschritt.
+Resume-Plan und Resume-Apply validieren Marker, gespeicherten Originalplan, Artefakthashes, abgeschlossene Phasen und Einzelteilfortschritte. Fault-Injection-Tests decken jede persistente Grenze ab. Der Pfad wurde ausschließlich lokal mit Fakes ausgeführt; für einen realen Einsatz fehlen weiterhin die kontrolliert angelegte Deploymentkonfiguration, der reale read-only Plan und dessen neue ausdrückliche Freigabe.

--- a/scripts/postgresql-main-deploy.py
+++ b/scripts/postgresql-main-deploy.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Hash-bound apply and resume CLI for the postgresql-main provider instance."""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import secrets
+import sys
+
+from postgresql_main.filesystem import SecureFilesystem
+from postgresql_main.host import (
+    ARTIFACT_PATHS,
+    CONFIG_PATH,
+    HostBackend,
+    Provisioner,
+    build_resume_plan,
+    utc_now,
+)
+from postgresql_main.marker import MarkerStore
+from postgresql_main.models import ProvisioningError
+from postgresql_main.pki import OpenSslRunner, PkiManager, load_policy
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PKI_POLICY_PATH = REPO_ROOT / "deploy/postgresql/pki-policy.toml"
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Bounded PostgreSQL-main apply and resume path"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    apply = subparsers.add_parser("apply")
+    apply.add_argument("--config", required=True, type=pathlib.Path)
+    apply.add_argument("--confirm-plan-sha256", required=True)
+
+    resume_plan = subparsers.add_parser("resume-plan")
+    resume_plan.add_argument("--config", required=True, type=pathlib.Path)
+    resume_plan.add_argument("--format", choices=("text", "json"), default="text")
+
+    resume_apply = subparsers.add_parser("resume-apply")
+    resume_apply.add_argument("--config", required=True, type=pathlib.Path)
+    resume_apply.add_argument("--confirm-resume-sha256", required=True)
+    return parser
+
+
+def build_services() -> tuple[Provisioner, SecureFilesystem, HostBackend, MarkerStore]:
+    filesystem = SecureFilesystem()
+    backend = HostBackend()
+    store = MarkerStore(filesystem, clock=utc_now)
+    pki = PkiManager(
+        filesystem,
+        OpenSslRunner(),
+        load_policy(PKI_POLICY_PATH),
+        serial_source=lambda: secrets.randbits(158) + 1,
+    )
+    provisioner = Provisioner(
+        filesystem=filesystem,
+        backend=backend,
+        marker_store=store,
+        pki=pki,
+        artifact_paths=ARTIFACT_PATHS,
+    )
+    return provisioner, filesystem, backend, store
+
+
+def require_config_path(path: pathlib.Path) -> pathlib.Path:
+    if path != CONFIG_PATH:
+        raise ProvisioningError(
+            "CONFIG_PATH_INVALID",
+            f"Reale Konfiguration muss exakt {CONFIG_PATH} sein",
+        )
+    return path
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = create_parser().parse_args(argv)
+    try:
+        config = require_config_path(args.config)
+        provisioner, filesystem, backend, store = build_services()
+        if args.command == "apply":
+            marker = provisioner.apply(config, args.confirm_plan_sha256)
+            print(f"PROVISIONING_COMPLETED operation_id={marker['operation_id']}")
+        elif args.command == "resume-plan":
+            resume = build_resume_plan(
+                filesystem=filesystem,
+                backend=backend,
+                marker_store=store,
+                pki=provisioner.pki,
+                artifact_paths=ARTIFACT_PATHS,
+            )
+            print(resume.render_json() if args.format == "json" else resume.render_text(), end="")
+            return 0 if resume.status == "RESUME_READY" else 4
+        elif args.command == "resume-apply":
+            resume = build_resume_plan(
+                filesystem=filesystem,
+                backend=backend,
+                marker_store=store,
+                pki=provisioner.pki,
+                artifact_paths=ARTIFACT_PATHS,
+            )
+            marker = provisioner.resume(resume, args.confirm_resume_sha256)
+            print(f"PROVISIONING_COMPLETED operation_id={marker['operation_id']}")
+        return 0
+    except ProvisioningError as exc:
+        print(f"{exc.code}: {exc.message}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/postgresql-main-guest.py
+++ b/scripts/postgresql-main-guest.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""CLI entrypoint for the bounded postgresql-main guest provisioner."""
+
+from postgresql_main.guest import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/postgresql-main-plan.py
+++ b/scripts/postgresql-main-plan.py
@@ -125,6 +125,7 @@ class AllocationConfig:
     allocation_id: str
     database_name: str
     application_identity: str
+    owner_identity: str
     allowed_client_cidrs: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...]
 
 
@@ -547,6 +548,14 @@ def load_config(path: pathlib.Path) -> DeploymentConfig:
             required=allocation_keys,
             context=f"allocations[{index}]",
         )
+        application_identity = validate_name(
+            table["application_identity"],
+            f"allocations[{index}].application_identity",
+        )
+        owner_identity = validate_name(
+            f"{application_identity}_owner",
+            f"allocations[{index}].derived_owner_identity",
+        )
         allocations.append(
             AllocationConfig(
                 allocation_id=_require_string(
@@ -555,10 +564,8 @@ def load_config(path: pathlib.Path) -> DeploymentConfig:
                 database_name=validate_name(
                     table["database_name"], f"allocations[{index}].database_name"
                 ),
-                application_identity=validate_name(
-                    table["application_identity"],
-                    f"allocations[{index}].application_identity",
-                ),
+                application_identity=application_identity,
+                owner_identity=owner_identity,
                 allowed_client_cidrs=validate_cidrs(
                     table["allowed_client_cidrs"],
                     f"allocations[{index}].allowed_client_cidrs",
@@ -578,6 +585,13 @@ def load_config(path: pathlib.Path) -> DeploymentConfig:
         raise ConfigurationError("database_name muss pro Allocation eindeutig sein")
     if len(identities) != len(set(identities)):
         raise ConfigurationError("application_identity muss pro Allocation eindeutig sein")
+    owner_identities = [allocation.owner_identity for allocation in allocations]
+    if len(owner_identities) != len(set(owner_identities)):
+        raise ConfigurationError("abgeleitete Eigentümeridentität muss eindeutig sein")
+    if set(owner_identities) & (set(database_names) | set(identities)):
+        raise ConfigurationError(
+            "abgeleitete Eigentümeridentität darf nicht mit Datenbank- oder Loginnamen kollidieren"
+        )
     allocations.sort(key=lambda item: EXPECTED_ALLOCATIONS.index(item.allocation_id))
     return DeploymentConfig(provider=provider, lxc=lxc, backup=backup, allocations=tuple(allocations))
 
@@ -1177,6 +1191,7 @@ def _plan_inputs(config: DeploymentConfig, matrix: VersionMatrix) -> dict[str, o
                 "allocation_id": allocation.allocation_id,
                 "database_name": allocation.database_name,
                 "application_identity": allocation.application_identity,
+                "owner_identity": allocation.owner_identity,
                 "allowed_client_cidrs": [
                     str(item) for item in allocation.allowed_client_cidrs
                 ],
@@ -1483,15 +1498,14 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def run_plan(
+def create_plan_report(
     config_path: pathlib.Path,
     *,
     runner: CommandRunner | None = None,
     require_real_path: bool = True,
     matrix_path: pathlib.Path = VERSION_MATRIX_PATH,
-    output_format: str = "text",
     generated_at: str | None = None,
-) -> tuple[int, str]:
+) -> PlanReport:
     if require_real_path and config_path.absolute() != REAL_CONFIG_PATH:
         raise ConfigurationError(
             f"reale Deploymentkonfiguration muss exakt {REAL_CONFIG_PATH} sein; das Repository-Beispiel wird nicht verwendet"
@@ -1506,7 +1520,7 @@ def run_plan(
     timestamp = generated_at or dt.datetime.now(dt.timezone.utc).isoformat(
         timespec="seconds"
     ).replace("+00:00", "Z")
-    report = build_plan(
+    return build_plan(
         config,
         matrix,
         proxmox,
@@ -1517,6 +1531,24 @@ def run_plan(
         configuration_sha256=sha256_file(config_path),
         version_matrix_sha256=sha256_file(matrix_path),
         generated_at=timestamp,
+    )
+
+
+def run_plan(
+    config_path: pathlib.Path,
+    *,
+    runner: CommandRunner | None = None,
+    require_real_path: bool = True,
+    matrix_path: pathlib.Path = VERSION_MATRIX_PATH,
+    output_format: str = "text",
+    generated_at: str | None = None,
+) -> tuple[int, str]:
+    report = create_plan_report(
+        config_path,
+        runner=runner,
+        require_real_path=require_real_path,
+        matrix_path=matrix_path,
+        generated_at=generated_at,
     )
     if output_format == "text":
         rendered = report.render()

--- a/scripts/postgresql_main/__init__.py
+++ b/scripts/postgresql_main/__init__.py
@@ -1,0 +1,5 @@
+"""Bounded PostgreSQL main provisioning implementation."""
+
+from .models import ALLOCATION_IDS, PHASES
+
+__all__ = ["ALLOCATION_IDS", "PHASES"]

--- a/scripts/postgresql_main/filesystem.py
+++ b/scripts/postgresql_main/filesystem.py
@@ -1,0 +1,232 @@
+"""Symlink-safe, durable filesystem primitives for security-relevant files."""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import pathlib
+import stat
+import tempfile
+from collections.abc import Iterator
+
+from .models import ProvisioningError, canonical_json
+
+
+class SecureFilesystem:
+    """Map absolute logical paths into an optional injected test root."""
+
+    def __init__(self, physical_root: pathlib.Path = pathlib.Path("/")) -> None:
+        self.physical_root = physical_root.resolve()
+
+    def path(self, logical: pathlib.Path | str) -> pathlib.Path:
+        value = pathlib.Path(logical)
+        if not value.is_absolute():
+            raise ProvisioningError("PATH_INVALID", f"Pfad ist nicht absolut: {value}")
+        relative = value.relative_to("/")
+        candidate = self.physical_root / relative
+        if self.physical_root != pathlib.Path("/"):
+            return candidate
+        return value
+
+    def reject_symlink_components(self, logical: pathlib.Path | str) -> pathlib.Path:
+        target = self.path(logical)
+        try:
+            relative = target.relative_to(self.physical_root)
+        except ValueError as exc:
+            raise ProvisioningError("PATH_OUTSIDE_ROOT", str(logical)) from exc
+        current = self.physical_root
+        for part in relative.parts:
+            current /= part
+            try:
+                info = current.lstat()
+            except FileNotFoundError:
+                continue
+            if stat.S_ISLNK(info.st_mode):
+                raise ProvisioningError("SYMLINK_CONFLICT", f"Symlink unzulässig: {logical}")
+        return target
+
+    def validate(
+        self,
+        logical: pathlib.Path | str,
+        *,
+        kind: str,
+        mode: int,
+        uid: int = 0,
+        gid: int = 0,
+        require_nonempty: bool = False,
+    ) -> os.stat_result:
+        target = self.reject_symlink_components(logical)
+        try:
+            info = target.lstat()
+        except FileNotFoundError as exc:
+            raise ProvisioningError("PATH_MISSING", f"Pfad fehlt: {logical}") from exc
+        expected_type = stat.S_ISDIR if kind == "directory" else stat.S_ISREG
+        if not expected_type(info.st_mode):
+            raise ProvisioningError("PATH_TYPE_CONFLICT", f"Falscher Typ: {logical}")
+        if stat.S_IMODE(info.st_mode) != mode or info.st_uid != uid or info.st_gid != gid:
+            raise ProvisioningError("PATH_METADATA_CONFLICT", f"Unsichere Metadaten: {logical}")
+        if require_nonempty and info.st_size == 0:
+            raise ProvisioningError("EMPTY_SECRET", f"Datei ist leer: {logical}")
+        return info
+
+    def ensure_directory(
+        self,
+        logical: pathlib.Path | str,
+        *,
+        mode: int = 0o700,
+        uid: int = 0,
+        gid: int = 0,
+    ) -> pathlib.Path:
+        target = self.reject_symlink_components(logical)
+        if target.exists():
+            self.validate(logical, kind="directory", mode=mode, uid=uid, gid=gid)
+            return target
+        parent = target.parent
+        if not parent.exists():
+            raise ProvisioningError("PARENT_MISSING", f"Elternpfad fehlt: {parent}")
+        parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            os.mkdir(target.name, mode=mode, dir_fd=parent_fd)
+            os.chown(target.name, uid, gid, dir_fd=parent_fd, follow_symlinks=False)
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+        self.validate(logical, kind="directory", mode=mode, uid=uid, gid=gid)
+        return target
+
+    def exclusive_bytes(
+        self,
+        logical: pathlib.Path | str,
+        data: bytes,
+        *,
+        mode: int = 0o600,
+        uid: int = 0,
+        gid: int = 0,
+    ) -> pathlib.Path:
+        target = self.reject_symlink_components(logical)
+        parent_fd = os.open(target.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            fd = os.open(target.name, flags, mode, dir_fd=parent_fd)
+            try:
+                os.fchmod(fd, mode)
+                os.fchown(fd, uid, gid)
+                view = memoryview(data)
+                while view:
+                    written = os.write(fd, view)
+                    view = view[written:]
+                os.fsync(fd)
+            finally:
+                os.close(fd)
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+        self.validate(logical, kind="file", mode=mode, uid=uid, gid=gid)
+        return target
+
+    def atomic_bytes(
+        self,
+        logical: pathlib.Path | str,
+        data: bytes,
+        *,
+        mode: int = 0o600,
+        uid: int = 0,
+        gid: int = 0,
+    ) -> pathlib.Path:
+        target = self.reject_symlink_components(logical)
+        parent = target.parent
+        parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        fd, temporary = tempfile.mkstemp(prefix=f".{target.name}.", dir=parent)
+        temporary_path = pathlib.Path(temporary)
+        try:
+            os.fchmod(fd, mode)
+            os.fchown(fd, uid, gid)
+            view = memoryview(data)
+            while view:
+                written = os.write(fd, view)
+                view = view[written:]
+            os.fsync(fd)
+            os.close(fd)
+            fd = -1
+            if target.exists() and target.is_symlink():
+                raise ProvisioningError("SYMLINK_CONFLICT", f"Symlink unzulässig: {logical}")
+            os.replace(temporary_path.name, target.name, src_dir_fd=parent_fd, dst_dir_fd=parent_fd)
+            os.fsync(parent_fd)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            with contextlib.suppress(FileNotFoundError):
+                temporary_path.unlink()
+            os.close(parent_fd)
+        self.validate(logical, kind="file", mode=mode, uid=uid, gid=gid)
+        return target
+
+    def atomic_json(self, logical: pathlib.Path | str, value: object) -> pathlib.Path:
+        return self.atomic_bytes(logical, canonical_json(value) + b"\n")
+
+    def exclusive_json(self, logical: pathlib.Path | str, value: object) -> pathlib.Path:
+        return self.exclusive_bytes(logical, canonical_json(value) + b"\n")
+
+    def read_json(self, logical: pathlib.Path | str) -> object:
+        data = self.read_bytes(logical, maximum=2_000_000)
+        try:
+            return json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ProvisioningError("JSON_INVALID", f"Ungültiges JSON: {logical}") from exc
+
+    def read_bytes(self, logical: pathlib.Path | str, *, maximum: int = 2_000_000) -> bytes:
+        target = self.reject_symlink_components(logical)
+        flags = os.O_RDONLY | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(target, flags)
+        try:
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                chunk = os.read(fd, 65_536)
+                if not chunk:
+                    break
+                total += len(chunk)
+                if total > maximum:
+                    raise ProvisioningError("FILE_TOO_LARGE", f"Datei zu groß: {logical}")
+                chunks.append(chunk)
+        finally:
+            os.close(fd)
+        return b"".join(chunks)
+
+    @contextlib.contextmanager
+    def exclusive_lock(self, logical: pathlib.Path | str) -> Iterator[int]:
+        import fcntl
+
+        target = self.reject_symlink_components(logical)
+        parent = target.parent
+        parent.mkdir(parents=True, exist_ok=True) if self.physical_root != pathlib.Path("/") else None
+        if target.exists():
+            info = target.lstat()
+            if not stat.S_ISREG(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o600:
+                raise ProvisioningError("LOCK_CONFLICT", "Sperrpfad besitzt falsche Metadaten")
+            if self.physical_root == pathlib.Path("/") and (info.st_uid != 0 or info.st_gid != 0):
+                raise ProvisioningError("LOCK_CONFLICT", "Sperrpfad gehört nicht root:root")
+        flags = os.O_RDWR | os.O_CREAT | os.O_CLOEXEC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(target, flags, 0o600)
+        try:
+            os.fchmod(fd, 0o600)
+            if os.geteuid() == 0:
+                os.fchown(fd, 0, 0)
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise ProvisioningError(
+                    "PROVISIONING_ALREADY_RUNNING", "Provisionierung läuft bereits"
+                ) from exc
+            yield fd
+        finally:
+            with contextlib.suppress(OSError):
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            os.close(fd)

--- a/scripts/postgresql_main/guest.py
+++ b/scripts/postgresql_main/guest.py
@@ -1,0 +1,679 @@
+"""Guest-side bounded Ubuntu and PostgreSQL provisioning phases."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import grp
+import hashlib
+import ipaddress
+import json
+import os
+import pathlib
+import platform
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+
+from .models import ALLOCATION_IDS, ProvisioningError
+
+
+GUEST_PHASES = (
+    "guest_os_ready",
+    "postgresql_installed",
+    "postgresql_configured",
+    "allocations_created",
+    "readiness_verified",
+)
+GUEST_ITEMS = (
+    "apt_update", "full_upgrade", "validate", "packages", "tls", "settings",
+    "hba", "start", "provider", *ALLOCATION_IDS,
+)
+BUNDLE_ROOT = pathlib.Path("/run/ralf-database-provision")
+POSTGRESQL_ROOT = pathlib.Path("/etc/postgresql/18/main")
+TLS_ROOT = POSTGRESQL_ROOT / "tls"
+HBA_PATH = POSTGRESQL_ROOT / "pg_hba.conf"
+POLICY_RC_PATH = pathlib.Path("/usr/sbin/policy-rc.d")
+
+
+class GuestCommandRunner:
+    def __init__(self, executor: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run) -> None:
+        self.executor = executor
+
+    def run(
+        self,
+        arguments: Sequence[str],
+        *,
+        input_data: bytes | None = None,
+        timeout: int = 300,
+        allowed_returncodes: tuple[int, ...] = (0,),
+    ) -> bytes:
+        if not self._allowed(arguments):
+            raise ProvisioningError("GUEST_COMMAND_BLOCKED", "Gastbefehl nicht erlaubt")
+        try:
+            result = self.executor(
+                list(arguments), input=input_data, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE, timeout=timeout, check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ProvisioningError("GUEST_COMMAND_FAILED", f"Gastoperation fehlgeschlagen: {arguments[0]}") from exc
+        if result.returncode not in allowed_returncodes:
+            raise ProvisioningError("GUEST_COMMAND_FAILED", f"Gastoperation fehlgeschlagen: {arguments[0]}")
+        return result.stdout[:262_144]
+
+    @staticmethod
+    def _allowed(arguments: Sequence[str]) -> bool:
+        if not arguments:
+            return False
+        command = arguments[0]
+        return command in {
+            "apt-get", "apt-cache", "dpkg", "uname", "systemctl", "ip", "df",
+            "pg_lsclusters", "pg_conftool",
+            "pg_ctlcluster", "pg_isready", "ss", "runuser", "openssl", "findmnt",
+        }
+
+
+def _safe_identifier(value: str) -> str:
+    if not re.fullmatch(r"[a-z][a-z0-9_]{0,62}", value):
+        raise ProvisioningError("IDENTIFIER_INVALID", "PostgreSQL-Bezeichner ungültig")
+    return value
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + _safe_identifier(value).replace('"', '""') + '"'
+
+
+def _quote_literal(value: str) -> str:
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ProvisioningError("SECRET_CONTENT_INVALID", "Secret enthält Steuerzeichen")
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _atomic_file(path: pathlib.Path, data: bytes, *, mode: int, uid: int = 0, gid: int = 0) -> None:
+    current = pathlib.Path(path.anchor)
+    for part in path.parent.parts[1:] if path.is_absolute() else path.parent.parts:
+        current /= part
+        if current.is_symlink():
+            raise ProvisioningError("GUEST_PATH_CONFLICT", f"Symlink unzulässig: {current}")
+    if path.is_symlink():
+        raise ProvisioningError("GUEST_PATH_CONFLICT", f"Symlink unzulässig: {path}")
+    path.parent.mkdir(mode=0o750, parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = pathlib.Path(temporary)
+    try:
+        os.fchmod(fd, mode)
+        os.fchown(fd, uid, gid)
+        view = memoryview(data)
+        while view:
+            size = os.write(fd, view)
+            view = view[size:]
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        os.replace(temp_path, path)
+        parent_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+        try:
+            os.fsync(parent_fd)
+        finally:
+            os.close(parent_fd)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        with contextlib.suppress(FileNotFoundError):
+            temp_path.unlink()
+
+
+def read_secret(path: pathlib.Path) -> str:
+    try:
+        info = path.lstat()
+    except OSError as exc:
+        raise ProvisioningError("SECRET_METADATA_INVALID", f"Secret fehlt: {path.name}") from exc
+    if not stat.S_ISREG(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o600 or info.st_uid != 0 or info.st_gid != 0 or info.st_size == 0:
+        raise ProvisioningError("SECRET_METADATA_INVALID", f"Secretmetadaten ungültig: {path.name}")
+    flags = os.O_RDONLY | os.O_CLOEXEC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(path, flags)
+    try:
+        data = os.read(fd, 4097)
+    finally:
+        os.close(fd)
+    if len(data) > 4096:
+        raise ProvisioningError("SECRET_CONTENT_INVALID", "Secret ist zu lang")
+    try:
+        value = data.decode("ascii")
+    except UnicodeDecodeError as exc:
+        raise ProvisioningError("SECRET_CONTENT_INVALID", "Secret ist nicht ASCII") from exc
+    if not value or any(char.isspace() or ord(char) < 33 or ord(char) == 127 for char in value):
+        raise ProvisioningError("SECRET_CONTENT_INVALID", "Secretformat ungültig")
+    return value
+
+
+def load_guest_plan(bundle: pathlib.Path) -> dict[str, object]:
+    path = bundle / "guest-plan.json"
+    if path.is_symlink() or not path.is_file():
+        raise ProvisioningError("GUEST_PLAN_INVALID", "guest-plan.json fehlt")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProvisioningError("GUEST_PLAN_INVALID", "guest-plan.json ungültig") from exc
+    if not isinstance(value, dict) or set(value) != {
+        "schema_version", "provider_instance_id", "postgresql_major", "fqdn", "hostname",
+        "provider_ip", "gateway", "dns_servers", "allocations"
+    }:
+        raise ProvisioningError("GUEST_PLAN_INVALID", "Gastplanfelder ungültig")
+    if value["schema_version"] != 1 or value["provider_instance_id"] != "postgresql-main" or value["postgresql_major"] != 18:
+        raise ProvisioningError("GUEST_PLAN_INVALID", "Gastprofil ungültig")
+    try:
+        ipaddress.IPv4Address(str(value["provider_ip"]))
+        ipaddress.IPv4Address(str(value["gateway"]))
+        for server in value["dns_servers"]:
+            ipaddress.ip_address(str(server))
+    except ipaddress.AddressValueError as exc:
+        raise ProvisioningError("GUEST_PLAN_INVALID", "Provider-IP ungültig") from exc
+    allocations = value["allocations"]
+    if not isinstance(allocations, list) or [item.get("allocation_id") for item in allocations if isinstance(item, dict)] != list(ALLOCATION_IDS):
+        raise ProvisioningError("GUEST_PLAN_INVALID", "Allocation-Menge ungültig")
+    for allocation in allocations:
+        _safe_identifier(str(allocation["database_name"]))
+        _safe_identifier(str(allocation["application_identity"]))
+        _safe_identifier(str(allocation["owner_identity"]))
+        for raw in allocation["allowed_client_cidrs"]:
+            network = ipaddress.ip_network(str(raw), strict=True)
+            if not isinstance(network, ipaddress.IPv4Network) or network.prefixlen == 0:
+                raise ProvisioningError("GUEST_PLAN_INVALID", "Nur begrenzte IPv4-Allowlists sind zulässig")
+    return value
+
+
+def verify_manifest(bundle: pathlib.Path) -> None:
+    manifest_path = bundle / "public-manifest.json"
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ProvisioningError("BUNDLE_INVALID", "Manifest ungültig") from exc
+    if set(manifest) != {"schema_version", "artifacts"} or manifest["schema_version"] != 1:
+        raise ProvisioningError("BUNDLE_INVALID", "Manifest-Schema ungültig")
+    expected = {"postgresql-main-guest.py", "guest-plan.json", "ca.crt", "server.crt"}
+    if set(manifest["artifacts"]) != expected:
+        raise ProvisioningError("BUNDLE_INVALID", "Manifest-Artefakte ungültig")
+    for name, digest in manifest["artifacts"].items():
+        path = bundle / name
+        if path.is_symlink() or not path.is_file():
+            raise ProvisioningError("BUNDLE_INVALID", f"Artefakt fehlt: {name}")
+        if hashlib.sha256(path.read_bytes()).hexdigest() != digest:
+            raise ProvisioningError("BUNDLE_INVALID", f"Artefakthash falsch: {name}")
+    for allocation in ALLOCATION_IDS:
+        read_secret(bundle / allocation / "application-password")
+
+
+def render_hba(plan: Mapping[str, object]) -> str:
+    lines = [
+        "# Managed by RALF postgresql-main provisioning",
+        "local all postgres peer",
+        "local all all reject",
+    ]
+    for allocation in plan["allocations"]:
+        database = _safe_identifier(str(allocation["database_name"]))
+        identity = _safe_identifier(str(allocation["application_identity"]))
+        for cidr in allocation["allowed_client_cidrs"]:
+            network = ipaddress.ip_network(str(cidr), strict=True)
+            if not isinstance(network, ipaddress.IPv4Network) or network.prefixlen == 0:
+                raise ProvisioningError("HBA_INVALID", "Nur begrenzte IPv4-CIDRs sind zulässig")
+            lines.append(f"hostssl {database} {identity} {network} scram-sha-256")
+    lines.extend((
+        "host all all 0.0.0.0/1 reject",
+        "host all all 128.0.0.0/1 reject",
+        "host all all ::/1 reject",
+        "host all all 8000::/1 reject",
+    ))
+    return "\n".join(lines) + "\n"
+
+
+def validate_hba(text: str) -> None:
+    lowered = text.lower()
+    forbidden = (
+        "0.0.0.0/0", "::/0", "hostssl all all", " trust", " md5", " password",
+    )
+    if any(item in lowered for item in forbidden):
+        raise ProvisioningError("HBA_UNSAFE", "HBA enthält breite oder schwache Regel")
+    for line in text.splitlines():
+        if line.startswith("hostssl ") and not line.endswith(" scram-sha-256"):
+            raise ProvisioningError("HBA_UNSAFE", "hostssl ohne SCRAM")
+
+
+class GuestProvisioner:
+    def __init__(
+        self,
+        *,
+        runner: GuestCommandRunner,
+        bundle: pathlib.Path = BUNDLE_ROOT,
+        root: pathlib.Path = pathlib.Path("/"),
+        fault: Callable[[str], None] = lambda _point: None,
+    ) -> None:
+        self.runner = runner
+        self.bundle = bundle
+        self.root = root
+        self.fault = fault
+        self.plan = load_guest_plan(bundle)
+
+    def target(self, absolute: pathlib.Path) -> pathlib.Path:
+        return self.root / absolute.relative_to("/")
+
+    def _os_release(self) -> Mapping[str, str]:
+        result: dict[str, str] = {}
+        for line in self.target(pathlib.Path("/etc/os-release")).read_text(encoding="utf-8").splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                result[key] = value.strip('"')
+        return result
+
+    def _validate_base(self) -> None:
+        if os.geteuid() != 0:
+            raise ProvisioningError("ROOT_REQUIRED", "Gastphase benötigt UID 0")
+        release = self._os_release()
+        if release.get("ID") != "ubuntu" or release.get("VERSION_ID") != "26.04":
+            raise ProvisioningError("GUEST_OS_CONFLICT", "Ubuntu 26.04 erforderlich")
+        machine = platform.machine()
+        if machine not in {"x86_64", "amd64"}:
+            raise ProvisioningError("GUEST_ARCH_CONFLICT", "amd64/x86_64 erforderlich")
+
+    def _reject_pgdg(self) -> None:
+        apt_root = self.target(pathlib.Path("/etc/apt"))
+        for path in apt_root.rglob("*"):
+            if path.is_file() and not path.is_symlink() and path.suffix in {".list", ".sources"}:
+                text = path.read_text(encoding="utf-8", errors="replace").lower()
+                if "apt.postgresql.org" in text or "postgresql.org/pub/repos/apt" in text:
+                    raise ProvisioningError("PGDG_SOURCE_CONFLICT", "PGDG-Quelle ist unzulässig")
+
+    def classify(self) -> str:
+        self._validate_base()
+        verify_manifest(self.bundle)
+        self._reject_pgdg()
+        clusters = self.runner.run(["pg_lsclusters", "--no-header"], allowed_returncodes=(0, 1)).decode("utf-8", "replace")
+        if not clusters.strip():
+            return "guest_os_ready"
+        rows = [line.split() for line in clusters.splitlines() if line.strip()]
+        if len(rows) != 1 or rows[0][:2] != ["18", "main"]:
+            return "guest_conflict"
+        return "postgresql_installed" if rows[0][3] == "down" else "postgresql_running"
+
+    def apply_phase(self, phase: str, item: str | None) -> str:
+        if phase not in GUEST_PHASES:
+            raise ProvisioningError("GUEST_PHASE_INVALID", phase)
+        self._validate_base()
+        verify_manifest(self.bundle)
+        self._reject_pgdg()
+        if phase == "guest_os_ready":
+            return self.prepare_os(item)
+        if phase == "postgresql_installed":
+            self.install_postgresql(item)
+        elif phase == "postgresql_configured":
+            self.configure_postgresql(item)
+        elif phase == "allocations_created":
+            if item not in ALLOCATION_IDS:
+                raise ProvisioningError("GUEST_ITEM_INVALID", str(item))
+            self.create_allocation(item)
+        elif phase == "readiness_verified":
+            if item not in ("provider", *ALLOCATION_IDS):
+                raise ProvisioningError("GUEST_ITEM_INVALID", str(item))
+            self.verify_readiness(item)
+        self.verify_phase(phase, item)
+        return f"PHASE_COMPLETED {phase}" + (f" {item}" if item else "")
+
+    def prepare_os(self, item: str | None) -> str:
+        if item not in {"apt_update", "full_upgrade", "validate"}:
+            raise ProvisioningError("GUEST_ITEM_INVALID", str(item))
+        locks = (
+            self.target(pathlib.Path("/var/lib/dpkg/lock-frontend")),
+            self.target(pathlib.Path("/var/lib/apt/lists/lock")),
+        )
+        for path in locks:
+            if path.exists():
+                fd = os.open(path, os.O_RDONLY | os.O_CLOEXEC)
+                try:
+                    import fcntl
+                    try:
+                        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except BlockingIOError as exc:
+                        raise ProvisioningError("PACKAGE_MANAGER_LOCKED", "Paketmanager ist belegt") from exc
+                finally:
+                    os.close(fd)
+        if item == "apt_update":
+            self.runner.run(["apt-get", "update"])
+            self.fault("after_apt_update")
+        elif item == "full_upgrade":
+            self.runner.run(["apt-get", "-y", "full-upgrade"])
+            if self.target(pathlib.Path("/var/run/reboot-required")).exists():
+                return "PROVISIONING_PAUSED_REBOOT_REQUIRED"
+        else:
+            self.runner.run(["dpkg", "--audit"])
+            self._verify_runtime_base()
+        return f"PHASE_COMPLETED guest_os_ready {item}"
+
+    def _verify_runtime_base(self) -> None:
+        self.runner.run(["systemctl", "is-system-running"])
+        failed = self.runner.run(["systemctl", "--failed", "--no-legend"]).decode("utf-8", "replace")
+        if failed.strip():
+            raise ProvisioningError("GUEST_UNITS_FAILED", "Fehlgeschlagene systemd-Units vorhanden")
+        addresses = self.runner.run(["ip", "-4", "address", "show"]).decode("utf-8", "replace")
+        routes = self.runner.run(["ip", "-4", "route", "show"]).decode("utf-8", "replace")
+        if str(self.plan["provider_ip"]) not in addresses or f"default via {self.plan['gateway']}" not in routes:
+            raise ProvisioningError("GUEST_NETWORK_CONFLICT", "Gastnetz weicht vom Plan ab")
+        resolv = self.target(pathlib.Path("/etc/resolv.conf")).read_text(encoding="utf-8", errors="replace")
+        if not any(f"nameserver {server}" in resolv for server in self.plan["dns_servers"]):
+            raise ProvisioningError("GUEST_DNS_CONFLICT", "Kein geplanter DNS-Server aktiv")
+        disk = self.runner.run(["df", "-Pk", "/"]).decode("utf-8", "replace")
+        numbers = re.findall(r"\d+", disk.splitlines()[-1] if disk.splitlines() else "")
+        if len(numbers) < 3 or int(numbers[2]) < 2_097_152:
+            raise ProvisioningError("GUEST_STORAGE_LOW", "Weniger als 2 GiB frei")
+        apt_root = self.target(pathlib.Path("/etc/apt"))
+        ubuntu_sources: list[str] = []
+        for path in apt_root.rglob("*"):
+            if path.is_file() and not path.is_symlink() and path.suffix in {".list", ".sources"}:
+                ubuntu_sources.extend(
+                    line.strip() for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+                    if "ubuntu" in line.lower() and ("uri" in line.lower() or line.lstrip().startswith("deb "))
+                )
+        if not ubuntu_sources or any("http://" in line.lower() for line in ubuntu_sources):
+            raise ProvisioningError("UBUNTU_SOURCE_SECURITY_CONFLICT", "Ubuntu-Paketquellen müssen HTTPS verwenden")
+
+    def install_postgresql(self, item: str | None) -> None:
+        if item not in {"packages", "validate"}:
+            raise ProvisioningError("GUEST_ITEM_INVALID", str(item))
+        if item == "validate":
+            self._verify_cluster(expected_status="down")
+            return
+        candidate = self.runner.run(["apt-cache", "policy", "postgresql-18"]).decode("utf-8", "replace")
+        match = re.search(r"^\s*Candidate:\s*(\S+)", candidate, re.MULTILINE)
+        if not match or not re.match(r"^18(?:\.|\+|~)", match.group(1)):
+            raise ProvisioningError("POSTGRESQL_CANDIDATE_CONFLICT", "Ubuntu bietet keine erwartete PostgreSQL-18-Version")
+        policy = self.target(POLICY_RC_PATH)
+        if policy.exists() or policy.is_symlink():
+            raise ProvisioningError("POLICY_RC_CONFLICT", "policy-rc.d existiert bereits")
+        _atomic_file(policy, b"#!/bin/sh\nexit 101\n", mode=0o755)
+        try:
+            self.runner.run(["apt-get", "-y", "install", "postgresql-18", "postgresql-client-18"])
+            self.fault("after_postgresql_install")
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                policy.unlink()
+        self._verify_cluster(expected_status="down")
+
+    def _verify_cluster(self, *, expected_status: str | None = None) -> None:
+        clusters = self.runner.run(["pg_lsclusters", "--no-header"]).decode("utf-8", "replace")
+        rows = [line.split() for line in clusters.splitlines() if line.strip()]
+        if len(rows) != 1 or rows[0][:2] != ["18", "main"]:
+            raise ProvisioningError("POSTGRESQL_CLUSTER_CONFLICT", "Erwartet wird genau 18/main")
+        if expected_status is not None and rows[0][3] != expected_status:
+            raise ProvisioningError("POSTGRESQL_STARTED_EARLY", "Cluster startete vor Sicherheitskonfiguration")
+
+    def configure_postgresql(self, item: str | None) -> None:
+        if item not in {"tls", "settings", "hba", "start", "validate"}:
+            raise ProvisioningError("GUEST_ITEM_INVALID", str(item))
+        postgres_gid = grp.getgrnam("postgres").gr_gid
+        if item == "tls":
+            self._validate_bundle_pki()
+            tls_root = self.target(TLS_ROOT)
+            tls_root.mkdir(mode=0o750, parents=True, exist_ok=True)
+            os.chown(tls_root, 0, postgres_gid)
+            os.chmod(tls_root, 0o750)
+            _atomic_file(tls_root / "server.key", (self.bundle / "server.key").read_bytes(), mode=0o640, uid=0, gid=postgres_gid)
+            _atomic_file(tls_root / "server.crt", (self.bundle / "server.crt").read_bytes(), mode=0o644)
+            _atomic_file(tls_root / "ca.crt", (self.bundle / "ca.crt").read_bytes(), mode=0o644)
+        elif item == "settings":
+            settings = (
+                ("listen_addresses", str(self.plan["provider_ip"])),
+                ("ssl", "on"),
+                ("ssl_cert_file", str(TLS_ROOT / "server.crt")),
+                ("ssl_key_file", str(TLS_ROOT / "server.key")),
+                ("ssl_ca_file", str(TLS_ROOT / "ca.crt")),
+                ("password_encryption", "scram-sha-256"),
+                ("ssl_min_protocol_version", "TLSv1.2"),
+            )
+            for key, value in settings:
+                self.runner.run(["pg_conftool", "18", "main", "set", key, value])
+        elif item == "hba":
+            hba = render_hba(self.plan)
+            validate_hba(hba)
+            _atomic_file(self.target(HBA_PATH), hba.encode("ascii"), mode=0o640, uid=0, gid=postgres_gid)
+        elif item == "start":
+            self.runner.run(["pg_conftool", "18", "main", "show"])
+            self.runner.run(["pg_ctlcluster", "18", "main", "start"])
+            self.fault("after_postgresql_configuration")
+        else:
+            self.verify_phase("postgresql_configured", "validate")
+
+    def _validate_bundle_pki(self) -> None:
+        ca = self.bundle / "ca.crt"
+        certificate = self.bundle / "server.crt"
+        key = self.bundle / "server.key"
+        self.runner.run(["openssl", "verify", "-CAfile", str(ca), str(certificate)])
+        text = self.runner.run([
+            "openssl", "x509", "-in", str(certificate), "-noout", "-text",
+        ]).decode("utf-8", "replace")
+        if f"DNS:{self.plan['fqdn']}" not in text or f"IP Address:{self.plan['provider_ip']}" not in text:
+            raise ProvisioningError("PKI_SAN_MISMATCH", "Serverzertifikat bindet Plan nicht")
+        key_public = self.runner.run(["openssl", "pkey", "-in", str(key), "-pubout"])
+        cert_public = self.runner.run(["openssl", "x509", "-in", str(certificate), "-pubkey", "-noout"])
+        if hashlib.sha256(key_public).digest() != hashlib.sha256(cert_public).digest():
+            raise ProvisioningError("PKI_KEY_MISMATCH", "Server-Key passt nicht zum Zertifikat")
+
+    def _allocation(self, allocation_id: str) -> Mapping[str, object]:
+        return next(item for item in self.plan["allocations"] if item["allocation_id"] == allocation_id)
+
+    def _psql(self, sql: str, *, database: str = "postgres") -> bytes:
+        return self.runner.run([
+            "runuser", "-u", "postgres", "--", "psql", "-X", "--no-psqlrc",
+            "--set", "ON_ERROR_STOP=1", "--dbname", database,
+        ], input_data=sql.encode("utf-8"))
+
+    def _query(self, sql: str, *, database: str = "postgres") -> str:
+        return self.runner.run([
+            "runuser", "-u", "postgres", "--", "psql", "-X", "--no-psqlrc",
+            "--set", "ON_ERROR_STOP=1", "--tuples-only", "--no-align",
+            "--dbname", database,
+        ], input_data=sql.encode("utf-8")).decode("utf-8", "replace").strip()
+
+    def create_allocation(self, allocation_id: str) -> None:
+        allocation = self._allocation(allocation_id)
+        database = _safe_identifier(str(allocation["database_name"]))
+        login = _safe_identifier(str(allocation["application_identity"]))
+        owner = _safe_identifier(str(allocation["owner_identity"]))
+        secret = read_secret(self.bundle / allocation_id / "application-password")
+        owner_state = self._query(
+            "SELECT rolcanlogin::text||'|'||rolsuper::text||'|'||rolcreatedb::text||'|'||rolcreaterole::text||'|'||rolreplication::text "
+            f"FROM pg_roles WHERE rolname={_quote_literal(owner)};\n"
+        )
+        if not owner_state:
+            self._psql(
+                f"CREATE ROLE {_quote_identifier(owner)} NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION;\n"
+            )
+        elif owner_state != "false|false|false|false|false" and owner_state != "f|f|f|f|f":
+            raise ProvisioningError("ALLOCATION_ROLE_CONFLICT", f"Eigentümerrolle weicht ab: {allocation_id}")
+        login_state = self._query(
+            "SELECT rolcanlogin::text||'|'||rolsuper::text||'|'||rolcreatedb::text||'|'||rolcreaterole::text||'|'||rolreplication::text "
+            f"FROM pg_roles WHERE rolname={_quote_literal(login)};\n"
+        )
+        if not login_state:
+            self._psql(
+                f"CREATE ROLE {_quote_identifier(login)} LOGIN INHERIT NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION PASSWORD {_quote_literal(secret)};\n"
+            )
+        elif login_state not in {"true|false|false|false|false", "t|f|f|f|f"}:
+            raise ProvisioningError("ALLOCATION_ROLE_CONFLICT", f"Loginrolle weicht ab: {allocation_id}")
+        membership = self._query(
+            f"SELECT pg_has_role({_quote_literal(login)}, {_quote_literal(owner)}, 'member');\n"
+        )
+        if membership not in {"t", "true"}:
+            self._psql(f"GRANT {_quote_identifier(owner)} TO {_quote_identifier(login)};\n")
+        database_owner = self._query(
+            "SELECT pg_get_userbyid(datdba) FROM pg_database "
+            f"WHERE datname={_quote_literal(database)};\n"
+        )
+        if not database_owner:
+            self._psql(
+                f"CREATE DATABASE {_quote_identifier(database)} OWNER {_quote_identifier(owner)} ENCODING 'UTF8' TEMPLATE template0;\n"
+            )
+        elif database_owner != owner:
+            raise ProvisioningError("ALLOCATION_DATABASE_CONFLICT", f"Datenbankeigentümer weicht ab: {allocation_id}")
+        self._psql(
+            "\n".join((
+                "REVOKE CONNECT ON DATABASE " + _quote_identifier(database) + " FROM PUBLIC;",
+                "GRANT CONNECT ON DATABASE " + _quote_identifier(database) + " TO " + _quote_identifier(login) + ";",
+                "",
+            ))
+        )
+        self._psql(
+            "REVOKE CREATE ON SCHEMA public FROM PUBLIC;\n"
+            "GRANT USAGE, CREATE ON SCHEMA public TO " + _quote_identifier(owner) + ";\n",
+            database=database,
+        )
+        self.fault(f"after_allocation:{allocation_id}")
+
+    def verify_readiness(self, item: str) -> None:
+        if item == "provider":
+            self.runner.run(["pg_isready", "--timeout=5"])
+            output = self.runner.run(["ss", "-ltnp"]).decode("utf-8", "replace")
+            if "0.0.0.0:5432" in output or "[::]:5432" in output:
+                raise ProvisioningError("LISTENER_TOO_BROAD", "PostgreSQL lauscht global")
+            if f"{self.plan['provider_ip']}:5432" not in output:
+                raise ProvisioningError("LISTENER_MISSING", "Providerlistener fehlt")
+            settings = self._query(
+                "SHOW server_version_num; SHOW ssl; SHOW password_encryption; SHOW ssl_min_protocol_version;\n"
+                "SELECT count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL;\n"
+            ).splitlines()
+            if len(settings) != 5 or not settings[0].startswith("18") or settings[1:] != ["on", "scram-sha-256", "TLSv1.2", "0"]:
+                raise ProvisioningError("POSTGRESQL_RUNTIME_CONFLICT", "Runtime- oder HBA-Zustand weicht ab")
+            return
+        allocation = self._allocation(item)
+        login = _quote_literal(str(allocation["application_identity"]))
+        owner = _quote_literal(str(allocation["owner_identity"]))
+        database = _quote_literal(str(allocation["database_name"]))
+        result = self._query(
+            "SELECT 1 FROM pg_roles WHERE rolname=" + login + " AND rolcanlogin AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole AND NOT rolreplication AND rolpassword LIKE 'SCRAM-SHA-256$%';\n"
+            "SELECT 1 FROM pg_roles WHERE rolname=" + owner + " AND NOT rolcanlogin AND NOT rolsuper AND NOT rolcreatedb AND NOT rolcreaterole AND NOT rolreplication;\n"
+            "SELECT 1 FROM pg_database WHERE datname=" + database + ";\n"
+        )
+        if result.splitlines() != ["1", "1", "1"]:
+            raise ProvisioningError("ALLOCATION_CONFIGURATION_CONFLICT", f"Allocationattribute weichen ab: {item}")
+        allocation = self._allocation(item)
+        login_name = _safe_identifier(str(allocation["application_identity"]))
+        database_name = _safe_identifier(str(allocation["database_name"]))
+        self._psql(
+            f"SET ROLE {_quote_identifier(login_name)};\n"
+            "CREATE TEMP TABLE ralf_readiness_probe(value integer);\n"
+            "INSERT INTO ralf_readiness_probe VALUES (1);\n"
+            "SELECT value FROM ralf_readiness_probe;\n"
+            "DROP TABLE ralf_readiness_probe;\nRESET ROLE;\n",
+            database=database_name,
+        )
+        for foreign in self.plan["allocations"]:
+            if foreign["allocation_id"] == item:
+                continue
+            has_connect = self._query(
+                "SELECT has_database_privilege("
+                f"{_quote_literal(login_name)}, {_quote_literal(str(foreign['database_name']))}, 'CONNECT');\n"
+            )
+            if has_connect not in {"f", "false"}:
+                raise ProvisioningError("ISOLATION_VIOLATION", f"Fremdzugriff möglich: {item}")
+
+    def verify_phase(self, phase: str, item: str | None = None) -> None:
+        if phase == "guest_os_ready":
+            self._validate_base()
+            self.runner.run(["dpkg", "--audit"])
+            self._verify_runtime_base()
+        elif phase == "postgresql_installed":
+            self._verify_cluster(expected_status="down")
+        elif phase == "postgresql_configured":
+            if item in {"tls", "validate"}:
+                self._validate_bundle_pki()
+                key_info = self.target(TLS_ROOT / "server.key").stat()
+                postgres_gid = grp.getgrnam("postgres").gr_gid
+                if stat.S_IMODE(key_info.st_mode) != 0o640 or key_info.st_uid != 0 or key_info.st_gid != postgres_gid:
+                    raise ProvisioningError("TLS_METADATA_INVALID", "Server-Key-Modus falsch")
+            if item in {"settings", "validate"}:
+                shown = self.runner.run(["pg_conftool", "18", "main", "show"]).decode("utf-8", "replace")
+                required = (
+                    f"listen_addresses = {self.plan['provider_ip']}",
+                    "ssl = on",
+                    "password_encryption = scram-sha-256",
+                    "ssl_min_protocol_version = TLSv1.2",
+                )
+                if "0.0.0.0" in shown or "listen_addresses = *" in shown or any(value not in shown for value in required):
+                    raise ProvisioningError("POSTGRESQL_CONFIG_CONFLICT", "Effektive Einstellungen weichen ab")
+            if item in {"hba", "validate"}:
+                validate_hba(self.target(HBA_PATH).read_text(encoding="ascii"))
+            if item in {"start", "validate"}:
+                self.verify_readiness("provider")
+        elif phase == "allocations_created":
+            if item is None:
+                for allocation in ALLOCATION_IDS:
+                    self.verify_readiness(allocation)
+            else:
+                self.verify_readiness(item)
+        elif phase == "readiness_verified":
+            self.verify_readiness(item or "provider")
+
+    def cleanup(self) -> None:
+        failures: list[str] = []
+        for allocation in ALLOCATION_IDS:
+            path = self.bundle / allocation / "application-password"
+            try:
+                path.unlink(missing_ok=True)
+            except OSError:
+                failures.append(allocation)
+        if failures:
+            raise ProvisioningError("SECURITY_CLEANUP_FAILED", "Temporäre Gastsecrets konnten nicht vollständig entfernt werden")
+
+
+def create_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Bounded postgresql-main guest provisioner")
+    sub = parser.add_subparsers(dest="command", required=True)
+    classify = sub.add_parser("classify")
+    classify.add_argument("--bundle", required=True, type=pathlib.Path)
+    apply_phase = sub.add_parser("apply-phase")
+    apply_phase.add_argument("--phase", required=True, choices=GUEST_PHASES)
+    apply_phase.add_argument("--item", choices=GUEST_ITEMS)
+    apply_phase.add_argument("--bundle", required=True, type=pathlib.Path)
+    verify = sub.add_parser("verify-phase")
+    verify.add_argument("--phase", required=True, choices=GUEST_PHASES)
+    verify.add_argument("--item", choices=GUEST_ITEMS)
+    verify.add_argument("--bundle", required=True, type=pathlib.Path)
+    cleanup = sub.add_parser("cleanup")
+    cleanup.add_argument("--bundle", required=True, type=pathlib.Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = create_parser().parse_args(argv)
+    provisioner: GuestProvisioner | None = None
+    try:
+        provisioner = GuestProvisioner(runner=GuestCommandRunner(), bundle=args.bundle)
+        if args.command == "classify":
+            print(f"RALF_POSTGRESQL_GUEST_STATE_V1={provisioner.classify()}")
+        elif args.command == "apply-phase":
+            print(provisioner.apply_phase(args.phase, args.item))
+        elif args.command == "verify-phase":
+            provisioner.verify_phase(args.phase, args.item)
+            print(f"PHASE_VERIFIED {args.phase}" + (f" {args.item}" if args.item else ""))
+        elif args.command == "cleanup":
+            provisioner.cleanup()
+            print("SECURITY_CLEANUP_COMPLETED")
+        return 0
+    except Exception as raw_exc:
+        exc = raw_exc if isinstance(raw_exc, ProvisioningError) else ProvisioningError(
+            "GUEST_INTERNAL_ERROR", type(raw_exc).__name__
+        )
+        cleanup_failed = False
+        if provisioner is not None and args.command in {"apply-phase", "verify-phase"}:
+            try:
+                provisioner.cleanup()
+            except ProvisioningError:
+                cleanup_failed = True
+        print(f"{exc.code}: {exc.message}", file=sys.stderr)
+        if cleanup_failed:
+            print("SECURITY_CLEANUP_FAILED: temporäre Gastsecrets konnten nicht vollständig entfernt werden", file=sys.stderr)
+        return 2

--- a/scripts/postgresql_main/guest.py
+++ b/scripts/postgresql_main/guest.py
@@ -19,7 +19,21 @@ import sys
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
 
-from .models import ALLOCATION_IDS, ProvisioningError
+try:
+    from .models import ALLOCATION_IDS, ProvisioningError
+except ImportError:
+    # The host transfers this file as the single, standalone guest program.
+    # Keep the fallback deliberately minimal so the exact same implementation
+    # is importable in the repository and executable in the LXC bundle.
+    ALLOCATION_IDS = ("gitea", "openbao", "semaphore", "nodered")
+
+    class ProvisioningError(RuntimeError):
+        """A bounded guest provisioning step cannot continue safely."""
+
+        def __init__(self, code: str, message: str) -> None:
+            super().__init__(message)
+            self.code = code
+            self.message = message
 
 
 GUEST_PHASES = (
@@ -139,6 +153,17 @@ def read_secret(path: pathlib.Path) -> str:
         flags |= os.O_NOFOLLOW
     fd = os.open(path, flags)
     try:
+        opened = os.fstat(fd)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or stat.S_IMODE(opened.st_mode) != 0o600
+            or opened.st_uid != 0
+            or opened.st_gid != 0
+            or opened.st_size == 0
+        ):
+            raise ProvisioningError(
+                "SECRET_METADATA_INVALID", f"Secretmetadaten ungültig: {path.name}"
+            )
         data = os.read(fd, 4097)
     finally:
         os.close(fd)
@@ -453,9 +478,11 @@ class GuestProvisioner:
         key = self.bundle / "server.key"
         self.runner.run(["openssl", "verify", "-CAfile", str(ca), str(certificate)])
         text = self.runner.run([
-            "openssl", "x509", "-in", str(certificate), "-noout", "-text",
+            "openssl", "x509", "-in", str(certificate), "-noout", "-ext", "subjectAltName",
         ]).decode("utf-8", "replace")
-        if f"DNS:{self.plan['fqdn']}" not in text or f"IP Address:{self.plan['provider_ip']}" not in text:
+        dns_names = re.findall(r"DNS:([^,\s]+)", text)
+        ip_addresses = re.findall(r"IP Address:([^,\s]+)", text)
+        if dns_names != [str(self.plan["fqdn"])] or ip_addresses != [str(self.plan["provider_ip"])]:
             raise ProvisioningError("PKI_SAN_MISMATCH", "Serverzertifikat bindet Plan nicht")
         key_public = self.runner.run(["openssl", "pkey", "-in", str(key), "-pubout"])
         cert_public = self.runner.run(["openssl", "x509", "-in", str(certificate), "-pubkey", "-noout"])
@@ -508,7 +535,10 @@ class GuestProvisioner:
             f"SELECT pg_has_role({_quote_literal(login)}, {_quote_literal(owner)}, 'member');\n"
         )
         if membership not in {"t", "true"}:
-            self._psql(f"GRANT {_quote_identifier(owner)} TO {_quote_identifier(login)};\n")
+            self._psql(
+                f"GRANT {_quote_identifier(owner)} TO {_quote_identifier(login)} "
+                "WITH INHERIT FALSE, SET FALSE;\n"
+            )
         database_owner = self._query(
             "SELECT pg_get_userbyid(datdba) FROM pg_database "
             f"WHERE datname={_quote_literal(database)};\n"
@@ -528,7 +558,7 @@ class GuestProvisioner:
         )
         self._psql(
             "REVOKE CREATE ON SCHEMA public FROM PUBLIC;\n"
-            "GRANT USAGE, CREATE ON SCHEMA public TO " + _quote_identifier(owner) + ";\n",
+            "GRANT USAGE, CREATE ON SCHEMA public TO " + _quote_identifier(login) + ";\n",
             database=database,
         )
         self.fault(f"after_allocation:{allocation_id}")
@@ -559,6 +589,16 @@ class GuestProvisioner:
         )
         if result.splitlines() != ["1", "1", "1"]:
             raise ProvisioningError("ALLOCATION_CONFIGURATION_CONFLICT", f"Allocationattribute weichen ab: {item}")
+        membership = self._query(
+            "SELECT pg_has_role(" + login + ", " + owner + ", 'member')::text||'|'||"
+            "pg_has_role(" + login + ", " + owner + ", 'usage')::text||'|'||"
+            "pg_has_role(" + login + ", " + owner + ", 'set')::text;\n"
+        )
+        if membership not in {"true|false|false", "t|f|f"}:
+            raise ProvisioningError(
+                "ALLOCATION_ROLE_CONFLICT",
+                f"Eigentümermitgliedschaft ist zu weitreichend: {item}",
+            )
         allocation = self._allocation(item)
         login_name = _safe_identifier(str(allocation["application_identity"]))
         database_name = _safe_identifier(str(allocation["database_name"]))
@@ -677,3 +717,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if cleanup_failed:
             print("SECURITY_CLEANUP_FAILED: temporäre Gastsecrets konnten nicht vollständig entfernt werden", file=sys.stderr)
         return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/postgresql_main/host.py
+++ b/scripts/postgresql_main/host.py
@@ -1,0 +1,896 @@
+"""Host-side apply and resume orchestration for postgresql-main."""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import datetime as dt
+import hashlib
+import json
+import os
+import pathlib
+import re
+import secrets
+import stat
+import subprocess
+import tempfile
+import uuid
+from collections.abc import Callable, Mapping, Sequence
+
+from . import plan as shared_plan
+from .filesystem import SecureFilesystem
+from .marker import MARKER_PATH, PLAN_PATH, MarkerStore, new_marker
+from .models import (
+    ALLOCATION_IDS,
+    MULTI_ITEM_PHASES,
+    PHASES,
+    ProvisioningError,
+    ResumePlan,
+    canonical_json,
+    canonical_sha256,
+)
+from .pki import PkiManager
+
+
+LOCK_PATH = pathlib.Path("/run/lock/ralf-postgresql-main.lock")
+CONFIG_PATH = pathlib.Path(
+    "/secrets/database-service/providers/postgresql-main/deployment.toml"
+)
+SECRET_DIRECTORIES = (
+    pathlib.Path("/secrets/database-service/providers/postgresql-main/pki"),
+    pathlib.Path("/secrets/database-service/allocations"),
+    *(pathlib.Path("/secrets/database-service/allocations") / item for item in ALLOCATION_IDS),
+)
+CONFIG_PARENT_DIRECTORIES = tuple(
+    pathlib.Path(value) for value in (
+        "/secrets",
+        "/secrets/database-service",
+        "/secrets/database-service/providers",
+        "/secrets/database-service/providers/postgresql-main",
+    )
+)
+PASSWORD_PATHS = {
+    item: pathlib.Path(f"/secrets/database-service/allocations/{item}/application-password")
+    for item in ALLOCATION_IDS
+}
+GUEST_ROOT = pathlib.PurePosixPath("/run/ralf-database-provision")
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+ARTIFACT_PATHS = {
+    "planner": REPO_ROOT / "scripts/postgresql-main-plan.py",
+    "deployer": REPO_ROOT / "scripts/postgresql-main-deploy.py",
+    "guest": REPO_ROOT / "scripts/postgresql-main-guest.py",
+    "pki_policy": REPO_ROOT / "deploy/postgresql/pki-policy.toml",
+    "version_matrix": REPO_ROOT / "deploy/postgresql/version-matrix.toml",
+}
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def sha256_path(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(65_536):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def artifact_hashes(paths: Mapping[str, pathlib.Path] = ARTIFACT_PATHS) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for name, path in paths.items():
+        if not path.is_file() or path.is_symlink():
+            raise ProvisioningError("ARTIFACT_MISSING", f"Artefakt fehlt: {name}")
+        result[name] = sha256_path(path)
+    return result
+
+
+def validate_hash(value: str, *, code: str) -> str:
+    normalized = value.lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", normalized):
+        raise ProvisioningError(code, "SHA-256 muss 64 Hex-Zeichen besitzen")
+    return normalized
+
+
+def ensure_root_directory(parent: pathlib.Path, name: str) -> pathlib.Path:
+    """Create one root-owned 0700 child without following a child symlink."""
+    if not re.fullmatch(r"[a-z0-9-]+", name):
+        raise ProvisioningError("BACKUP_PATH_CONFLICT", name)
+    parent_info = parent.lstat()
+    if parent.is_symlink() or not stat.S_ISDIR(parent_info.st_mode):
+        raise ProvisioningError("BACKUP_PATH_CONFLICT", str(parent))
+    child = parent / name
+    parent_fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+    try:
+        try:
+            child_info = child.lstat()
+        except FileNotFoundError:
+            os.mkdir(name, mode=0o700, dir_fd=parent_fd)
+            os.chown(name, 0, 0, dir_fd=parent_fd, follow_symlinks=False)
+            os.fsync(parent_fd)
+            child_info = child.lstat()
+    finally:
+        os.close(parent_fd)
+    if (
+        child.is_symlink()
+        or not stat.S_ISDIR(child_info.st_mode)
+        or stat.S_IMODE(child_info.st_mode) != 0o700
+        or child_info.st_uid != 0
+        or child_info.st_gid != 0
+    ):
+        raise ProvisioningError("BACKUP_PATH_CONFLICT", str(child))
+    return child
+
+
+def build_pct_create_arguments(plan: Mapping[str, object]) -> list[str]:
+    proxmox = plan["proxmox_observations"]
+    inputs = plan["plan_inputs"]
+    lxc = inputs["lxc"]
+    vmid = int(proxmox["vmid"])
+    storage = str(proxmox["storage"])
+    bridge = str(proxmox["bridge"])
+    template = str(proxmox["template"])
+    nameserver = " ".join(str(item) for item in lxc["dns_servers"])
+    net0 = ",".join((
+        "name=eth0",
+        f"bridge={bridge}",
+        f"ip={lxc['ipv4_cidr']}",
+        f"gw={lxc['gateway']}",
+        "firewall=1",
+    ))
+    return [
+        "pct", "create", str(vmid), template,
+        "--hostname", "postgresql-main",
+        "--arch", "amd64",
+        "--ostype", "ubuntu",
+        "--unprivileged", "1",
+        "--features", "nesting=1",
+        "--cores", str(lxc["cores"]),
+        "--memory", str(lxc["memory_mib"]),
+        "--swap", str(lxc["swap_mib"]),
+        "--rootfs", f"{storage}:{lxc['disk_gib']}",
+        "--net0", net0,
+        "--nameserver", nameserver,
+        "--onboot", "1",
+        "--start", "0",
+    ]
+
+
+class HostBackend:
+    """Production backend with bounded fixed-argument subprocess operations."""
+
+    def __init__(self, executor: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run) -> None:
+        self.executor = executor
+
+    def _run(self, arguments: Sequence[str], *, mutating: bool, input_data: bytes | None = None) -> str:
+        args = list(arguments)
+        if not self._allowed(args, mutating=mutating):
+            raise ProvisioningError("HOST_COMMAND_BLOCKED", "Nicht erlaubte Hostoperation")
+        try:
+            result = self.executor(
+                args,
+                input=input_data,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=input_data is None,
+                timeout=300 if mutating else 15,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ProvisioningError("HOST_COMMAND_FAILED", f"Hostoperation fehlgeschlagen: {args[0]}") from exc
+        if result.returncode != 0:
+            raise ProvisioningError("HOST_COMMAND_FAILED", f"Hostoperation fehlgeschlagen: {args[0]}")
+        output = result.stdout
+        if isinstance(output, bytes):
+            return output.decode("utf-8", "replace")
+        return output[:131_072]
+
+    @staticmethod
+    def _allowed(args: Sequence[str], *, mutating: bool) -> bool:
+        if not args:
+            return False
+        if not mutating:
+            if args[:3] == ["git", "-C", str(REPO_ROOT)] and args[3:] in (["status", "--porcelain"], ["rev-parse", "HEAD"]):
+                return True
+            if args == ["pct", "list"]:
+                return True
+            if len(args) == 3 and args[:2] in (["pct", "status"], ["pct", "config"], ["pct", "pending"]):
+                return args[2].isdigit()
+            return False
+        if args[:2] == ["pct", "create"] and len(args) >= 4:
+            return args[2].isdigit()
+        if args[:2] == ["pct", "start"] and len(args) == 3:
+            return args[2].isdigit()
+        if args[:2] == ["pct", "push"] and len(args) >= 5:
+            return args[2].isdigit()
+        if args[:2] == ["pct", "exec"] and len(args) >= 6:
+            return args[2].isdigit() and args[3] == "--"
+        return False
+
+    def repository_commit(self) -> str:
+        return self._run(["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"], mutating=False).strip()
+
+    def repository_clean(self) -> bool:
+        output = self._run(
+            ["git", "-C", str(REPO_ROOT), "status", "--porcelain"], mutating=False
+        )
+        return not output.strip()
+
+    def create_lxc(self, plan: Mapping[str, object]) -> None:
+        self._run(build_pct_create_arguments(plan), mutating=True)
+
+    def start_lxc(self, vmid: int) -> None:
+        self._run(["pct", "start", str(vmid)], mutating=True)
+
+    def verify_lxc(self, plan: Mapping[str, object], *, expected_status: str) -> None:
+        vmid = int(plan["proxmox_observations"]["vmid"])
+        status_text = self._run(["pct", "status", str(vmid)], mutating=False)
+        if f"status: {expected_status}" not in status_text:
+            raise ProvisioningError("LXC_STATE_CONFLICT", "Containerstatus stimmt nicht")
+        config = self._run(["pct", "config", str(vmid)], mutating=False)
+        pending = self._run(["pct", "pending", str(vmid)], mutating=False)
+        expected = build_pct_create_arguments(plan)
+        required_fragments = {
+            "hostname: postgresql-main",
+            "unprivileged: 1",
+            "features: nesting=1",
+            f"cores: {expected[expected.index('--cores') + 1]}",
+            f"memory: {expected[expected.index('--memory') + 1]}",
+            f"swap: {expected[expected.index('--swap') + 1]}",
+            f"net0: {expected[expected.index('--net0') + 1]}",
+            f"nameserver: {expected[expected.index('--nameserver') + 1]}",
+            "onboot: 1",
+        }
+        if any(item not in config for item in required_fragments):
+            raise ProvisioningError("LXC_CONFIG_CONFLICT", "Containerkonfiguration weicht vom Plan ab")
+        rootfs_lines = [line for line in config.splitlines() if line.startswith("rootfs: ")]
+        storage = str(plan["proxmox_observations"]["storage"])
+        disk_gib = int(plan["plan_inputs"]["lxc"]["disk_gib"])
+        if len(rootfs_lines) != 1 or storage not in rootfs_lines[0] or f"size={disk_gib}G" not in rootfs_lines[0]:
+            raise ProvisioningError("LXC_CONFIG_CONFLICT", "Root-Disk weicht vom Plan ab")
+        forbidden_prefixes = ("mp0:", "mp1:", "dev0:", "hookscript:")
+        if any(line.startswith(forbidden_prefixes) for line in config.splitlines()):
+            raise ProvisioningError("LXC_CONFIG_CONFLICT", "Unerlaubte LXC-Erweiterung")
+        if any(line.strip() for line in pending.splitlines()[1:]):
+            raise ProvisioningError("LXC_PENDING_CONFLICT", "Pending-Konfiguration vorhanden")
+
+    def verify_started_guest(self, plan: Mapping[str, object]) -> None:
+        vmid = str(plan["proxmox_observations"]["vmid"])
+        lxc = plan["plan_inputs"]["lxc"]
+        provider_ip = str(lxc["ipv4_cidr"]).split("/", 1)[0]
+        release = self._run(["pct", "exec", vmid, "--", "/usr/bin/cat", "/etc/os-release"], mutating=True)
+        if "ID=ubuntu" not in release or 'VERSION_ID="26.04"' not in release:
+            raise ProvisioningError("GUEST_OS_CONFLICT", "Ubuntu 26.04 fehlt")
+        architecture = self._run(["pct", "exec", vmid, "--", "/usr/bin/uname", "-m"], mutating=True).strip()
+        if architecture not in {"x86_64", "amd64"}:
+            raise ProvisioningError("GUEST_ARCH_CONFLICT", architecture)
+        self._run(["pct", "exec", vmid, "--", "/usr/bin/systemctl", "is-system-running"], mutating=True)
+        failed = self._run(["pct", "exec", vmid, "--", "/usr/bin/systemctl", "--failed", "--no-legend"], mutating=True)
+        if failed.strip():
+            raise ProvisioningError("GUEST_UNITS_FAILED", "Gast besitzt fehlgeschlagene Units")
+        addresses = self._run(["pct", "exec", vmid, "--", "/usr/sbin/ip", "-4", "address", "show"], mutating=True)
+        routes = self._run(["pct", "exec", vmid, "--", "/usr/sbin/ip", "-4", "route", "show"], mutating=True)
+        if provider_ip not in addresses or f"default via {lxc['gateway']}" not in routes:
+            raise ProvisioningError("GUEST_NETWORK_CONFLICT", "Adresse oder Default-Route weicht ab")
+
+    def verify_guest_base(self, vmid: int, plan: Mapping[str, object]) -> None:
+        arguments = [
+            "pct", "exec", str(vmid), "--", "python3", str(GUEST_ROOT / "postgresql-main-guest.py"),
+            "classify", "--bundle", str(GUEST_ROOT),
+        ]
+        output = self._run(arguments, mutating=True).strip()
+        if not re.fullmatch(r"RALF_POSTGRESQL_GUEST_STATE_V1=[a-z0-9_]+", output):
+            raise ProvisioningError("GUEST_CLASSIFICATION_INVALID", "Gastklassifikation ungültig")
+
+    def initialize_guest_bundle(self, vmid: int) -> None:
+        self._run([
+            "pct", "exec", str(vmid), "--", "/usr/bin/install", "-d", "-o", "root", "-g", "root", "-m", "0700", str(GUEST_ROOT),
+        ], mutating=True)
+
+    def push_bundle_item(self, vmid: int, source: pathlib.Path, relative: str, mode: int) -> None:
+        destination = str(GUEST_ROOT / relative)
+        parent = str(pathlib.PurePosixPath(destination).parent)
+        self._run([
+            "pct", "exec", str(vmid), "--", "/usr/bin/install", "-d", "-o", "root", "-g", "root", "-m", "0700", parent,
+        ], mutating=True)
+
+    def verify_guest_bundle_item(
+        self, vmid: int, source: pathlib.Path, relative: str, mode: int
+    ) -> None:
+        destination = str(GUEST_ROOT / relative)
+        metadata = self._run([
+            "pct", "exec", str(vmid), "--", "/usr/bin/stat",
+            "--format=%F|%a|%u|%g|%s", destination,
+        ], mutating=True).strip()
+        expected_size = source.stat().st_size
+        if metadata != f"regular file|{mode:o}|0|0|{expected_size}":
+            raise ProvisioningError("BUNDLE_ITEM_CONFLICT", relative)
+        if not relative.endswith("application-password"):
+            remote_hash = self._run([
+                "pct", "exec", str(vmid), "--", "/usr/bin/sha256sum", destination,
+            ], mutating=True).split()[0]
+            if remote_hash != sha256_path(source):
+                raise ProvisioningError("BUNDLE_ITEM_CONFLICT", relative)
+        self._run([
+            "pct", "push", str(vmid), str(source), destination,
+            "--perms", f"{mode:04o}", "--user", "0", "--group", "0",
+        ], mutating=True)
+
+    def verify_guest_bundle(self, vmid: int) -> None:
+        self.verify_guest_base(vmid, {})
+
+    def ensure_guest_secrets(self, vmid: int, sources: Mapping[str, pathlib.Path]) -> None:
+        """Rehydrate only ephemeral password copies removed by failure cleanup."""
+        for allocation in ALLOCATION_IDS:
+            self.push_bundle_item(
+                vmid,
+                sources[allocation],
+                f"{allocation}/application-password",
+                0o600,
+            )
+
+    def apply_guest_phase(
+        self, vmid: int, phase: str, *, item: str | None = None
+    ) -> str:
+        arguments = [
+            "pct", "exec", str(vmid), "--", "python3",
+            str(GUEST_ROOT / "postgresql-main-guest.py"), "apply-phase",
+            "--phase", phase, "--bundle", str(GUEST_ROOT),
+        ]
+        if item is not None:
+            arguments.extend(["--item", item])
+        return self._run(arguments, mutating=True).strip()
+
+    def verify_guest_phase(self, vmid: int, phase: str, *, item: str | None = None) -> None:
+        arguments = [
+            "pct", "exec", str(vmid), "--", "python3",
+            str(GUEST_ROOT / "postgresql-main-guest.py"), "verify-phase",
+            "--phase", phase, "--bundle", str(GUEST_ROOT),
+        ]
+        if item is not None:
+            arguments.extend(["--item", item])
+        self._run(arguments, mutating=True)
+
+    def cleanup_guest_secrets(self, vmid: int) -> None:
+        self._run([
+            "pct", "exec", str(vmid), "--", "python3",
+            str(GUEST_ROOT / "postgresql-main-guest.py"), "cleanup",
+            "--bundle", str(GUEST_ROOT),
+        ], mutating=True)
+
+    def stream_backup(self, vmid: int, database_name: str, destination: pathlib.Path) -> None:
+        arguments = [
+            "pct", "exec", str(vmid), "--", "runuser", "-u", "postgres", "--",
+            "pg_dump", "--format=custom", f"--dbname={database_name}",
+        ]
+        if not self._allowed(arguments, mutating=True):
+            raise ProvisioningError("HOST_COMMAND_BLOCKED", "Backupstream blockiert")
+        with destination.open("xb") as output:
+            os.fchmod(output.fileno(), 0o600)
+            process = subprocess.Popen(arguments, stdout=output, stderr=subprocess.PIPE)
+            try:
+                _stderr = process.communicate(timeout=300)[1]
+            except subprocess.TimeoutExpired as exc:
+                process.terminate()
+                try:
+                    process.communicate(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.communicate()
+                raise ProvisioningError("BACKUP_TIMEOUT", "pg_dump Zeitlimit überschritten") from exc
+            if process.returncode != 0:
+                raise ProvisioningError("BACKUP_FAILED", "pg_dump fehlgeschlagen")
+            output.flush()
+            os.fsync(output.fileno())
+
+    def verify_backup(self, vmid: int, backup_path: pathlib.Path) -> None:
+        arguments = [
+            "pct", "exec", str(vmid), "--", "runuser", "-u", "postgres", "--",
+            "pg_restore", "--list", "-",
+        ]
+        with backup_path.open("rb") as source:
+            self._run(arguments, mutating=True, input_data=source.read())
+
+    def verify_phase(self, phase: str, marker: Mapping[str, object], plan: Mapping[str, object]) -> None:
+        vmid = int(marker["vmid"])
+        if phase == "lxc_created":
+            self.verify_lxc(plan, expected_status="stopped")
+        elif phase in {"lxc_started", "guest_bundle_ready", "guest_os_ready", "postgresql_installed", "postgresql_configured", "allocations_created", "readiness_verified", "backups_verified", "completed"}:
+            self.verify_lxc(plan, expected_status="running")
+        if phase in {"guest_os_ready", "postgresql_installed", "postgresql_configured", "allocations_created", "readiness_verified"}:
+            self.verify_guest_phase(vmid, phase)
+
+
+class Provisioner:
+    def __init__(
+        self,
+        *,
+        filesystem: SecureFilesystem,
+        backend: HostBackend,
+        marker_store: MarkerStore,
+        pki: PkiManager,
+        plan_factory: Callable[[pathlib.Path], object] = shared_plan.create_plan_report,
+        token_source: Callable[[], str] = lambda: secrets.token_urlsafe(48),
+        operation_id_source: Callable[[], str] = lambda: str(uuid.uuid4()),
+        clock: Callable[[], str] = utc_now,
+        fault: Callable[[str], None] = lambda _point: None,
+        repository_root: pathlib.Path = REPO_ROOT,
+        artifact_paths: Mapping[str, pathlib.Path] = ARTIFACT_PATHS,
+    ) -> None:
+        self.fs = filesystem
+        self.backend = backend
+        self.store = marker_store
+        self.pki = pki
+        self.plan_factory = plan_factory
+        self.token_source = token_source
+        self.operation_id_source = operation_id_source
+        self.clock = clock
+        self.fault = fault
+        self.repository_root = repository_root
+        self.artifact_paths = artifact_paths
+
+    def _validate_repository(self, expected_commit: str) -> None:
+        if self.backend.repository_commit() != expected_commit or not self.backend.repository_clean():
+            raise ProvisioningError("REPOSITORY_STATE_CONFLICT", "Repository ist nicht exakt planidentisch und sauber")
+        for path in self.artifact_paths.values():
+            if not path.is_file() or path.is_symlink():
+                raise ProvisioningError("ARTIFACT_MISSING", str(path))
+
+    def _validate_config_metadata(self, config_path: pathlib.Path) -> None:
+        if config_path != CONFIG_PATH:
+            raise ProvisioningError("CONFIG_PATH_INVALID", str(config_path))
+        for directory in CONFIG_PARENT_DIRECTORIES:
+            self.fs.validate(directory, kind="directory", mode=0o700)
+        self.fs.validate(CONFIG_PATH, kind="file", mode=0o600)
+
+    def _preflight(self, config_path: pathlib.Path, confirmed_hash: str):
+        self._validate_config_metadata(config_path)
+        report = self.plan_factory(config_path)
+        if report.machine_plan is None:
+            raise ProvisioningError("PLAN_INVALID", "Maschinenplan fehlt")
+        plan = report.machine_plan
+        if plan["plan_status"] != "PLAN_READY" or report.blockers:
+            raise ProvisioningError("PLAN_BLOCKED", "Plan enthält Blocker")
+        actual_hash = str(plan["plan_sha256"])
+        if actual_hash != validate_hash(confirmed_hash, code="PLAN_HASH_INVALID"):
+            raise ProvisioningError("APPLY_BLOCKED_PLAN_CHANGED", "Plan-Hash stimmt nicht")
+        self._validate_repository(str(plan["repository_commit"]))
+        if self.store.exists() or self.fs.path(PLAN_PATH).exists():
+            raise ProvisioningError("APPLY_REQUIRES_RESUME", "Provisionierungsmarker oder Planevidenz existiert")
+        for path in (
+            *(item.parent for item in PASSWORD_PATHS.values()),
+            *PASSWORD_PATHS.values(),
+            self.pki.root,
+        ):
+            if self.fs.path(path).exists():
+                raise ProvisioningError("TARGET_STATE_CONFLICT", f"Zielartefakt existiert: {path}")
+        return report
+
+    def apply(self, config_path: pathlib.Path, confirmed_hash: str) -> dict[str, object]:
+        if os.geteuid() != 0:
+            raise ProvisioningError("ROOT_REQUIRED", "Apply benötigt UID 0")
+        # Reject stale or blocked confirmations without even publishing the lock inode.
+        self._preflight(config_path, confirmed_hash)
+        with self.fs.exclusive_lock(LOCK_PATH):
+            # Repeat under the process lock; this is the mutation-authorizing preflight.
+            report = self._preflight(config_path, confirmed_hash)
+            assert report.machine_plan is not None
+            plan = copy.deepcopy(report.machine_plan)
+            artifacts = artifact_hashes(self.artifact_paths)
+            operation_id = self.operation_id_source()
+            marker = new_marker(
+                operation_id=operation_id,
+                repository_commit=str(plan["repository_commit"]),
+                plan=plan,
+                artifact_hashes=artifacts,
+                now=self.clock(),
+            )
+            self.store.create(marker, plan)
+            self.fault("after_marker")
+            marker = self.store.load()
+            marker = self.store.complete(marker, "planned")
+            return self._continue(marker, plan)
+
+    def resume(self, resume_plan: ResumePlan, confirmed_hash: str) -> dict[str, object]:
+        if os.geteuid() != 0:
+            raise ProvisioningError("ROOT_REQUIRED", "Resume-Apply benötigt UID 0")
+        if resume_plan.status != "RESUME_READY" or resume_plan.sha256 != validate_hash(confirmed_hash, code="RESUME_HASH_INVALID"):
+            raise ProvisioningError("APPLY_BLOCKED_PLAN_CHANGED", "Resume-Hash stimmt nicht")
+        with self.fs.exclusive_lock(LOCK_PATH):
+            current = build_resume_plan(
+                filesystem=self.fs,
+                backend=self.backend,
+                marker_store=self.store,
+                pki=self.pki,
+                artifact_paths=self.artifact_paths,
+                generated_at=self.clock(),
+            )
+            if current.status != "RESUME_READY" or current.sha256 != resume_plan.sha256:
+                raise ProvisioningError("APPLY_BLOCKED_PLAN_CHANGED", "Resume-Plan hat sich geändert")
+            marker = self.store.load()
+            original_plan = self.store.load_plan()
+            return self._continue(marker, original_plan)
+
+    def _continue(self, marker: dict[str, object], plan: Mapping[str, object]) -> dict[str, object]:
+        vmid = int(marker["vmid"])
+        try:
+            while marker["phase"] != "completed":
+                phase = PHASES[len(marker["completed_phases"])]
+                if phase == "planned":
+                    marker = self.store.complete(marker, "planned")
+                elif phase == "secret_directories_ready":
+                    marker = self._directories(marker)
+                elif phase == "secrets_ready":
+                    marker = self._secrets(marker)
+                elif phase == "pki_ready":
+                    marker = self._pki(marker, plan)
+                elif phase == "lxc_created":
+                    marker = self._lxc_create(marker, plan)
+                elif phase == "lxc_started":
+                    marker = self._lxc_start(marker, plan)
+                elif phase == "guest_bundle_ready":
+                    marker = self._bundle(marker, plan)
+                elif phase in {"guest_os_ready", "postgresql_installed", "postgresql_configured", "allocations_created", "readiness_verified"}:
+                    marker = self._guest_items(marker, plan, phase)
+                elif phase == "backups_verified":
+                    marker = self._backups(marker, plan)
+                elif phase == "completed":
+                    marker = self._complete(marker, plan)
+                else:
+                    raise ProvisioningError("PHASE_UNKNOWN", phase)
+            return marker
+        except Exception as raw_exc:
+            exc = raw_exc if isinstance(raw_exc, ProvisioningError) else ProvisioningError(
+                "PROVISIONING_INTERNAL_ERROR", type(raw_exc).__name__
+            )
+            with contextlib.suppress(Exception):
+                marker = self.store.record_error(self.store.load(), exc.code, exc.message)
+            cleanup_error: ProvisioningError | None = None
+            if marker.get("phase") in PHASES[5:] and exc.code != "SECURITY_CLEANUP_FAILED":
+                try:
+                    self.backend.cleanup_guest_secrets(vmid)
+                except ProvisioningError as cleanup_exc:
+                    cleanup_error = cleanup_exc
+                    with contextlib.suppress(Exception):
+                        marker = self.store.record_error(
+                            self.store.load(),
+                            exc.code,
+                            f"{exc.message}; SECURITY_CLEANUP_FAILED",
+                        )
+            if cleanup_error is not None:
+                raise ProvisioningError(
+                    exc.code,
+                    f"{exc.message}; SECURITY_CLEANUP_FAILED: {cleanup_error.message}",
+                ) from raw_exc
+            if isinstance(raw_exc, ProvisioningError):
+                raise
+            raise exc from raw_exc
+
+    def _directories(self, marker: dict[str, object]) -> dict[str, object]:
+        completed = list(marker["phase_progress"].get("secret_directories_ready", []))
+        labels = MULTI_ITEM_PHASES["secret_directories_ready"]
+        for label, path in list(zip(labels, SECRET_DIRECTORIES))[len(completed):]:
+            marker = self.store.begin(marker, "secret_directories_ready", label)
+            self.fs.ensure_directory(path)
+            self.fault(f"after_directory:{label}")
+            marker = self.store.progress(marker, "secret_directories_ready", label)
+        return self.store.complete(marker, "secret_directories_ready")
+
+    def _secrets(self, marker: dict[str, object]) -> dict[str, object]:
+        progress = list(marker["phase_progress"].get("secrets_ready", []))
+        for allocation in ALLOCATION_IDS[len(progress):]:
+            if marker.get("in_progress_phase") == "secrets_ready" and marker.get("in_progress_item") == allocation:
+                self._validate_secret(allocation)
+                marker = self.store.progress(marker, "secrets_ready", allocation)
+                continue
+            marker = self.store.begin(marker, "secrets_ready", allocation)
+            value = self.token_source()
+            if len(value) < 64 or not value.isascii() or any(ch.isspace() or ord(ch) < 33 for ch in value):
+                raise ProvisioningError("SECRET_GENERATOR_INVALID", "Kennwortgenerator verletzt Vertrag")
+            self.fs.exclusive_bytes(PASSWORD_PATHS[allocation], value.encode("ascii"), mode=0o600)
+            self.fault(f"after_secret:{allocation}")
+            self._validate_secret(allocation)
+            marker = self.store.progress(marker, "secrets_ready", allocation)
+        return self.store.complete(marker, "secrets_ready")
+
+    def _validate_secret(self, allocation: str) -> None:
+        path = self.fs.path(PASSWORD_PATHS[allocation])
+        self.fs.validate(PASSWORD_PATHS[allocation], kind="file", mode=0o600, require_nonempty=True)
+        data = self.fs.read_bytes(PASSWORD_PATHS[allocation], maximum=4096)
+        if not data.isascii() or any(byte < 33 or byte == 127 for byte in data):
+            raise ProvisioningError("SECRET_CONTENT_INVALID", f"Secretmetadaten ungültig: {allocation}")
+
+    def _pki(self, marker: dict[str, object], plan: Mapping[str, object]) -> dict[str, object]:
+        marker = self.store.begin(marker, "pki_ready")
+        provider = plan["plan_inputs"]["provider"]
+        lxc = plan["plan_inputs"]["lxc"]
+        provider_ip = str(lxc["ipv4_cidr"]).split("/", 1)[0]
+        fingerprints = self.pki.generate(str(provider["fqdn"]), provider_ip)
+        marker["public_certificate_fingerprints"] = fingerprints
+        marker = self.store.save(marker)
+        return self.store.complete(marker, "pki_ready")
+
+    def _lxc_create(self, marker: dict[str, object], plan: Mapping[str, object]) -> dict[str, object]:
+        if marker.get("in_progress_phase") == "lxc_created":
+            self.backend.verify_lxc(plan, expected_status="stopped")
+            return self.store.complete(marker, "lxc_created")
+        marker = self.store.begin(marker, "lxc_created")
+        self.backend.create_lxc(plan)
+        self.fault("after_pct_create")
+        self.backend.verify_lxc(plan, expected_status="stopped")
+        return self.store.complete(marker, "lxc_created")
+
+    def _lxc_start(self, marker: dict[str, object], plan: Mapping[str, object]) -> dict[str, object]:
+        if marker.get("in_progress_phase") == "lxc_started":
+            self.backend.verify_lxc(plan, expected_status="running")
+            self.backend.verify_started_guest(plan)
+            return self.store.complete(marker, "lxc_started")
+        marker = self.store.begin(marker, "lxc_started")
+        self.backend.start_lxc(int(marker["vmid"]))
+        self.fault("after_pct_start")
+        self.backend.verify_lxc(plan, expected_status="running")
+        self.backend.verify_started_guest(plan)
+        return self.store.complete(marker, "lxc_started")
+
+    def _guest_plan(self, plan: Mapping[str, object]) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "provider_instance_id": "postgresql-main",
+            "postgresql_major": 18,
+            "fqdn": plan["plan_inputs"]["provider"]["fqdn"],
+            "hostname": "postgresql-main",
+            "provider_ip": str(plan["plan_inputs"]["lxc"]["ipv4_cidr"]).split("/", 1)[0],
+            "gateway": plan["plan_inputs"]["lxc"]["gateway"],
+            "dns_servers": plan["plan_inputs"]["lxc"]["dns_servers"],
+            "allocations": plan["plan_inputs"]["allocations"],
+        }
+
+    def _bundle(self, marker: dict[str, object], plan: Mapping[str, object]) -> dict[str, object]:
+        vmid = int(marker["vmid"])
+        self.backend.initialize_guest_bundle(vmid)
+        guest_plan = self._guest_plan(plan)
+        with tempfile.TemporaryDirectory(prefix="ralf-pg-bundle-") as raw:
+            root = pathlib.Path(raw)
+            os.chmod(root, 0o700)
+            guest_plan_path = root / "guest-plan.json"
+            guest_plan_path.write_bytes(canonical_json(guest_plan) + b"\n")
+            os.chmod(guest_plan_path, 0o600)
+            manifest = {
+                "schema_version": 1,
+                "artifacts": {
+                    "postgresql-main-guest.py": sha256_path(self.artifact_paths["guest"]),
+                    "guest-plan.json": sha256_path(guest_plan_path),
+                    "ca.crt": sha256_path(self.fs.path(self.pki.root / "ca.crt")),
+                    "server.crt": sha256_path(self.fs.path(self.pki.root / "server.crt")),
+                },
+            }
+            manifest_path = root / "public-manifest.json"
+            manifest_path.write_bytes(canonical_json(manifest) + b"\n")
+            os.chmod(manifest_path, 0o600)
+            sources = {
+                "postgresql-main-guest.py": (self.artifact_paths["guest"], 0o644),
+                "guest-plan.json": (guest_plan_path, 0o644),
+                "public-manifest.json": (manifest_path, 0o644),
+                "ca.crt": (self.fs.path(self.pki.root / "ca.crt"), 0o644),
+                "server.crt": (self.fs.path(self.pki.root / "server.crt"), 0o644),
+                "server.key": (self.fs.path(self.pki.root / "server.key"), 0o600),
+                **{
+                    f"{allocation}/application-password": (self.fs.path(PASSWORD_PATHS[allocation]), 0o600)
+                    for allocation in ALLOCATION_IDS
+                },
+            }
+            if marker.get("last_error"):
+                self.backend.ensure_guest_secrets(
+                    vmid,
+                    {allocation: self.fs.path(PASSWORD_PATHS[allocation]) for allocation in ALLOCATION_IDS},
+                )
+            completed = list(marker["phase_progress"].get("guest_bundle_ready", []))
+            for item in MULTI_ITEM_PHASES["guest_bundle_ready"][len(completed):]:
+                source, mode = sources[item]
+                if marker.get("in_progress_phase") == "guest_bundle_ready" and marker.get("in_progress_item") == item:
+                    try:
+                        self.backend.verify_guest_bundle_item(vmid, source, item, mode)
+                    except ProvisioningError:
+                        if not item.endswith("application-password"):
+                            raise
+                        # Error cleanup intentionally removed the ephemeral copy.
+                        self.backend.push_bundle_item(vmid, source, item, mode)
+                    marker = self.store.progress(marker, "guest_bundle_ready", item)
+                    continue
+                marker = self.store.begin(marker, "guest_bundle_ready", item)
+                self.backend.push_bundle_item(vmid, source, item, mode)
+                self.fault(f"after_bundle:{item}")
+                marker = self.store.progress(marker, "guest_bundle_ready", item)
+        self.backend.verify_guest_bundle(vmid)
+        return self.store.complete(marker, "guest_bundle_ready")
+
+    def _guest_items(self, marker: dict[str, object], plan: Mapping[str, object], phase: str) -> dict[str, object]:
+        if marker.get("last_error"):
+            self.backend.ensure_guest_secrets(
+                int(marker["vmid"]),
+                {allocation: self.fs.path(PASSWORD_PATHS[allocation]) for allocation in ALLOCATION_IDS},
+            )
+        allowed = MULTI_ITEM_PHASES[phase]
+        completed = list(marker["phase_progress"].get(phase, []))
+        for item in allowed[len(completed):]:
+            if marker.get("in_progress_phase") == phase and marker.get("in_progress_item") == item:
+                self.backend.verify_guest_phase(int(marker["vmid"]), phase, item=item)
+                marker = self.store.progress(marker, phase, item)
+                continue
+            marker = self.store.begin(marker, phase, item)
+            result = self.backend.apply_guest_phase(int(marker["vmid"]), phase, item=item)
+            if result == "PROVISIONING_PAUSED_REBOOT_REQUIRED":
+                raise ProvisioningError(result, "Gast benötigt getrennt freigegebenen Neustart")
+            self.fault(f"after_{phase}:{item}")
+            self.backend.verify_guest_phase(int(marker["vmid"]), phase, item=item)
+            marker = self.store.progress(marker, phase, item)
+        if phase == "readiness_verified":
+            marker["readiness_status"] = {
+                "provider_status": "ready",
+                "allocation_configuration": "verified",
+                "consumer_connectivity": "pending",
+                "allocation_readiness": "consumer_validation_pending",
+            }
+            marker = self.store.save(marker)
+        return self.store.complete(marker, phase)
+
+    def _backups(self, marker: dict[str, object], plan: Mapping[str, object]) -> dict[str, object]:
+        by_id = {item["allocation_id"]: item for item in plan["plan_inputs"]["allocations"]}
+        configured_backup_root = pathlib.Path(str(plan["plan_inputs"]["backup"]["host_root"]))
+        backup_root = ensure_root_directory(configured_backup_root, "postgresql-main")
+        timestamp = self.clock().replace("-", "").replace(":", "")
+        completed = list(marker["phase_progress"].get("backups_verified", []))
+        for allocation in ALLOCATION_IDS[len(completed):]:
+            if marker.get("in_progress_phase") == "backups_verified" and marker.get("in_progress_item") == allocation:
+                evidence = marker["backup_artifacts"].get(allocation)
+                if isinstance(evidence, dict):
+                    existing = pathlib.Path(str(evidence["path"]))
+                    if (
+                        existing.is_symlink()
+                        or not existing.is_file()
+                        or stat.S_IMODE(existing.stat().st_mode) != 0o600
+                        or existing.stat().st_uid != 0
+                        or existing.stat().st_gid != 0
+                        or existing.stat().st_size != evidence["size"]
+                        or sha256_path(existing) != evidence["sha256"]
+                    ):
+                        raise ProvisioningError("RESUME_CONFLICT", f"Backup weicht ab: {allocation}")
+                    marker = self.store.progress(marker, "backups_verified", allocation)
+                    continue
+            marker = self.store.begin(marker, "backups_verified", allocation)
+            directory = ensure_root_directory(backup_root, allocation)
+            filename = f"{timestamp}-{marker['operation_id']}.dump"
+            final = directory / filename
+            if final.exists():
+                raise ProvisioningError("BACKUP_ALREADY_EXISTS", str(final))
+            temporary = directory / f".{filename}.partial"
+            try:
+                self.backend.stream_backup(int(marker["vmid"]), str(by_id[allocation]["database_name"]), temporary)
+                self.fault(f"after_backup_stream:{allocation}")
+                self.backend.verify_backup(int(marker["vmid"]), temporary)
+                digest = sha256_path(temporary)
+                os.replace(temporary, final)
+            finally:
+                with contextlib.suppress(FileNotFoundError):
+                    temporary.unlink()
+            parent_fd = os.open(directory, os.O_RDONLY | os.O_DIRECTORY | os.O_CLOEXEC)
+            try:
+                os.fsync(parent_fd)
+            finally:
+                os.close(parent_fd)
+            marker["backup_artifacts"][allocation] = {
+                "path": str(final), "sha256": digest, "size": final.stat().st_size,
+            }
+            marker = self.store.save(marker)
+            self.fault(f"after_backup:{allocation}")
+            marker = self.store.progress(marker, "backups_verified", allocation)
+        return self.store.complete(marker, "backups_verified")
+
+    def _complete(self, marker: dict[str, object], plan: Mapping[str, object]) -> dict[str, object]:
+        marker = self.store.begin(marker, "completed")
+        self.backend.cleanup_guest_secrets(int(marker["vmid"]))
+        self.fault("before_completion")
+        return self.store.complete(marker, "completed")
+
+
+def build_resume_plan(
+    *,
+    filesystem: SecureFilesystem,
+    backend: HostBackend,
+    marker_store: MarkerStore,
+    pki: PkiManager | None = None,
+    artifact_paths: Mapping[str, pathlib.Path] = ARTIFACT_PATHS,
+    generated_at: str | None = None,
+) -> ResumePlan:
+    conflicts: list[str] = []
+    try:
+        marker = marker_store.load()
+        original_plan = marker_store.load_plan()
+        planner = shared_plan.planner_module()
+        if planner.calculate_plan_sha256(original_plan) != original_plan.get("plan_sha256"):
+            conflicts.append("gespeicherter Plan-Hash stimmt nicht")
+        if marker["plan_sha256"] != original_plan.get("plan_sha256"):
+            conflicts.append("Marker und gespeicherter Plan unterscheiden sich")
+        if backend.repository_commit() != marker["repository_commit"] or not backend.repository_clean():
+            conflicts.append("Repositoryzustand stimmt nicht")
+        current_artifacts = artifact_hashes(artifact_paths)
+        if current_artifacts != marker["artifact_hashes"]:
+            conflicts.append("Skripthashes stimmen nicht")
+        config_path = filesystem.path(CONFIG_PATH)
+        if sha256_path(config_path) != marker["configuration_sha256"]:
+            conflicts.append("Konfigurationshash stimmt nicht")
+        if sha256_path(artifact_paths["version_matrix"]) != marker["version_matrix_sha256"]:
+            conflicts.append("Versionsmatrixhash stimmt nicht")
+        for phase in marker["completed_phases"]:
+            try:
+                if phase == "secret_directories_ready":
+                    for path in SECRET_DIRECTORIES:
+                        filesystem.validate(path, kind="directory", mode=0o700)
+                elif phase == "secrets_ready":
+                    for path in PASSWORD_PATHS.values():
+                        filesystem.validate(path, kind="file", mode=0o600, require_nonempty=True)
+                elif phase == "pki_ready":
+                    if pki is None:
+                        conflicts.append("pki_ready: PKI_VERIFICATION_UNAVAILABLE")
+                    else:
+                        provider = original_plan["plan_inputs"]["provider"]
+                        lxc = original_plan["plan_inputs"]["lxc"]
+                        provider_ip = str(lxc["ipv4_cidr"]).split("/", 1)[0]
+                        fingerprints = pki.verify(str(provider["fqdn"]), provider_ip)
+                        if fingerprints != marker["public_certificate_fingerprints"]:
+                            conflicts.append("pki_ready: PKI_FINGERPRINT_CONFLICT")
+                elif phase not in {"planned"}:
+                    backend.verify_phase(phase, marker, original_plan)
+            except ProvisioningError as exc:
+                conflicts.append(f"{phase}: {exc.code}")
+        in_progress = marker.get("in_progress_phase")
+        in_progress_item = marker.get("in_progress_item")
+        try:
+            if in_progress == "lxc_created":
+                backend.verify_lxc(original_plan, expected_status="stopped")
+            elif in_progress == "lxc_started":
+                backend.verify_lxc(original_plan, expected_status="running")
+                backend.verify_started_guest(original_plan)
+            elif in_progress in {
+                "guest_os_ready", "postgresql_installed", "postgresql_configured",
+                "allocations_created", "readiness_verified",
+            }:
+                backend.verify_guest_phase(
+                    int(marker["vmid"]), str(in_progress),
+                    item=str(in_progress_item) if in_progress_item is not None else None,
+                )
+            elif in_progress == "secrets_ready" and in_progress_item is not None:
+                secret_path = PASSWORD_PATHS[str(in_progress_item)]
+                if filesystem.path(secret_path).exists():
+                    filesystem.validate(secret_path, kind="file", mode=0o600, require_nonempty=True)
+        except ProvisioningError as exc:
+            conflicts.append(f"{in_progress}: {exc.code}")
+        next_phase = PHASES[len(marker["completed_phases"])] if len(marker["completed_phases"]) < len(PHASES) else None
+        next_item = None
+        if next_phase in MULTI_ITEM_PHASES:
+            done = marker["phase_progress"].get(next_phase, [])
+            allowed = MULTI_ITEM_PHASES[next_phase]
+            next_item = allowed[len(done)] if len(done) < len(allowed) else None
+    except (ProvisioningError, OSError, KeyError, TypeError, ValueError) as exc:
+        marker = {"operation_id": "unknown", "plan_sha256": "0" * 64, "phase": None, "completed_phases": []}
+        next_phase = None
+        next_item = None
+        conflicts.append(exc.code if isinstance(exc, ProvisioningError) else "RESUME_STATE_INVALID")
+    document: dict[str, object] = {
+        "schema_version": 1,
+        "plan_type": "postgresql-main-resume",
+        "operation_id": marker["operation_id"],
+        "provider_instance_id": "postgresql-main",
+        "plan_sha256": marker["plan_sha256"],
+        "repository_commit": marker.get("repository_commit"),
+        "phase": marker.get("phase"),
+        "completed_phases": marker.get("completed_phases", []),
+        "phase_progress": marker.get("phase_progress", {}),
+        "next_phase": next_phase,
+        "next_item": next_item,
+        "conflicts": sorted(set(conflicts)),
+        "generated_at": generated_at or utc_now(),
+        "resume_status": "RESUME_CONFLICT" if conflicts else "RESUME_READY",
+    }
+    document["resume_sha256"] = canonical_sha256(document, ("generated_at", "resume_sha256"))
+    return ResumePlan(document)

--- a/scripts/postgresql_main/host.py
+++ b/scripts/postgresql_main/host.py
@@ -58,7 +58,9 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 ARTIFACT_PATHS = {
     "planner": REPO_ROOT / "scripts/postgresql-main-plan.py",
     "deployer": REPO_ROOT / "scripts/postgresql-main-deploy.py",
-    "guest": REPO_ROOT / "scripts/postgresql-main-guest.py",
+    # The transferred guest artifact must be executable without the repository
+    # package being present in the new container.
+    "guest": REPO_ROOT / "scripts/postgresql_main/guest.py",
     "pki_policy": REPO_ROOT / "deploy/postgresql/pki-policy.toml",
     "version_matrix": REPO_ROOT / "deploy/postgresql/version-matrix.toml",
 }
@@ -230,26 +232,37 @@ class HostBackend:
         config = self._run(["pct", "config", str(vmid)], mutating=False)
         pending = self._run(["pct", "pending", str(vmid)], mutating=False)
         expected = build_pct_create_arguments(plan)
-        required_fragments = {
-            "hostname: postgresql-main",
-            "unprivileged: 1",
-            "features: nesting=1",
-            f"cores: {expected[expected.index('--cores') + 1]}",
-            f"memory: {expected[expected.index('--memory') + 1]}",
-            f"swap: {expected[expected.index('--swap') + 1]}",
-            f"net0: {expected[expected.index('--net0') + 1]}",
-            f"nameserver: {expected[expected.index('--nameserver') + 1]}",
-            "onboot: 1",
+        parsed = {
+            key.strip(): value.strip()
+            for line in config.splitlines()
+            if ":" in line
+            for key, value in (line.split(":", 1),)
         }
-        if any(item not in config for item in required_fragments):
+        required = {
+            "hostname": "postgresql-main",
+            "arch": "amd64",
+            "ostype": "ubuntu",
+            "unprivileged": "1",
+            "features": "nesting=1",
+            "cores": expected[expected.index("--cores") + 1],
+            "memory": expected[expected.index("--memory") + 1],
+            "swap": expected[expected.index("--swap") + 1],
+            "net0": expected[expected.index("--net0") + 1],
+            "nameserver": expected[expected.index("--nameserver") + 1],
+            "onboot": "1",
+        }
+        if any(parsed.get(key) != value for key, value in required.items()):
             raise ProvisioningError("LXC_CONFIG_CONFLICT", "Containerkonfiguration weicht vom Plan ab")
         rootfs_lines = [line for line in config.splitlines() if line.startswith("rootfs: ")]
         storage = str(plan["proxmox_observations"]["storage"])
         disk_gib = int(plan["plan_inputs"]["lxc"]["disk_gib"])
         if len(rootfs_lines) != 1 or storage not in rootfs_lines[0] or f"size={disk_gib}G" not in rootfs_lines[0]:
             raise ProvisioningError("LXC_CONFIG_CONFLICT", "Root-Disk weicht vom Plan ab")
-        forbidden_prefixes = ("mp0:", "mp1:", "dev0:", "hookscript:")
-        if any(line.startswith(forbidden_prefixes) for line in config.splitlines()):
+        forbidden_keys = re.compile(r"^(?:mp|dev|usb|hostpci)\d+$")
+        if any(
+            forbidden_keys.fullmatch(key) or key in {"hookscript", "lxc.mount.entry"}
+            for key in parsed
+        ):
             raise ProvisioningError("LXC_CONFIG_CONFLICT", "Unerlaubte LXC-Erweiterung")
         if any(line.strip() for line in pending.splitlines()[1:]):
             raise ProvisioningError("LXC_PENDING_CONFLICT", "Pending-Konfiguration vorhanden")
@@ -264,6 +277,11 @@ class HostBackend:
         architecture = self._run(["pct", "exec", vmid, "--", "/usr/bin/uname", "-m"], mutating=True).strip()
         if architecture not in {"x86_64", "amd64"}:
             raise ProvisioningError("GUEST_ARCH_CONFLICT", architecture)
+        hostname = self._run(
+            ["pct", "exec", vmid, "--", "/usr/bin/hostname"], mutating=True
+        ).strip()
+        if hostname != "postgresql-main":
+            raise ProvisioningError("GUEST_HOSTNAME_CONFLICT", hostname)
         self._run(["pct", "exec", vmid, "--", "/usr/bin/systemctl", "is-system-running"], mutating=True)
         failed = self._run(["pct", "exec", vmid, "--", "/usr/bin/systemctl", "--failed", "--no-legend"], mutating=True)
         if failed.strip():
@@ -272,6 +290,28 @@ class HostBackend:
         routes = self._run(["pct", "exec", vmid, "--", "/usr/sbin/ip", "-4", "route", "show"], mutating=True)
         if provider_ip not in addresses or f"default via {lxc['gateway']}" not in routes:
             raise ProvisioningError("GUEST_NETWORK_CONFLICT", "Adresse oder Default-Route weicht ab")
+        resolv = self._run(
+            ["pct", "exec", vmid, "--", "/usr/bin/cat", "/etc/resolv.conf"],
+            mutating=True,
+        )
+        if any(f"nameserver {server}" not in resolv for server in lxc["dns_servers"]):
+            raise ProvisioningError("GUEST_DNS_CONFLICT", "DNS-Konfiguration weicht ab")
+        disk = self._run(
+            ["pct", "exec", vmid, "--", "/usr/bin/df", "-Pk", "/"], mutating=True
+        )
+        lines = [line for line in disk.splitlines() if line.strip()]
+        fields = lines[-1].split() if lines else []
+        if len(fields) < 4 or not fields[3].isdigit() or int(fields[3]) < 2_097_152:
+            raise ProvisioningError("GUEST_STORAGE_LOW", "Weniger als 2 GiB frei")
+        https = self._run(
+            [
+                "pct", "exec", vmid, "--", "/usr/bin/python3", "-c",
+                "import urllib.request; print(urllib.request.urlopen('https://archive.ubuntu.com/ubuntu/', timeout=10).status)",
+            ],
+            mutating=True,
+        ).strip()
+        if https != "200":
+            raise ProvisioningError("UBUNTU_HTTPS_UNAVAILABLE", "Ubuntu-Paketquelle nicht per HTTPS erreichbar")
 
     def verify_guest_base(self, vmid: int, plan: Mapping[str, object]) -> None:
         arguments = [
@@ -293,6 +333,10 @@ class HostBackend:
         self._run([
             "pct", "exec", str(vmid), "--", "/usr/bin/install", "-d", "-o", "root", "-g", "root", "-m", "0700", parent,
         ], mutating=True)
+        self._run([
+            "pct", "push", str(vmid), str(source), destination,
+            "--perms", f"{mode:04o}", "--user", "0", "--group", "0",
+        ], mutating=True)
 
     def verify_guest_bundle_item(
         self, vmid: int, source: pathlib.Path, relative: str, mode: int
@@ -311,10 +355,6 @@ class HostBackend:
             ], mutating=True).split()[0]
             if remote_hash != sha256_path(source):
                 raise ProvisioningError("BUNDLE_ITEM_CONFLICT", relative)
-        self._run([
-            "pct", "push", str(vmid), str(source), destination,
-            "--perms", f"{mode:04o}", "--user", "0", "--group", "0",
-        ], mutating=True)
 
     def verify_guest_bundle(self, vmid: int) -> None:
         self.verify_guest_base(vmid, {})
@@ -323,6 +363,12 @@ class HostBackend:
         """Rehydrate only ephemeral password copies removed by failure cleanup."""
         for allocation in ALLOCATION_IDS:
             self.push_bundle_item(
+                vmid,
+                sources[allocation],
+                f"{allocation}/application-password",
+                0o600,
+            )
+            self.verify_guest_bundle_item(
                 vmid,
                 sources[allocation],
                 f"{allocation}/application-password",
@@ -695,11 +741,13 @@ class Provisioner:
                             raise
                         # Error cleanup intentionally removed the ephemeral copy.
                         self.backend.push_bundle_item(vmid, source, item, mode)
+                        self.backend.verify_guest_bundle_item(vmid, source, item, mode)
                     marker = self.store.progress(marker, "guest_bundle_ready", item)
                     continue
                 marker = self.store.begin(marker, "guest_bundle_ready", item)
                 self.backend.push_bundle_item(vmid, source, item, mode)
                 self.fault(f"after_bundle:{item}")
+                self.backend.verify_guest_bundle_item(vmid, source, item, mode)
                 marker = self.store.progress(marker, "guest_bundle_ready", item)
         self.backend.verify_guest_bundle(vmid)
         return self.store.complete(marker, "guest_bundle_ready")

--- a/scripts/postgresql_main/marker.py
+++ b/scripts/postgresql_main/marker.py
@@ -1,0 +1,188 @@
+"""Atomic provisioning marker with phase and item-level progress."""
+
+from __future__ import annotations
+
+import copy
+import pathlib
+import re
+from collections.abc import Callable, Mapping
+
+from .filesystem import SecureFilesystem
+from .models import ALLOCATION_IDS, MULTI_ITEM_PHASES, PHASES, ProvisioningError, SHA256_RE
+
+
+MARKER_PATH = pathlib.Path(
+    "/secrets/database-service/providers/postgresql-main/provisioning-state.json"
+)
+PLAN_PATH = pathlib.Path(
+    "/secrets/database-service/providers/postgresql-main/provisioning-plan.json"
+)
+MARKER_SCHEMA_VERSION = 1
+
+
+def new_marker(
+    *,
+    operation_id: str,
+    repository_commit: str,
+    plan: Mapping[str, object],
+    artifact_hashes: Mapping[str, str],
+    now: str,
+) -> dict[str, object]:
+    if not re.fullmatch(r"[0-9a-f]{40}", repository_commit):
+        raise ProvisioningError("REPOSITORY_COMMIT_INVALID", repository_commit)
+    return {
+        "schema_version": MARKER_SCHEMA_VERSION,
+        "operation_id": operation_id,
+        "provider_instance_id": "postgresql-main",
+        "repository_commit": repository_commit,
+        "plan_sha256": plan["plan_sha256"],
+        "configuration_sha256": plan["configuration_sha256"],
+        "version_matrix_sha256": plan["version_matrix_sha256"],
+        "phase": None,
+        "in_progress_phase": "planned",
+        "in_progress_item": "provisioning-state",
+        "completed_phases": [],
+        "phase_progress": {},
+        "created_at": now,
+        "updated_at": now,
+        "vmid": plan["proxmox_observations"]["vmid"],
+        "artifact_hashes": dict(sorted(artifact_hashes.items())),
+        "public_certificate_fingerprints": {},
+        "readiness_status": {
+            "provider_status": "not_verified",
+            "allocation_configuration": "not_verified",
+            "consumer_connectivity": "pending",
+            "allocation_readiness": "consumer_validation_pending",
+        },
+        "backup_artifacts": {},
+        "last_error": None,
+    }
+
+
+def validate_marker(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ProvisioningError("MARKER_INVALID", "Markerwurzel ist kein Objekt")
+    required = {
+        "schema_version", "operation_id", "provider_instance_id", "repository_commit",
+        "plan_sha256", "configuration_sha256", "version_matrix_sha256", "phase",
+        "in_progress_phase", "in_progress_item", "completed_phases", "phase_progress",
+        "created_at", "updated_at", "vmid", "artifact_hashes",
+        "public_certificate_fingerprints", "readiness_status", "backup_artifacts", "last_error",
+    }
+    if set(value) != required:
+        raise ProvisioningError("MARKER_INVALID", "Markerfelder sind unvollständig oder unbekannt")
+    if value["schema_version"] != MARKER_SCHEMA_VERSION or value["provider_instance_id"] != "postgresql-main":
+        raise ProvisioningError("MARKER_INVALID", "Markerschema oder Provider ist ungültig")
+    for key in ("plan_sha256", "configuration_sha256", "version_matrix_sha256"):
+        if not isinstance(value[key], str) or not SHA256_RE.fullmatch(value[key]):
+            raise ProvisioningError("MARKER_INVALID", f"Ungültiger Hash: {key}")
+    if not isinstance(value["repository_commit"], str) or not re.fullmatch(r"[0-9a-f]{40}", value["repository_commit"]):
+        raise ProvisioningError("MARKER_INVALID", "Repository-Commit ungültig")
+    completed = value["completed_phases"]
+    if not isinstance(completed, list) or completed != list(PHASES[: len(completed)]):
+        raise ProvisioningError("MARKER_INVALID", "Phasenreihenfolge ist ungültig")
+    phase = value["phase"]
+    expected_phase = completed[-1] if completed else None
+    if phase != expected_phase:
+        raise ProvisioningError("MARKER_INVALID", "Phase stimmt nicht mit completed_phases überein")
+    in_progress = value["in_progress_phase"]
+    if in_progress is not None:
+        next_index = len(completed)
+        if next_index >= len(PHASES) or in_progress != PHASES[next_index]:
+            raise ProvisioningError("MARKER_INVALID", "in_progress_phase ist nicht die nächste Phase")
+    in_progress_item = value["in_progress_item"]
+    if in_progress_item is not None:
+        if in_progress not in MULTI_ITEM_PHASES or in_progress_item not in MULTI_ITEM_PHASES[in_progress]:
+            if not (in_progress == "planned" and in_progress_item == "provisioning-state"):
+                raise ProvisioningError("MARKER_INVALID", "in_progress_item ist ungültig")
+    progress = value["phase_progress"]
+    if not isinstance(progress, dict):
+        raise ProvisioningError("MARKER_INVALID", "phase_progress ist ungültig")
+    for key, items in progress.items():
+        if key not in MULTI_ITEM_PHASES or not isinstance(items, list):
+            raise ProvisioningError("MARKER_INVALID", "Unbekannter Teilfortschritt")
+        allowed = MULTI_ITEM_PHASES[key]
+        if len(items) != len(set(items)) or any(item not in allowed for item in items):
+            raise ProvisioningError("MARKER_INVALID", "Teilfortschritt enthält ungültige Elemente")
+        if items != [item for item in allowed if item in items]:
+            raise ProvisioningError("MARKER_INVALID", "Teilfortschritt ist nicht geordnet")
+    return copy.deepcopy(value)
+
+
+class MarkerStore:
+    def __init__(
+        self,
+        filesystem: SecureFilesystem,
+        *,
+        marker_path: pathlib.Path = MARKER_PATH,
+        plan_path: pathlib.Path = PLAN_PATH,
+        clock: Callable[[], str],
+    ) -> None:
+        self.fs = filesystem
+        self.marker_path = marker_path
+        self.plan_path = plan_path
+        self.clock = clock
+
+    def exists(self) -> bool:
+        return self.fs.path(self.marker_path).exists()
+
+    def create(self, marker: Mapping[str, object], plan: Mapping[str, object]) -> None:
+        self.fs.exclusive_json(self.plan_path, plan)
+        self.fs.exclusive_json(self.marker_path, marker)
+
+    def load(self) -> dict[str, object]:
+        self.fs.validate(self.marker_path, kind="file", mode=0o600)
+        return validate_marker(self.fs.read_json(self.marker_path))
+
+    def load_plan(self) -> dict[str, object]:
+        self.fs.validate(self.plan_path, kind="file", mode=0o600)
+        value = self.fs.read_json(self.plan_path)
+        if not isinstance(value, dict) or not SHA256_RE.fullmatch(str(value.get("plan_sha256", ""))):
+            raise ProvisioningError("PLAN_EVIDENCE_INVALID", "Gespeicherter Plan ist ungültig")
+        return value
+
+    def save(self, marker: Mapping[str, object]) -> dict[str, object]:
+        updated = copy.deepcopy(dict(marker))
+        updated["updated_at"] = self.clock()
+        validate_marker(updated)
+        self.fs.atomic_json(self.marker_path, updated)
+        return updated
+
+    def begin(self, marker: Mapping[str, object], phase: str, item: str | None = None) -> dict[str, object]:
+        updated = copy.deepcopy(dict(marker))
+        if phase != PHASES[len(updated["completed_phases"])]:
+            raise ProvisioningError("PHASE_ORDER_CONFLICT", phase)
+        updated["in_progress_phase"] = phase
+        updated["in_progress_item"] = item
+        updated["last_error"] = None
+        return self.save(updated)
+
+    def progress(self, marker: Mapping[str, object], phase: str, item: str) -> dict[str, object]:
+        updated = copy.deepcopy(dict(marker))
+        items = list(updated["phase_progress"].get(phase, []))
+        allowed = MULTI_ITEM_PHASES[phase]
+        expected = allowed[len(items)] if len(items) < len(allowed) else None
+        if item != expected:
+            raise ProvisioningError("PHASE_PROGRESS_CONFLICT", f"{phase}:{item}")
+        items.append(item)
+        updated["phase_progress"][phase] = items
+        updated["in_progress_item"] = None
+        return self.save(updated)
+
+    def complete(self, marker: Mapping[str, object], phase: str) -> dict[str, object]:
+        updated = copy.deepcopy(dict(marker))
+        if phase in MULTI_ITEM_PHASES and updated["phase_progress"].get(phase, []) != list(MULTI_ITEM_PHASES[phase]):
+            raise ProvisioningError("PHASE_INCOMPLETE", phase)
+        if phase != PHASES[len(updated["completed_phases"])]:
+            raise ProvisioningError("PHASE_ORDER_CONFLICT", phase)
+        updated["completed_phases"].append(phase)
+        updated["phase"] = phase
+        updated["in_progress_phase"] = None
+        updated["in_progress_item"] = None
+        updated["last_error"] = None
+        return self.save(updated)
+
+    def record_error(self, marker: Mapping[str, object], code: str, message: str) -> dict[str, object]:
+        updated = copy.deepcopy(dict(marker))
+        updated["last_error"] = {"code": code, "summary": message[:300]}
+        return self.save(updated)

--- a/scripts/postgresql_main/models.py
+++ b/scripts/postgresql_main/models.py
@@ -1,0 +1,110 @@
+"""Shared immutable models and canonical serialization helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+
+
+ALLOCATION_IDS = ("gitea", "openbao", "semaphore", "nodered")
+PHASES = (
+    "planned",
+    "secret_directories_ready",
+    "secrets_ready",
+    "pki_ready",
+    "lxc_created",
+    "lxc_started",
+    "guest_bundle_ready",
+    "guest_os_ready",
+    "postgresql_installed",
+    "postgresql_configured",
+    "allocations_created",
+    "readiness_verified",
+    "backups_verified",
+    "completed",
+)
+MULTI_ITEM_PHASES = {
+    "secret_directories_ready": (
+        "provider-pki",
+        "allocations-root",
+        *ALLOCATION_IDS,
+    ),
+    "secrets_ready": ALLOCATION_IDS,
+    "guest_bundle_ready": (
+        "postgresql-main-guest.py",
+        "guest-plan.json",
+        "public-manifest.json",
+        "ca.crt",
+        "server.crt",
+        "server.key",
+        "gitea/application-password",
+        "openbao/application-password",
+        "semaphore/application-password",
+        "nodered/application-password",
+    ),
+    "guest_os_ready": ("apt_update", "full_upgrade", "validate"),
+    "postgresql_installed": ("packages", "validate"),
+    "postgresql_configured": ("tls", "settings", "hba", "start", "validate"),
+    "allocations_created": ALLOCATION_IDS,
+    "readiness_verified": ("provider", *ALLOCATION_IDS),
+    "backups_verified": ALLOCATION_IDS,
+}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ProvisioningError(RuntimeError):
+    """A bounded provisioning step cannot continue safely."""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+
+def canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def canonical_sha256(value: Mapping[str, object], excluded: Sequence[str] = ()) -> str:
+    reduced = {key: item for key, item in value.items() if key not in set(excluded)}
+    return hashlib.sha256(canonical_json(reduced)).hexdigest()
+
+
+@dataclasses.dataclass(frozen=True)
+class ResumePlan:
+    document: Mapping[str, object]
+
+    @property
+    def status(self) -> str:
+        return str(self.document["resume_status"])
+
+    @property
+    def sha256(self) -> str:
+        return str(self.document["resume_sha256"])
+
+    def render_json(self) -> str:
+        return canonical_json(self.document).decode("utf-8") + "\n"
+
+    def render_text(self) -> str:
+        lines = [
+            "== POSTGRESQL-MAIN RESUME-PLAN ==",
+            f"Operation: {self.document['operation_id']}",
+            f"Originalplan: {self.document['plan_sha256']}",
+            f"Letzte bestätigte Phase: {self.document['phase']}",
+            f"Offene Phase: {self.document.get('next_phase') or 'keine'}",
+            f"Nächste Einzelmutation: {self.document.get('next_item') or 'keine'}",
+        ]
+        conflicts = list(self.document.get("conflicts", []))
+        lines.append("Konflikte: " + ("; ".join(conflicts) if conflicts else "keine"))
+        lines.append(f"Resume-SHA-256: {self.sha256}")
+        lines.append(self.status)
+        return "\n".join(lines) + "\n"

--- a/scripts/postgresql_main/pki.py
+++ b/scripts/postgresql_main/pki.py
@@ -201,11 +201,16 @@ class PkiManager:
         self.fs.validate(self._logical("ca.crt"), kind="file", mode=0o644, require_nonempty=True)
         self.fs.validate(self._logical("server.crt"), kind="file", mode=0o644, require_nonempty=True)
         self.runner.run(["openssl", "verify", "-CAfile", str(ca_crt), str(server_crt)])
+        san_text = self.runner.run([
+            "openssl", "x509", "-in", str(server_crt), "-noout", "-ext", "subjectAltName",
+        ]).decode("utf-8", "replace")
+        dns_names = re.findall(r"DNS:([^,\s]+)", san_text)
+        ip_addresses = re.findall(r"IP Address:([^,\s]+)", san_text)
+        if dns_names != [fqdn] or ip_addresses != [provider_ip]:
+            raise ProvisioningError("PKI_SAN_MISMATCH", "Server-SAN stimmt nicht")
         text = self.runner.run([
             "openssl", "x509", "-in", str(server_crt), "-noout", "-text",
         ]).decode("utf-8", "replace")
-        if f"DNS:{fqdn}" not in text or f"IP Address:{provider_ip}" not in text:
-            raise ProvisioningError("PKI_SAN_MISMATCH", "Server-SAN stimmt nicht")
         if "TLS Web Server Authentication" not in text or "CA:FALSE" not in text:
             raise ProvisioningError("PKI_CERTIFICATE_INVALID", "Serverzertifikat verletzt Policy")
         ca_text = self.runner.run([
@@ -213,6 +218,10 @@ class PkiManager:
         ]).decode("utf-8", "replace")
         if "CA:TRUE, pathlen:0" not in ca_text:
             raise ProvisioningError("PKI_CA_INVALID", "CA-Beschränkung fehlt")
+        ca_key_public = self.runner.run(["openssl", "pkey", "-in", str(ca_key), "-pubout"])
+        ca_cert_public = self.runner.run(["openssl", "x509", "-in", str(ca_crt), "-pubkey", "-noout"])
+        if hashlib.sha256(ca_key_public).digest() != hashlib.sha256(ca_cert_public).digest():
+            raise ProvisioningError("PKI_KEY_MISMATCH", "CA-Key und Zertifikat stimmen nicht")
         key_public = self.runner.run(["openssl", "pkey", "-in", str(server_key), "-pubout"])
         cert_public = self.runner.run(["openssl", "x509", "-in", str(server_crt), "-pubkey", "-noout"])
         if hashlib.sha256(key_public).digest() != hashlib.sha256(cert_public).digest():

--- a/scripts/postgresql_main/pki.py
+++ b/scripts/postgresql_main/pki.py
@@ -1,0 +1,224 @@
+"""Versioned PostgreSQL provider PKI creation and verification."""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import ipaddress
+import os
+import pathlib
+import re
+import subprocess
+import tempfile
+import tomllib
+from collections.abc import Callable, Sequence
+
+from .filesystem import SecureFilesystem
+from .models import ProvisioningError
+
+
+@dataclasses.dataclass(frozen=True)
+class PkiPolicy:
+    ca_key_bits: int
+    ca_validity_days: int
+    server_key_bits: int
+    server_validity_days: int
+
+
+def load_policy(path: pathlib.Path) -> PkiPolicy:
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ProvisioningError("PKI_POLICY_INVALID", str(path)) from exc
+    if set(data) != {"schema_version", "ca", "server"} or data["schema_version"] != 1:
+        raise ProvisioningError("PKI_POLICY_INVALID", "Unerwartetes Schema")
+    ca, server = data["ca"], data["server"]
+    if ca != {
+        "key_algorithm": "rsa",
+        "key_bits": 4096,
+        "validity_days": 3650,
+        "digest": "sha256",
+    }:
+        raise ProvisioningError("PKI_POLICY_INVALID", "CA-Policy weicht ab")
+    if server != {
+        "key_algorithm": "rsa",
+        "key_bits": 3072,
+        "validity_days": 397,
+        "digest": "sha256",
+        "extended_key_usage": ["serverAuth"],
+    }:
+        raise ProvisioningError("PKI_POLICY_INVALID", "Server-Policy weicht ab")
+    return PkiPolicy(4096, 3650, 3072, 397)
+
+
+class OpenSslRunner:
+    def __init__(
+        self,
+        executor: Callable[..., subprocess.CompletedProcess[bytes]] = subprocess.run,
+    ) -> None:
+        self.executor = executor
+
+    def run(self, arguments: Sequence[str], *, input_data: bytes | None = None) -> bytes:
+        if not arguments or arguments[0] != "openssl":
+            raise ProvisioningError("PKI_COMMAND_BLOCKED", "Nur openssl ist erlaubt")
+        try:
+            result = self.executor(
+                list(arguments),
+                input=input_data,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise ProvisioningError("PKI_COMMAND_FAILED", "OpenSSL konnte nicht ausgeführt werden") from exc
+        if result.returncode != 0:
+            raise ProvisioningError("PKI_COMMAND_FAILED", "OpenSSL-Prüfung oder Erzeugung fehlgeschlagen")
+        return result.stdout
+
+
+class PkiManager:
+    def __init__(
+        self,
+        filesystem: SecureFilesystem,
+        runner: OpenSslRunner,
+        policy: PkiPolicy,
+        *,
+        pki_root: pathlib.Path = pathlib.Path(
+            "/secrets/database-service/providers/postgresql-main/pki"
+        ),
+        serial_source: Callable[[], int],
+        fault: Callable[[str], None] = lambda _point: None,
+    ) -> None:
+        self.fs = filesystem
+        self.runner = runner
+        self.policy = policy
+        self.root = pki_root
+        self.serial_source = serial_source
+        self.fault = fault
+
+    def _logical(self, name: str) -> pathlib.Path:
+        return self.root / name
+
+    def generate(self, fqdn: str, provider_ip: str) -> dict[str, str]:
+        if not re.fullmatch(r"[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?", fqdn):
+            raise ProvisioningError("PKI_INPUT_INVALID", "FQDN ungültig")
+        try:
+            address = ipaddress.IPv4Address(provider_ip)
+        except ipaddress.AddressValueError as exc:
+            raise ProvisioningError("PKI_INPUT_INVALID", "Provider-IP ungültig") from exc
+        existing = {
+            name: self.fs.path(self._logical(name)).exists()
+            for name in ("ca.key", "ca.crt", "server.key", "server.crt")
+        }
+        if existing["ca.crt"] and not existing["ca.key"]:
+            raise ProvisioningError("PKI_PARTIAL_CONFLICT", "CA-Zertifikat ohne CA-Key")
+        if existing["server.crt"] and not existing["server.key"]:
+            raise ProvisioningError("PKI_PARTIAL_CONFLICT", "Serverzertifikat ohne Server-Key")
+        for name, present in existing.items():
+            if present:
+                self.fs.validate(
+                    self._logical(name),
+                    kind="file",
+                    mode=0o600 if name.endswith(".key") else 0o644,
+                    require_nonempty=True,
+                )
+        root = self.fs.path(self.root)
+        with tempfile.TemporaryDirectory(prefix=".pki.", dir=root) as raw_temp:
+            temporary = pathlib.Path(raw_temp)
+            os.chmod(temporary, 0o700)
+            ca_key = temporary / "ca.key"
+            ca_crt = temporary / "ca.crt"
+            server_key = temporary / "server.key"
+            server_csr = temporary / "server.csr"
+            server_crt = temporary / "server.crt"
+            ext_file = temporary / "server.ext"
+            if not existing["ca.key"]:
+                self.runner.run([
+                    "openssl", "genpkey", "-algorithm", "RSA", "-pkeyopt",
+                    f"rsa_keygen_bits:{self.policy.ca_key_bits}", "-out", str(ca_key),
+                ])
+                self.fs.exclusive_bytes(self._logical("ca.key"), ca_key.read_bytes(), mode=0o600)
+                self.fault("after_ca_key")
+            published_ca_key = self.fs.path(self._logical("ca.key"))
+            if not existing["ca.crt"]:
+                self.runner.run([
+                    "openssl", "req", "-new", "-x509", "-key", str(published_ca_key),
+                    "-sha256", "-days", str(self.policy.ca_validity_days), "-subj",
+                    "/CN=RALF postgresql-main CA", "-addext",
+                    "basicConstraints=critical,CA:true,pathlen:0", "-addext",
+                    "keyUsage=critical,keyCertSign,cRLSign", "-out", str(ca_crt),
+                ])
+                self.fs.exclusive_bytes(self._logical("ca.crt"), ca_crt.read_bytes(), mode=0o644)
+                self.fault("after_ca_certificate")
+            published_ca_crt = self.fs.path(self._logical("ca.crt"))
+            if not existing["server.key"]:
+                self.runner.run([
+                    "openssl", "genpkey", "-algorithm", "RSA", "-pkeyopt",
+                    f"rsa_keygen_bits:{self.policy.server_key_bits}", "-out", str(server_key),
+                ])
+                self.fs.exclusive_bytes(self._logical("server.key"), server_key.read_bytes(), mode=0o600)
+                self.fault("after_server_key")
+            published_server_key = self.fs.path(self._logical("server.key"))
+            if existing["server.crt"]:
+                return self.verify(fqdn, provider_ip)
+            self.runner.run([
+                "openssl", "req", "-new", "-sha256", "-key", str(published_server_key),
+                "-subj", f"/CN={fqdn}", "-out", str(server_csr),
+            ])
+            ext_file.write_text(
+                "\n".join((
+                    "basicConstraints=critical,CA:false",
+                    "keyUsage=critical,digitalSignature,keyEncipherment",
+                    "extendedKeyUsage=serverAuth",
+                    f"subjectAltName=DNS:{fqdn},IP:{address}",
+                    "",
+                )),
+                encoding="ascii",
+            )
+            os.chmod(ext_file, 0o600)
+            serial = self.serial_source()
+            if not 0 < serial < 2**159:
+                raise ProvisioningError("PKI_SERIAL_INVALID", "Seriennummer ungültig")
+            self.runner.run([
+                "openssl", "x509", "-req", "-sha256", "-in", str(server_csr),
+                "-CA", str(published_ca_crt), "-CAkey", str(published_ca_key), "-set_serial",
+                f"0x{serial:x}", "-days", str(self.policy.server_validity_days),
+                "-extfile", str(ext_file), "-out", str(server_crt),
+            ])
+            self.fs.exclusive_bytes(self._logical("server.crt"), server_crt.read_bytes(), mode=0o644)
+            self.fault("after_server_certificate")
+        return self.verify(fqdn, provider_ip)
+
+    def verify(self, fqdn: str, provider_ip: str) -> dict[str, str]:
+        ca_key = self.fs.path(self._logical("ca.key"))
+        ca_crt = self.fs.path(self._logical("ca.crt"))
+        server_key = self.fs.path(self._logical("server.key"))
+        server_crt = self.fs.path(self._logical("server.crt"))
+        self.fs.validate(self._logical("ca.key"), kind="file", mode=0o600, require_nonempty=True)
+        self.fs.validate(self._logical("server.key"), kind="file", mode=0o600, require_nonempty=True)
+        self.fs.validate(self._logical("ca.crt"), kind="file", mode=0o644, require_nonempty=True)
+        self.fs.validate(self._logical("server.crt"), kind="file", mode=0o644, require_nonempty=True)
+        self.runner.run(["openssl", "verify", "-CAfile", str(ca_crt), str(server_crt)])
+        text = self.runner.run([
+            "openssl", "x509", "-in", str(server_crt), "-noout", "-text",
+        ]).decode("utf-8", "replace")
+        if f"DNS:{fqdn}" not in text or f"IP Address:{provider_ip}" not in text:
+            raise ProvisioningError("PKI_SAN_MISMATCH", "Server-SAN stimmt nicht")
+        if "TLS Web Server Authentication" not in text or "CA:FALSE" not in text:
+            raise ProvisioningError("PKI_CERTIFICATE_INVALID", "Serverzertifikat verletzt Policy")
+        ca_text = self.runner.run([
+            "openssl", "x509", "-in", str(ca_crt), "-noout", "-text",
+        ]).decode("utf-8", "replace")
+        if "CA:TRUE, pathlen:0" not in ca_text:
+            raise ProvisioningError("PKI_CA_INVALID", "CA-Beschränkung fehlt")
+        key_public = self.runner.run(["openssl", "pkey", "-in", str(server_key), "-pubout"])
+        cert_public = self.runner.run(["openssl", "x509", "-in", str(server_crt), "-pubkey", "-noout"])
+        if hashlib.sha256(key_public).digest() != hashlib.sha256(cert_public).digest():
+            raise ProvisioningError("PKI_KEY_MISMATCH", "Server-Key und Zertifikat stimmen nicht")
+        fingerprints: dict[str, str] = {}
+        for name, path in (("ca", ca_crt), ("server", server_crt)):
+            der = self.runner.run(["openssl", "x509", "-in", str(path), "-outform", "DER"])
+            fingerprints[name] = hashlib.sha256(der).hexdigest()
+        return fingerprints

--- a/scripts/postgresql_main/plan.py
+++ b/scripts/postgresql_main/plan.py
@@ -1,0 +1,29 @@
+"""Import the standalone planner without parsing its rendered CLI output."""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+from functools import lru_cache
+
+
+SCRIPT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+PLANNER_PATH = SCRIPT_ROOT / "postgresql-main-plan.py"
+
+
+@lru_cache(maxsize=1)
+def planner_module() -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("ralf_postgresql_main_plan", PLANNER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Planermodul kann nicht geladen werden: {PLANNER_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def create_plan_report(*args, **kwargs):
+    """Return the shared PlanReport used by both planner and deployer."""
+    return planner_module().create_plan_report(*args, **kwargs)

--- a/tests/postgresql_main_support.py
+++ b/tests/postgresql_main_support.py
@@ -1,0 +1,224 @@
+"""Shared fakes for the postgresql-main provisioning tests."""
+
+from __future__ import annotations
+
+import hashlib
+import pathlib
+import types
+
+from postgresql_main.filesystem import SecureFilesystem
+from postgresql_main.host import CONFIG_PATH, PASSWORD_PATHS, sha256_path
+from postgresql_main.marker import MarkerStore
+from postgresql_main.models import ALLOCATION_IDS, ProvisioningError
+from postgresql_main import plan as shared_plan
+
+
+NOW = "2026-08-06T12:00:00Z"
+COMMIT = "a" * 40
+
+
+class FakePki:
+    def __init__(self, filesystem: SecureFilesystem, *, fault=lambda _point: None) -> None:
+        self.fs = filesystem
+        self.root = pathlib.Path("/secrets/database-service/providers/postgresql-main/pki")
+        self.fault = fault
+
+    def generate(self, fqdn: str, provider_ip: str) -> dict[str, str]:
+        del fqdn, provider_ip
+        for name, mode, point in (
+            ("ca.key", 0o600, "after_ca_key"),
+            ("ca.crt", 0o644, "after_ca_certificate"),
+            ("server.key", 0o600, "after_server_key"),
+            ("server.crt", 0o644, "after_server_certificate"),
+        ):
+            logical = self.root / name
+            if not self.fs.path(logical).exists():
+                self.fs.exclusive_bytes(logical, f"fake-{name}".encode(), mode=mode)
+                self.fault(point)
+        return self.verify("", "")
+
+    def verify(self, fqdn: str, provider_ip: str) -> dict[str, str]:
+        del fqdn, provider_ip
+        for name, mode in (("ca.key", 0o600), ("ca.crt", 0o644), ("server.key", 0o600), ("server.crt", 0o644)):
+            self.fs.validate(self.root / name, kind="file", mode=mode, require_nonempty=True)
+        return {
+            "ca": hashlib.sha256(b"fake-ca.crt").hexdigest(),
+            "server": hashlib.sha256(b"fake-server.crt").hexdigest(),
+        }
+
+
+class FakeBackend:
+    def __init__(self) -> None:
+        self.commit = COMMIT
+        self.clean = True
+        self.actions: list[str] = []
+        self.status = "absent"
+        self.guest_completed: set[tuple[str, str | None]] = set()
+        self.bundle_items: set[str] = set()
+        self.cleanup_calls = 0
+
+    def repository_commit(self) -> str:
+        return self.commit
+
+    def repository_clean(self) -> bool:
+        return self.clean
+
+    def create_lxc(self, plan) -> None:
+        del plan
+        self.actions.append("pct create")
+        if self.status != "absent":
+            raise ProvisioningError("LXC_CONFLICT", "exists")
+        self.status = "stopped"
+
+    def start_lxc(self, vmid: int) -> None:
+        self.actions.append(f"pct start {vmid}")
+        if self.status != "stopped":
+            raise ProvisioningError("LXC_CONFLICT", "not stopped")
+        self.status = "running"
+
+    def verify_lxc(self, plan, *, expected_status: str) -> None:
+        del plan
+        if self.status != expected_status:
+            raise ProvisioningError("LXC_STATE_CONFLICT", self.status)
+
+    def verify_started_guest(self, plan) -> None:
+        del plan
+        if self.status != "running":
+            raise ProvisioningError("GUEST_STATE_CONFLICT", self.status)
+
+    def initialize_guest_bundle(self, vmid: int) -> None:
+        self.actions.append(f"bundle init {vmid}")
+
+    def push_bundle_item(self, vmid: int, source: pathlib.Path, relative: str, mode: int) -> None:
+        del vmid, mode
+        if not source.is_file():
+            raise ProvisioningError("BUNDLE_SOURCE_MISSING", relative)
+        self.actions.append(f"bundle push {relative}")
+        self.bundle_items.add(relative)
+
+    def verify_guest_bundle(self, vmid: int) -> None:
+        del vmid
+        if len(self.bundle_items) != 10:
+            raise ProvisioningError("BUNDLE_INVALID", "incomplete")
+
+    def verify_guest_bundle_item(self, vmid: int, source: pathlib.Path, relative: str, mode: int) -> None:
+        del vmid, source, mode
+        if relative not in self.bundle_items:
+            raise ProvisioningError("BUNDLE_ITEM_CONFLICT", relative)
+
+    def ensure_guest_secrets(self, vmid: int, sources) -> None:
+        del vmid
+        for allocation, source in sources.items():
+            if not source.is_file():
+                raise ProvisioningError("SECRET_MISSING", allocation)
+            self.bundle_items.add(f"{allocation}/application-password")
+        self.actions.append("guest secrets rehydrated")
+
+    def apply_guest_phase(self, vmid: int, phase: str, *, item: str | None = None) -> str:
+        del vmid
+        self.actions.append(f"guest {phase}:{item}")
+        self.guest_completed.add((phase, item))
+        return f"PHASE_COMPLETED {phase} {item}"
+
+    def verify_guest_phase(self, vmid: int, phase: str, *, item: str | None = None) -> None:
+        del vmid
+        if item is not None and (phase, item) not in self.guest_completed:
+            raise ProvisioningError("GUEST_STATE_CONFLICT", f"{phase}:{item}")
+
+    def verify_phase(self, phase: str, marker, plan) -> None:
+        del marker, plan
+        if phase == "lxc_created" and self.status not in {"stopped", "running"}:
+            raise ProvisioningError("LXC_STATE_CONFLICT", self.status)
+        if phase not in {"planned", "secret_directories_ready", "secrets_ready", "pki_ready", "lxc_created"} and self.status != "running":
+            raise ProvisioningError("LXC_STATE_CONFLICT", self.status)
+
+    def stream_backup(self, vmid: int, database_name: str, destination: pathlib.Path) -> None:
+        del vmid
+        self.actions.append(f"backup {database_name}")
+        with destination.open("xb") as handle:
+            handle.write(f"backup:{database_name}".encode())
+        destination.chmod(0o600)
+
+    def verify_backup(self, vmid: int, backup_path: pathlib.Path) -> None:
+        del vmid
+        if not backup_path.read_bytes().startswith(b"backup:"):
+            raise ProvisioningError("BACKUP_FAILED", "invalid")
+
+    def cleanup_guest_secrets(self, vmid: int) -> None:
+        del vmid
+        self.cleanup_calls += 1
+        self.bundle_items -= {f"{item}/application-password" for item in ALLOCATION_IDS}
+
+
+def make_environment(root: pathlib.Path):
+    filesystem = SecureFilesystem(root)
+    provider = root / "secrets/database-service/providers/postgresql-main"
+    provider.mkdir(parents=True, mode=0o700)
+    for directory in (
+        root / "secrets",
+        root / "secrets/database-service",
+        root / "secrets/database-service/providers",
+        provider,
+    ):
+        directory.chmod(0o700)
+    config = provider / "deployment.toml"
+    config.write_text("schema_version = 1\n", encoding="utf-8")
+    config.chmod(0o600)
+    backup = root / "backup"
+    backup.mkdir(mode=0o700)
+    artifacts_dir = root / "artifacts"
+    artifacts_dir.mkdir()
+    artifacts = {}
+    for name in ("planner", "deployer", "guest", "pki_policy", "version_matrix"):
+        path = artifacts_dir / name
+        path.write_text(name, encoding="utf-8")
+        artifacts[name] = path
+    allocations = []
+    for allocation in ALLOCATION_IDS:
+        allocations.append({
+            "allocation_id": allocation,
+            "database_name": allocation,
+            "application_identity": allocation,
+            "owner_identity": f"{allocation}_owner",
+            "allowed_client_cidrs": [f"10.20.{len(allocations) + 1}.0/24"],
+        })
+    plan = {
+        "schema_version": 1,
+        "plan_type": "postgresql-main-deployment",
+        "repository_commit": COMMIT,
+        "configuration_path": str(CONFIG_PATH),
+        "configuration_sha256": sha256_path(config),
+        "version_matrix_sha256": sha256_path(artifacts["version_matrix"]),
+        "plan_inputs": {
+            "provider": {"provider_instance_id": "postgresql-main", "fqdn": "postgresql-main.example.internal"},
+            "lxc": {
+                "ipv4_cidr": "10.20.0.10/24", "gateway": "10.20.0.1",
+                "cores": 4, "memory_mib": 8192, "swap_mib": 2048,
+                "disk_gib": 100, "dns_servers": ["10.20.0.1"],
+            },
+            "backup": {"host_root": str(backup)},
+            "allocations": allocations,
+        },
+        "proxmox_observations": {
+            "vmid": 250, "storage": "local-lvm", "bridge": "vmbr0",
+            "template": "local:vztmpl/ubuntu-26.04-standard_amd64.tar.zst",
+        },
+        "secret_metadata_observations": [],
+        "backup_observations": {},
+        "warnings": [],
+        "blockers": [],
+        "planned_mutations": ["bounded provisioning"],
+        "excluded_scope": ["rollback"],
+        "plan_status": "PLAN_READY",
+    }
+    planner = shared_plan.planner_module()
+    plan["plan_sha256"] = planner.calculate_plan_sha256(plan)
+    report = types.SimpleNamespace(machine_plan=plan, blockers=[])
+    store = MarkerStore(filesystem, clock=lambda: NOW)
+    backend = FakeBackend()
+    pki = FakePki(filesystem)
+    return filesystem, backend, store, pki, artifacts, report
+
+
+def secret_values(filesystem: SecureFilesystem) -> list[bytes]:
+    return [filesystem.read_bytes(PASSWORD_PATHS[item]) for item in ALLOCATION_IDS]

--- a/tests/test_postgresql_main_deploy.py
+++ b/tests/test_postgresql_main_deploy.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from postgresql_main.host import (
+    CONFIG_PATH, LOCK_PATH, Provisioner, build_pct_create_arguments,
+)
+from postgresql_main.models import ALLOCATION_IDS, ProvisioningError
+from postgresql_main_support import NOW, make_environment
+
+
+def make_provisioner(root: pathlib.Path, *, fault=lambda _point: None):
+    fs, backend, store, pki, artifacts, report = make_environment(root)
+    provisioner = Provisioner(
+        filesystem=fs, backend=backend, marker_store=store, pki=pki,
+        plan_factory=lambda _path: report, token_source=lambda: "S" * 64,
+        operation_id_source=lambda: "operation-1", clock=lambda: NOW,
+        fault=fault, artifact_paths=artifacts,
+    )
+    return provisioner, fs, backend, store, pki, artifacts, report
+
+
+class ApplyBoundaryTests(unittest.TestCase):
+    def test_wrong_hash_blocks_before_any_mutation(self):
+        with tempfile.TemporaryDirectory() as raw:
+            provisioner, fs, backend, _store, _pki, _artifacts, _report = make_provisioner(pathlib.Path(raw))
+            with self.assertRaisesRegex(ProvisioningError, "Plan-Hash") as caught:
+                provisioner.apply(CONFIG_PATH, "0" * 64)
+            self.assertEqual(caught.exception.code, "APPLY_BLOCKED_PLAN_CHANGED")
+            self.assertEqual(backend.actions, [])
+            self.assertFalse(fs.path("/secrets/database-service/providers/postgresql-main/provisioning-state.json").exists())
+            self.assertFalse(fs.path(LOCK_PATH).exists())
+
+    def test_blocked_plan_is_not_applyable(self):
+        with tempfile.TemporaryDirectory() as raw:
+            provisioner, _fs, backend, _store, _pki, _artifacts, report = make_provisioner(pathlib.Path(raw))
+            report.blockers.append("blocked")
+            with self.assertRaisesRegex(ProvisioningError, "Blocker"):
+                provisioner.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+            self.assertEqual(backend.actions, [])
+
+    def test_dirty_repository_blocks_before_marker(self):
+        with tempfile.TemporaryDirectory() as raw:
+            provisioner, fs, backend, _store, _pki, _artifacts, report = make_provisioner(pathlib.Path(raw))
+            backend.clean = False
+            with self.assertRaisesRegex(ProvisioningError, "Repository"):
+                provisioner.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+            self.assertFalse(fs.path("/secrets/database-service/providers/postgresql-main/provisioning-state.json").exists())
+
+    def test_unsafe_configuration_metadata_blocks(self):
+        with tempfile.TemporaryDirectory() as raw:
+            provisioner, fs, _backend, _store, _pki, _artifacts, report = make_provisioner(pathlib.Path(raw))
+            fs.path(CONFIG_PATH).chmod(0o644)
+            with self.assertRaisesRegex(ProvisioningError, "Metadaten"):
+                provisioner.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+
+    def test_parallel_apply_is_rejected_without_waiting(self):
+        with tempfile.TemporaryDirectory() as raw:
+            provisioner, fs, _backend, _store, _pki, _artifacts, report = make_provisioner(pathlib.Path(raw))
+            with fs.exclusive_lock(LOCK_PATH):
+                with self.assertRaises(ProvisioningError) as caught:
+                    provisioner.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+            self.assertEqual(caught.exception.code, "PROVISIONING_ALREADY_RUNNING")
+
+    def test_complete_mocked_apply_has_single_create_and_start(self):
+        with tempfile.TemporaryDirectory() as raw:
+            provisioner, _fs, backend, _store, _pki, _artifacts, report = make_provisioner(pathlib.Path(raw))
+            marker = provisioner.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+            self.assertEqual(backend.actions.count("pct create"), 1)
+            self.assertEqual(backend.actions.count("pct start 250"), 1)
+            self.assertEqual(marker["readiness_status"]["provider_status"], "ready")
+            self.assertEqual(marker["readiness_status"]["allocation_readiness"], "consumer_validation_pending")
+            self.assertEqual(set(marker["backup_artifacts"]), set(ALLOCATION_IDS))
+            self.assertEqual(backend.cleanup_calls, 1)
+
+    def test_lxc_command_is_exactly_bounded(self):
+        with tempfile.TemporaryDirectory() as raw:
+            _provisioner, _fs, _backend, _store, _pki, _artifacts, report = make_provisioner(pathlib.Path(raw))
+            args = build_pct_create_arguments(report.machine_plan)
+            self.assertEqual(args[:4], ["pct", "create", "250", "local:vztmpl/ubuntu-26.04-standard_amd64.tar.zst"])
+            self.assertIn("nesting=1", args)
+            self.assertIn("--unprivileged", args)
+            self.assertNotIn("mp0", " ".join(args))
+            self.assertNotIn("gpu", " ".join(args).lower())
+
+    def test_cleanup_failure_is_reported_without_hiding_original_error(self):
+        with tempfile.TemporaryDirectory() as raw:
+            provisioner, fs, backend, _store, _pki, _artifacts, report = make_provisioner(pathlib.Path(raw))
+
+            def fail_after_guest(point: str) -> None:
+                if point == "after_guest_os_ready:apt_update":
+                    raise ProvisioningError("ORIGINAL_FAILURE", "original")
+
+            def cleanup_failure(_vmid: int) -> None:
+                raise ProvisioningError("SECURITY_CLEANUP_FAILED", "cleanup")
+
+            provisioner.fault = fail_after_guest
+            backend.cleanup_guest_secrets = cleanup_failure
+            with self.assertRaises(ProvisioningError) as caught:
+                provisioner.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+            self.assertEqual(caught.exception.code, "ORIGINAL_FAILURE")
+            self.assertIn("SECURITY_CLEANUP_FAILED", caught.exception.message)
+            self.assertEqual(backend.status, "running")
+            self.assertTrue(fs.path("/secrets/database-service/allocations/gitea/application-password").exists())
+
+
+class CliSurfaceTests(unittest.TestCase):
+    def test_only_contractual_commands_are_exposed(self):
+        import importlib.util
+        path = SCRIPTS / "postgresql-main-deploy.py"
+        spec = importlib.util.spec_from_file_location("postgresql_main_deploy_cli", path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader
+        spec.loader.exec_module(module)
+        parser = module.create_parser()
+        commands = next(action for action in parser._actions if action.dest == "command").choices
+        self.assertEqual(set(commands), {"apply", "resume-plan", "resume-apply"})
+        for forbidden in ("--force", "--yes", "--skip-checks", "--rollback", "--mock", "--test-root"):
+            self.assertNotIn(forbidden, parser.format_help())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgresql_main_deploy.py
+++ b/tests/test_postgresql_main_deploy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -9,7 +10,8 @@ SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
 sys.path.insert(0, str(SCRIPTS))
 
 from postgresql_main.host import (
-    CONFIG_PATH, LOCK_PATH, Provisioner, build_pct_create_arguments,
+    ARTIFACT_PATHS, CONFIG_PATH, GUEST_ROOT, HostBackend, LOCK_PATH, Provisioner,
+    build_pct_create_arguments,
 )
 from postgresql_main.models import ALLOCATION_IDS, ProvisioningError
 from postgresql_main_support import NOW, make_environment
@@ -88,6 +90,41 @@ class ApplyBoundaryTests(unittest.TestCase):
             self.assertIn("--unprivileged", args)
             self.assertNotIn("mp0", " ".join(args))
             self.assertNotIn("gpu", " ".join(args).lower())
+
+    def test_production_bundle_push_precedes_read_only_verification(self):
+        calls: list[list[str]] = []
+
+        def executor(arguments, **_kwargs):
+            args = list(arguments)
+            calls.append(args)
+            if args[4:6] == ["/usr/bin/stat", "--format=%F|%a|%u|%g|%s"]:
+                return subprocess.CompletedProcess(args, 0, stdout="regular file|644|0|0|5\n", stderr="")
+            if args[4:6] == ["/usr/bin/sha256sum", str(GUEST_ROOT / "guest-plan.json")]:
+                import hashlib
+                return subprocess.CompletedProcess(
+                    args, 0, stdout=hashlib.sha256(b"hello").hexdigest() + "  file\n", stderr=""
+                )
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as raw:
+            source = pathlib.Path(raw) / "guest-plan.json"
+            source.write_bytes(b"hello")
+            backend = HostBackend(executor=executor)
+            backend.push_bundle_item(250, source, "guest-plan.json", 0o644)
+            self.assertEqual(calls[1][:4], ["pct", "push", "250", str(source)])
+            backend.verify_guest_bundle_item(250, source, "guest-plan.json", 0o644)
+            self.assertEqual(len([args for args in calls if args[:2] == ["pct", "push"]]), 1)
+
+    def test_transferred_guest_artifact_is_standalone_executable(self):
+        result = subprocess.run(
+            [sys.executable, str(ARTIFACT_PATHS["guest"]), "--help"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_cleanup_failure_is_reported_without_hiding_original_error(self):
         with tempfile.TemporaryDirectory() as raw:

--- a/tests/test_postgresql_main_guest.py
+++ b/tests/test_postgresql_main_guest.py
@@ -35,7 +35,7 @@ class FakeRunner:
             return b"Installed: (none)\nCandidate: 18.4-0ubuntu0.26.04.1\n"
         if args[:2] == ["openssl", "verify"]:
             return b"ok"
-        if args[:3] == ["openssl", "x509", "-in"] and "-text" in args:
+        if args[:3] == ["openssl", "x509", "-in"] and ("-text" in args or "subjectAltName" in args):
             return b"DNS:postgresql-main.example.internal, IP Address:10.20.0.10\n"
         if args[:2] == ["openssl", "pkey"] or (args[:2] == ["openssl", "x509"] and "-pubkey" in args):
             return b"same-public-key"
@@ -218,11 +218,30 @@ class GuestValidationTests(unittest.TestCase):
             original = runner.run
 
             def wrong_san(arguments, **kwargs):
-                if arguments[:3] == ["openssl", "x509", "-in"] and "-text" in arguments:
+                if arguments[:3] == ["openssl", "x509", "-in"] and ("-text" in arguments or "subjectAltName" in arguments):
                     return b"DNS:other.example, IP Address:192.0.2.1\n"
                 return original(arguments, **kwargs)
 
             runner.run = wrong_san
+            provisioner = GuestProvisioner(runner=runner, bundle=bundle, root=target)
+            with self.assertRaisesRegex(ProvisioningError, "bindet Plan nicht"):
+                provisioner._validate_bundle_pki()
+
+    def test_additional_certificate_san_is_rejected(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            runner = FakeRunner()
+            original = runner.run
+
+            def extra_san(arguments, **kwargs):
+                if arguments[:3] == ["openssl", "x509", "-in"] and "subjectAltName" in arguments:
+                    return (
+                        b"DNS:postgresql-main.example.internal, DNS:extra.example.internal, "
+                        b"IP Address:10.20.0.10\n"
+                    )
+                return original(arguments, **kwargs)
+
+            runner.run = extra_san
             provisioner = GuestProvisioner(runner=runner, bundle=bundle, root=target)
             with self.assertRaisesRegex(ProvisioningError, "bindet Plan nicht"):
                 provisioner._validate_bundle_pki()
@@ -238,6 +257,10 @@ class GuestValidationTests(unittest.TestCase):
             argv = "\n".join(" ".join(arguments) for arguments, _input in runner.calls)
             self.assertNotIn(secret, argv)
             self.assertTrue(any(secret.encode() in (input_data or b"") for _args, input_data in runner.calls))
+            sql = b"\n".join(input_data or b"" for _args, input_data in runner.calls)
+            self.assertIn(b"WITH INHERIT FALSE, SET FALSE", sql)
+            self.assertIn(b"GRANT USAGE, CREATE ON SCHEMA public TO \"gitea\"", sql)
+            self.assertNotIn(b"GRANT USAGE, CREATE ON SCHEMA public TO \"gitea_owner\"", sql)
 
     def test_global_listener_is_rejected(self):
         with tempfile.TemporaryDirectory() as raw:

--- a/tests/test_postgresql_main_guest.py
+++ b/tests/test_postgresql_main_guest.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from postgresql_main.guest import (
+    GuestProvisioner, load_guest_plan, render_hba, validate_hba,
+)
+from postgresql_main.models import ALLOCATION_IDS, ProvisioningError
+
+
+class FakeRunner:
+    def __init__(self, *, clusters: bytes = b"") -> None:
+        self.clusters = clusters
+        self.calls: list[tuple[list[str], bytes | None]] = []
+        self.query_results: list[bytes] = []
+
+    def run(self, arguments, *, input_data=None, **_kwargs):
+        args = list(arguments)
+        self.calls.append((args, input_data))
+        if args[0] == "pg_lsclusters":
+            return self.clusters
+        if args[:2] == ["apt-cache", "policy"]:
+            return b"Installed: (none)\nCandidate: 18.4-0ubuntu0.26.04.1\n"
+        if args[:2] == ["openssl", "verify"]:
+            return b"ok"
+        if args[:3] == ["openssl", "x509", "-in"] and "-text" in args:
+            return b"DNS:postgresql-main.example.internal, IP Address:10.20.0.10\n"
+        if args[:2] == ["openssl", "pkey"] or (args[:2] == ["openssl", "x509"] and "-pubkey" in args):
+            return b"same-public-key"
+        if args[:4] == ["pg_conftool", "18", "main", "show"]:
+            return b"listen_addresses = 10.20.0.10\nssl = on\npassword_encryption = scram-sha-256\nssl_min_protocol_version = TLSv1.2\n"
+        if args[0] == "ss":
+            return b"LISTEN 0 244 10.20.0.10:5432"
+        if args[:3] == ["ip", "-4", "address"]:
+            return b"inet 10.20.0.10/24 scope global eth0"
+        if args[:3] == ["ip", "-4", "route"]:
+            return b"default via 10.20.0.1 dev eth0"
+        if args[0] == "df":
+            return b"Filesystem 1024-blocks Used Available Capacity Mounted\n/dev/root 10000000 1000 9000000 1% /\n"
+        if args[0] == "runuser" and "--tuples-only" in args:
+            return self.query_results.pop(0) if self.query_results else b"180004\non\nscram-sha-256\nTLSv1.2\n0\n"
+        return b""
+
+
+def make_bundle(root: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path, dict[str, object]]:
+    guest_root = root / "guest"
+    guest_root.mkdir()
+    target_root = root / "target"
+    (target_root / "etc/apt/sources.list.d").mkdir(parents=True)
+    (target_root / "etc").mkdir(exist_ok=True)
+    (target_root / "etc/os-release").write_text('ID=ubuntu\nVERSION_ID="26.04"\n', encoding="utf-8")
+    (target_root / "etc/resolv.conf").write_text("nameserver 10.20.0.1\n", encoding="utf-8")
+    (target_root / "etc/apt/sources.list.d/ubuntu.sources").write_text(
+        "Types: deb\nURIs: https://archive.ubuntu.com/ubuntu\nSuites: resolute\n",
+        encoding="utf-8",
+    )
+    (target_root / "var/lib/dpkg").mkdir(parents=True)
+    (target_root / "var/lib/apt/lists").mkdir(parents=True)
+    allocations = [
+        {
+            "allocation_id": item,
+            "database_name": item,
+            "application_identity": item,
+            "owner_identity": f"{item}_owner",
+            "allowed_client_cidrs": [f"10.30.{index}.0/24"],
+        }
+        for index, item in enumerate(ALLOCATION_IDS, 1)
+    ]
+    plan = {
+        "schema_version": 1,
+        "provider_instance_id": "postgresql-main",
+        "postgresql_major": 18,
+        "fqdn": "postgresql-main.example.internal",
+        "hostname": "postgresql-main",
+        "provider_ip": "10.20.0.10",
+        "gateway": "10.20.0.1",
+        "dns_servers": ["10.20.0.1"],
+        "allocations": allocations,
+    }
+    (guest_root / "guest-plan.json").write_text(json.dumps(plan), encoding="utf-8")
+    for name in ("postgresql-main-guest.py", "ca.crt", "server.crt", "server.key"):
+        (guest_root / name).write_bytes(name.encode())
+    artifacts = {}
+    for name in ("postgresql-main-guest.py", "guest-plan.json", "ca.crt", "server.crt"):
+        artifacts[name] = hashlib.sha256((guest_root / name).read_bytes()).hexdigest()
+    (guest_root / "public-manifest.json").write_text(json.dumps({"schema_version": 1, "artifacts": artifacts}), encoding="utf-8")
+    for allocation in ALLOCATION_IDS:
+        directory = guest_root / allocation
+        directory.mkdir()
+        secret = directory / "application-password"
+        secret.write_bytes((allocation + "-" + "S" * 64).encode())
+        secret.chmod(0o600)
+    return guest_root, target_root, plan
+
+
+class GuestValidationTests(unittest.TestCase):
+    def test_wrong_os_and_architecture_are_rejected(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            provisioner = GuestProvisioner(runner=FakeRunner(), bundle=bundle, root=target)
+            (target / "etc/os-release").write_text("ID=debian\nVERSION_ID=13\n", encoding="utf-8")
+            with self.assertRaisesRegex(ProvisioningError, "Ubuntu 26.04"):
+                provisioner._validate_base()
+            (target / "etc/os-release").write_text('ID=ubuntu\nVERSION_ID="26.04"\n', encoding="utf-8")
+            with mock.patch("postgresql_main.guest.platform.machine", return_value="aarch64"):
+                with self.assertRaisesRegex(ProvisioningError, "amd64"):
+                    provisioner._validate_base()
+
+    def test_pgdg_source_is_rejected(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            (target / "etc/apt/sources.list.d/pgdg.list").write_text("deb https://apt.postgresql.org/pub/repos/apt", encoding="utf-8")
+            provisioner = GuestProvisioner(runner=FakeRunner(), bundle=bundle, root=target)
+            with self.assertRaisesRegex(ProvisioningError, "PGDG"):
+                provisioner.classify()
+
+    def test_wrong_or_multiple_clusters_are_conflict(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            for clusters in (b"19 main 5432 down postgres\n", b"18 main 5432 down postgres\n18 other 5433 down postgres\n"):
+                with self.subTest(clusters=clusters):
+                    provisioner = GuestProvisioner(runner=FakeRunner(clusters=clusters), bundle=bundle, root=target)
+                    self.assertEqual(provisioner.classify(), "guest_conflict")
+
+    def test_package_lock_and_reboot_pause_are_visible(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            provisioner = GuestProvisioner(runner=FakeRunner(), bundle=bundle, root=target)
+            lock = target / "var/lib/dpkg/lock-frontend"
+            lock.touch()
+            fd = os.open(lock, os.O_RDONLY)
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            try:
+                with self.assertRaisesRegex(ProvisioningError, "belegt"):
+                    provisioner.prepare_os("apt_update")
+            finally:
+                os.close(fd)
+            lock.unlink()
+            (target / "var/run").mkdir(parents=True)
+            (target / "var/run/reboot-required").touch()
+            self.assertEqual(provisioner.prepare_os("full_upgrade"), "PROVISIONING_PAUSED_REBOOT_REQUIRED")
+
+    def test_existing_policy_rc_blocks_package_install(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            policy = target / "usr/sbin/policy-rc.d"
+            policy.parent.mkdir(parents=True)
+            policy.write_text("existing", encoding="utf-8")
+            provisioner = GuestProvisioner(runner=FakeRunner(), bundle=bundle, root=target)
+            with self.assertRaisesRegex(ProvisioningError, "policy-rc.d"):
+                provisioner.install_postgresql("packages")
+
+    def test_non_18_package_candidate_is_rejected_before_install(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            runner = FakeRunner()
+            original = runner.run
+
+            def candidate_19(arguments, **kwargs):
+                if arguments[:2] == ["apt-cache", "policy"]:
+                    return b"Candidate: 19.0-1\n"
+                return original(arguments, **kwargs)
+
+            runner.run = candidate_19
+            provisioner = GuestProvisioner(runner=runner, bundle=bundle, root=target)
+            with self.assertRaisesRegex(ProvisioningError, "PostgreSQL-18"):
+                provisioner.install_postgresql("packages")
+            self.assertFalse(any(call[0][:2] == ["apt-get", "-y"] for call in runner.calls))
+
+    def test_runtime_base_checks_network_dns_https_sources_and_storage(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            provisioner = GuestProvisioner(runner=FakeRunner(), bundle=bundle, root=target)
+            self.assertEqual(provisioner.prepare_os("validate"), "PHASE_COMPLETED guest_os_ready validate")
+            (target / "etc/resolv.conf").write_text("nameserver 192.0.2.1\n", encoding="utf-8")
+            with self.assertRaisesRegex(ProvisioningError, "DNS"):
+                provisioner.prepare_os("validate")
+
+    def test_hba_is_allocation_specific_and_rejects_weak_rules(self):
+        with tempfile.TemporaryDirectory() as raw:
+            _bundle, _target, plan = make_bundle(pathlib.Path(raw))
+            hba = render_hba(plan)
+            validate_hba(hba)
+            self.assertEqual(hba.count("hostssl "), 4)
+            self.assertNotIn("hostssl all all", hba)
+            self.assertNotIn("0.0.0.0/0", hba)
+            for bad in ("host all all 0.0.0.0/0 trust\n", "hostssl all all 10.0.0.0/8 md5\n"):
+                with self.assertRaises(ProvisioningError):
+                    validate_hba(bad)
+
+    def test_tls_files_are_installed_with_bounded_metadata(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            provisioner = GuestProvisioner(runner=FakeRunner(), bundle=bundle, root=target)
+            with mock.patch("postgresql_main.guest.grp.getgrnam", return_value=types.SimpleNamespace(gr_gid=0)):
+                provisioner.configure_postgresql("tls")
+            tls = target / "etc/postgresql/18/main/tls"
+            self.assertEqual((tls / "server.key").stat().st_mode & 0o777, 0o640)
+            self.assertEqual((tls / "server.crt").stat().st_mode & 0o777, 0o644)
+            self.assertEqual((tls / "ca.crt").stat().st_mode & 0o777, 0o644)
+
+    def test_wrong_certificate_san_is_rejected(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            runner = FakeRunner()
+            original = runner.run
+
+            def wrong_san(arguments, **kwargs):
+                if arguments[:3] == ["openssl", "x509", "-in"] and "-text" in arguments:
+                    return b"DNS:other.example, IP Address:192.0.2.1\n"
+                return original(arguments, **kwargs)
+
+            runner.run = wrong_san
+            provisioner = GuestProvisioner(runner=runner, bundle=bundle, root=target)
+            with self.assertRaisesRegex(ProvisioningError, "bindet Plan nicht"):
+                provisioner._validate_bundle_pki()
+
+    def test_allocation_secret_is_only_sent_over_stdin(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            runner = FakeRunner(clusters=b"18 main 5432 online postgres\n")
+            runner.query_results = [b"", b"", b"f\n", b""]
+            provisioner = GuestProvisioner(runner=runner, bundle=bundle, root=target)
+            provisioner.create_allocation("gitea")
+            secret = (bundle / "gitea/application-password").read_text()
+            argv = "\n".join(" ".join(arguments) for arguments, _input in runner.calls)
+            self.assertNotIn(secret, argv)
+            self.assertTrue(any(secret.encode() in (input_data or b"") for _args, input_data in runner.calls))
+
+    def test_global_listener_is_rejected(self):
+        with tempfile.TemporaryDirectory() as raw:
+            bundle, target, _plan = make_bundle(pathlib.Path(raw))
+            runner = FakeRunner(clusters=b"18 main 5432 online postgres\n")
+            original = runner.run
+
+            def broad(arguments, **kwargs):
+                if arguments[0] == "ss":
+                    return b"LISTEN 0 244 0.0.0.0:5432"
+                return original(arguments, **kwargs)
+
+            runner.run = broad
+            provisioner = GuestProvisioner(runner=runner, bundle=bundle, root=target)
+            with self.assertRaisesRegex(ProvisioningError, "global"):
+                provisioner.verify_readiness("provider")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgresql_main_marker.py
+++ b/tests/test_postgresql_main_marker.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from postgresql_main.filesystem import SecureFilesystem
+from postgresql_main.marker import MarkerStore, new_marker, validate_marker
+from postgresql_main.models import PHASES, ProvisioningError
+from postgresql_main_support import COMMIT, NOW, make_environment
+
+
+class MarkerTests(unittest.TestCase):
+    def test_marker_and_plan_are_exclusive_atomic_files(self):
+        with tempfile.TemporaryDirectory() as raw:
+            fs, _backend, store, _pki, artifacts, report = make_environment(pathlib.Path(raw))
+            marker = new_marker(
+                operation_id="operation-1", repository_commit=COMMIT,
+                plan=report.machine_plan,
+                artifact_hashes={name: "b" * 64 for name in artifacts}, now=NOW,
+            )
+            store.create(marker, report.machine_plan)
+            self.assertEqual(store.load()["in_progress_phase"], "planned")
+            self.assertEqual(fs.path(store.marker_path).stat().st_mode & 0o777, 0o600)
+            self.assertEqual(fs.path(store.plan_path).stat().st_mode & 0o777, 0o600)
+            with self.assertRaises(FileExistsError):
+                store.create(marker, report.machine_plan)
+
+    def test_phase_order_and_partial_progress_are_strict(self):
+        with tempfile.TemporaryDirectory() as raw:
+            _fs, _backend, store, _pki, artifacts, report = make_environment(pathlib.Path(raw))
+            marker = new_marker(
+                operation_id="operation-1", repository_commit=COMMIT,
+                plan=report.machine_plan,
+                artifact_hashes={name: "b" * 64 for name in artifacts}, now=NOW,
+            )
+            marker["completed_phases"] = ["planned", "secrets_ready"]
+            marker["phase"] = "secrets_ready"
+            with self.assertRaises(ProvisioningError):
+                validate_marker(marker)
+
+    def test_unknown_in_progress_item_is_rejected(self):
+        with tempfile.TemporaryDirectory() as raw:
+            _fs, _backend, _store, _pki, artifacts, report = make_environment(pathlib.Path(raw))
+            marker = new_marker(
+                operation_id="operation-1", repository_commit=COMMIT,
+                plan=report.machine_plan,
+                artifact_hashes={name: "b" * 64 for name in artifacts}, now=NOW,
+            )
+            marker["in_progress_item"] = "unknown"
+            with self.assertRaisesRegex(ProvisioningError, "in_progress_item"):
+                validate_marker(marker)
+
+    def test_marker_never_contains_secret_material(self):
+        with tempfile.TemporaryDirectory() as raw:
+            _fs, _backend, _store, _pki, artifacts, report = make_environment(pathlib.Path(raw))
+            marker = new_marker(
+                operation_id="operation-1", repository_commit=COMMIT,
+                plan=report.machine_plan,
+                artifact_hashes={name: "b" * 64 for name in artifacts}, now=NOW,
+            )
+            rendered = json.dumps(marker)
+            self.assertNotIn("password", rendered.lower())
+            self.assertNotIn("connection", rendered.lower())
+            self.assertEqual(tuple(PHASES)[-1], "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgresql_main_pki.py
+++ b/tests/test_postgresql_main_pki.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pathlib
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+REPO = SCRIPTS.parent
+sys.path.insert(0, str(SCRIPTS))
+
+from postgresql_main.filesystem import SecureFilesystem
+from postgresql_main.models import ProvisioningError
+from postgresql_main.pki import OpenSslRunner, PkiManager, load_policy
+
+
+@unittest.skipUnless(shutil.which("openssl"), "openssl is unavailable")
+class PkiIntegrationTests(unittest.TestCase):
+    def make_manager(self, root: pathlib.Path, *, fault=lambda _point: None):
+        pki = root / "secrets/database-service/providers/postgresql-main/pki"
+        pki.mkdir(parents=True, mode=0o700, exist_ok=True)
+        return PkiManager(
+            SecureFilesystem(root), OpenSslRunner(),
+            load_policy(REPO / "deploy/postgresql/pki-policy.toml"),
+            serial_source=lambda: 123456789, fault=fault,
+        )
+
+    def test_real_pki_chain_san_key_match_and_modes(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            manager = self.make_manager(root)
+            fingerprints = manager.generate("postgresql-main.example.internal", "10.20.0.10")
+            self.assertEqual(set(fingerprints), {"ca", "server"})
+            self.assertTrue(all(len(value) == 64 for value in fingerprints.values()))
+            for name, mode in (("ca.key", 0o600), ("server.key", 0o600), ("ca.crt", 0o644), ("server.crt", 0o644)):
+                info = manager.fs.path(manager.root / name).stat()
+                self.assertEqual(stat.S_IMODE(info.st_mode), mode)
+            self.assertEqual(
+                fingerprints,
+                manager.verify("postgresql-main.example.internal", "10.20.0.10"),
+            )
+
+    def test_partial_generation_is_resumed_without_replacing_ca_key(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+
+            def fail(point: str) -> None:
+                if point == "after_ca_key":
+                    raise ProvisioningError("INJECTED", point)
+
+            manager = self.make_manager(root, fault=fail)
+            with self.assertRaises(ProvisioningError):
+                manager.generate("postgresql-main.example.internal", "10.20.0.10")
+            ca_key = manager.fs.path(manager.root / "ca.key")
+            before = ca_key.read_bytes()
+            resumed = self.make_manager(root)
+            resumed.generate("postgresql-main.example.internal", "10.20.0.10")
+            self.assertEqual(ca_key.read_bytes(), before)
+
+    def test_policy_is_exact_and_unknown_value_is_rejected(self):
+        policy = load_policy(REPO / "deploy/postgresql/pki-policy.toml")
+        self.assertEqual((policy.ca_key_bits, policy.server_key_bits), (4096, 3072))
+        with tempfile.TemporaryDirectory() as raw:
+            bad = pathlib.Path(raw) / "policy.toml"
+            bad.write_text((REPO / "deploy/postgresql/pki-policy.toml").read_text().replace("397", "398"), encoding="utf-8")
+            with self.assertRaises(ProvisioningError):
+                load_policy(bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgresql_main_plan.py
+++ b/tests/test_postgresql_main_plan.py
@@ -217,6 +217,21 @@ class ConfigurationTests(PlannerTestCase):
         with self.assertRaisesRegex(planner.ConfigurationError, "application_identity"):
             planner.load_config(self.write_config(text))
 
+    def test_derived_owner_must_fit_postgresql_identifier_limit(self) -> None:
+        identity = "a" * 63
+        text = config_text(self.backup).replace(
+            'application_identity = "gitea"', f'application_identity = "{identity}"'
+        )
+        with self.assertRaisesRegex(planner.ConfigurationError, "derived_owner_identity"):
+            planner.load_config(self.write_config(text))
+
+    def test_derived_owner_must_not_collide_with_database_name(self) -> None:
+        text = config_text(self.backup).replace(
+            'database_name = "gitea"', 'database_name = "gitea_owner"'
+        )
+        with self.assertRaisesRegex(planner.ConfigurationError, "kollidieren"):
+            planner.load_config(self.write_config(text))
+
     def test_invalid_ip(self) -> None:
         with self.assertRaisesRegex(planner.ConfigurationError, "ipv4_cidr"):
             self.load(ipv4_cidr="10.10.0.0/24")
@@ -820,8 +835,16 @@ class DocumentationContractTests(unittest.TestCase):
         self.assertIn("bei Erfolg und Fehler entfernt", self.apply_contract)
         self.assertIn("Sicherheitsbereinigung ist kein Rollback", self.apply_contract)
 
-    def test_no_apply_implementation_exists(self) -> None:
-        self.assertFalse((self.repository / "scripts/postgresql-main-deploy.py").exists())
+    def test_apply_implementation_is_separate_from_read_only_planner(self) -> None:
+        deploy = self.repository / "scripts/postgresql-main-deploy.py"
+        self.assertTrue(deploy.is_file())
+        planner_parser = planner.create_parser()
+        choices = next(
+            action.choices
+            for action in planner_parser._actions
+            if isinstance(action, planner.argparse._SubParsersAction)
+        )
+        self.assertEqual(set(choices), {"plan"})
 
 
 def dataclasses_replace(instance, **changes):

--- a/tests/test_postgresql_main_resume.py
+++ b/tests/test_postgresql_main_resume.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from postgresql_main.host import CONFIG_PATH, Provisioner, build_resume_plan
+from postgresql_main.models import ALLOCATION_IDS, MULTI_ITEM_PHASES, ProvisioningError
+from postgresql_main_support import FakePki, NOW, make_environment
+
+
+class FaultOnce:
+    def __init__(self, target: str) -> None:
+        self.target = target
+        self.hit = False
+
+    def __call__(self, point: str) -> None:
+        if point == self.target and not self.hit:
+            self.hit = True
+            raise ProvisioningError("FAULT_INJECTED", point)
+
+
+def provisioner_for(fs, backend, store, pki, artifacts, report, *, fault=lambda _point: None):
+    return Provisioner(
+        filesystem=fs, backend=backend, marker_store=store, pki=pki,
+        plan_factory=lambda _path: report, token_source=lambda: "R" * 64,
+        operation_id_source=lambda: "operation-1", clock=lambda: NOW,
+        fault=fault, artifact_paths=artifacts,
+    )
+
+
+class ResumeTests(unittest.TestCase):
+    def exercise_fault(self, point: str):
+        temporary = tempfile.TemporaryDirectory()
+        root = pathlib.Path(temporary.name)
+        fs, backend, store, pki, artifacts, report = make_environment(root)
+        fault = FaultOnce(point)
+        initial = provisioner_for(fs, backend, store, pki, artifacts, report, fault=fault)
+        with self.assertRaises(ProvisioningError):
+            initial.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+        resume = build_resume_plan(
+            filesystem=fs, backend=backend, marker_store=store, pki=pki,
+            artifact_paths=artifacts, generated_at=NOW,
+        )
+        self.assertEqual(resume.status, "RESUME_READY", resume.document["conflicts"])
+        continued = provisioner_for(fs, backend, store, pki, artifacts, report)
+        marker = continued.resume(resume, resume.sha256)
+        self.assertEqual(marker["phase"], "completed")
+        return temporary, backend, marker
+
+    def test_resume_after_marker_creation(self):
+        temporary, backend, _marker = self.exercise_fault("after_marker")
+        self.addCleanup(temporary.cleanup)
+        self.assertEqual(backend.actions.count("pct create"), 1)
+
+    def test_resume_after_first_secret_does_not_replace_it(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            fs, backend, store, pki, artifacts, report = make_environment(root)
+            initial = provisioner_for(fs, backend, store, pki, artifacts, report, fault=FaultOnce("after_secret:gitea"))
+            with self.assertRaises(ProvisioningError):
+                initial.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+            path = fs.path("/secrets/database-service/allocations/gitea/application-password")
+            before = path.read_bytes()
+            resume = build_resume_plan(filesystem=fs, backend=backend, marker_store=store, pki=pki, artifact_paths=artifacts, generated_at=NOW)
+            marker = provisioner_for(fs, backend, store, pki, artifacts, report).resume(resume, resume.sha256)
+            self.assertEqual(path.read_bytes(), before)
+            self.assertEqual(marker["phase_progress"]["secrets_ready"], ["gitea", "openbao", "semaphore", "nodered"])
+
+    def test_resume_does_not_repeat_pct_create_or_start(self):
+        for point in ("after_pct_create", "after_pct_start"):
+            with self.subTest(point=point):
+                temporary, backend, _marker = self.exercise_fault(point)
+                self.addCleanup(temporary.cleanup)
+                self.assertEqual(backend.actions.count("pct create"), 1)
+                self.assertEqual(backend.actions.count("pct start 250"), 1)
+
+    def test_failed_start_is_conflict_and_never_retried(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            fs, backend, store, pki, artifacts, report = make_environment(root)
+
+            def failed_start(vmid: int) -> None:
+                backend.actions.append(f"pct start {vmid}")
+                raise ProvisioningError("START_FAILED", "start")
+
+            backend.start_lxc = failed_start
+            with self.assertRaises(ProvisioningError):
+                provisioner_for(fs, backend, store, pki, artifacts, report).apply(
+                    CONFIG_PATH, report.machine_plan["plan_sha256"]
+                )
+            resume = build_resume_plan(
+                filesystem=fs, backend=backend, marker_store=store, pki=pki,
+                artifact_paths=artifacts, generated_at=NOW,
+            )
+            self.assertEqual(resume.status, "RESUME_CONFLICT")
+            self.assertEqual(backend.actions.count("pct start 250"), 1)
+
+    def test_resume_recognizes_completed_guest_item(self):
+        temporary, backend, marker = self.exercise_fault("after_allocations_created:gitea")
+        self.addCleanup(temporary.cleanup)
+        self.assertEqual(backend.actions.count("guest allocations_created:gitea"), 1)
+        self.assertEqual(marker["phase_progress"]["allocations_created"], ["gitea", "openbao", "semaphore", "nodered"])
+        self.assertIn("guest secrets rehydrated", backend.actions)
+
+    def test_resume_recognizes_published_backup(self):
+        temporary, backend, marker = self.exercise_fault("after_backup:gitea")
+        self.addCleanup(temporary.cleanup)
+        self.assertEqual(backend.actions.count("backup gitea"), 1)
+        self.assertIn("gitea", marker["backup_artifacts"])
+
+    def test_unpublished_backup_temp_is_cleaned_and_recreated(self):
+        temporary, backend, marker = self.exercise_fault("after_backup_stream:gitea")
+        self.addCleanup(temporary.cleanup)
+        self.assertEqual(backend.actions.count("backup gitea"), 2)
+        self.assertIn("gitea", marker["backup_artifacts"])
+
+    def test_inconsistent_completed_secret_is_resume_conflict(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            fs, backend, store, pki, artifacts, report = make_environment(root)
+            initial = provisioner_for(fs, backend, store, pki, artifacts, report, fault=FaultOnce("after_pct_create"))
+            with self.assertRaises(ProvisioningError):
+                initial.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+            fs.path("/secrets/database-service/allocations/gitea/application-password").chmod(0o644)
+            resume = build_resume_plan(filesystem=fs, backend=backend, marker_store=store, pki=pki, artifact_paths=artifacts, generated_at=NOW)
+            self.assertEqual(resume.status, "RESUME_CONFLICT")
+
+    def test_resume_hash_binds_state_not_generation_time(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            fs, backend, store, pki, artifacts, report = make_environment(root)
+            with self.assertRaises(ProvisioningError):
+                provisioner_for(fs, backend, store, pki, artifacts, report, fault=FaultOnce("after_marker")).apply(
+                    CONFIG_PATH, report.machine_plan["plan_sha256"]
+                )
+            first = build_resume_plan(filesystem=fs, backend=backend, marker_store=store, pki=pki, artifact_paths=artifacts, generated_at="2026-08-06T12:00:00Z")
+            second = build_resume_plan(filesystem=fs, backend=backend, marker_store=store, pki=pki, artifact_paths=artifacts, generated_at="2026-08-07T12:00:00Z")
+            self.assertEqual(first.sha256, second.sha256)
+            backend.clean = False
+            changed = build_resume_plan(filesystem=fs, backend=backend, marker_store=store, pki=pki, artifact_paths=artifacts, generated_at=NOW)
+            self.assertNotEqual(first.sha256, changed.sha256)
+
+    def test_fault_injection_after_every_persistent_boundary_is_resumable(self):
+        points = [
+            "after_marker",
+            *(f"after_directory:{item}" for item in MULTI_ITEM_PHASES["secret_directories_ready"]),
+            *(f"after_secret:{item}" for item in ALLOCATION_IDS),
+            "after_ca_key", "after_ca_certificate", "after_server_key", "after_server_certificate",
+            "after_pct_create", "after_pct_start",
+            *(f"after_bundle:{item}" for item in MULTI_ITEM_PHASES["guest_bundle_ready"]),
+            *(
+                f"after_{phase}:{item}"
+                for phase in ("guest_os_ready", "postgresql_installed", "postgresql_configured", "allocations_created", "readiness_verified")
+                for item in MULTI_ITEM_PHASES[phase]
+            ),
+            *(f"after_backup_stream:{item}" for item in ALLOCATION_IDS),
+            *(f"after_backup:{item}" for item in ALLOCATION_IDS),
+            "before_completion",
+        ]
+        for point in points:
+            with self.subTest(point=point), tempfile.TemporaryDirectory() as raw:
+                root = pathlib.Path(raw)
+                fs, backend, store, _pki, artifacts, report = make_environment(root)
+                fault = FaultOnce(point)
+                pki = FakePki(fs, fault=fault)
+                initial = provisioner_for(fs, backend, store, pki, artifacts, report, fault=fault)
+                with self.assertRaises(ProvisioningError):
+                    initial.apply(CONFIG_PATH, report.machine_plan["plan_sha256"])
+                resumed_pki = FakePki(fs)
+                resume = build_resume_plan(
+                    filesystem=fs, backend=backend, marker_store=store, pki=resumed_pki,
+                    artifact_paths=artifacts, generated_at=NOW,
+                )
+                self.assertEqual(resume.status, "RESUME_READY", (point, resume.document["conflicts"]))
+                marker = provisioner_for(fs, backend, store, resumed_pki, artifacts, report).resume(resume, resume.sha256)
+                self.assertEqual(marker["phase"], "completed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgresql_main_secrets.py
+++ b/tests/test_postgresql_main_secrets.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pathlib
+import sys
+import tempfile
+import unittest
+
+SCRIPTS = pathlib.Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS))
+
+from postgresql_main.filesystem import SecureFilesystem
+from postgresql_main.host import PASSWORD_PATHS, Provisioner
+from postgresql_main.models import ALLOCATION_IDS, ProvisioningError
+from postgresql_main_support import NOW, make_environment, secret_values
+
+
+class SecureFilesystemTests(unittest.TestCase):
+    def test_exclusive_secret_creation_and_atomic_replacement(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            (root / "secrets").mkdir(mode=0o700)
+            fs = SecureFilesystem(root)
+            logical = pathlib.Path("/secrets/value")
+            fs.exclusive_bytes(logical, b"first")
+            with self.assertRaises(FileExistsError):
+                fs.exclusive_bytes(logical, b"second")
+            fs.atomic_bytes(logical, b"second")
+            self.assertEqual(fs.read_bytes(logical), b"second")
+            self.assertEqual(fs.path(logical).stat().st_mode & 0o777, 0o600)
+
+    def test_symlink_component_is_rejected(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            (root / "outside").mkdir()
+            (root / "secrets").symlink_to(root / "outside", target_is_directory=True)
+            with self.assertRaisesRegex(ProvisioningError, "Symlink"):
+                SecureFilesystem(root).exclusive_bytes("/secrets/value", b"secret")
+
+
+class ProvisionedSecretTests(unittest.TestCase):
+    def test_exactly_four_independent_secrets_with_safe_metadata(self):
+        with tempfile.TemporaryDirectory() as raw:
+            fs, backend, store, pki, artifacts, report = make_environment(pathlib.Path(raw))
+            counter = iter([("A" * 63) + str(index) for index in range(4)])
+            provisioner = Provisioner(
+                filesystem=fs, backend=backend, marker_store=store, pki=pki,
+                plan_factory=lambda _path: report, token_source=lambda: next(counter),
+                operation_id_source=lambda: "operation-1", clock=lambda: NOW,
+                artifact_paths=artifacts,
+            )
+            marker = provisioner.apply(pathlib.Path("/secrets/database-service/providers/postgresql-main/deployment.toml"), report.machine_plan["plan_sha256"])
+            values = secret_values(fs)
+            self.assertEqual(len(values), 4)
+            self.assertEqual(len(set(values)), 4)
+            self.assertEqual(marker["phase"], "completed")
+            for allocation in ALLOCATION_IDS:
+                info = fs.path(PASSWORD_PATHS[allocation]).stat()
+                self.assertEqual(info.st_mode & 0o777, 0o600)
+                self.assertEqual((info.st_uid, info.st_gid), (0, 0))
+            combined = repr(marker) + repr(backend.actions)
+            for value in values:
+                self.assertNotIn(value.decode(), combined)
+
+    def test_foreign_secrets_tree_is_untouched(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = pathlib.Path(raw)
+            fs, backend, store, pki, artifacts, report = make_environment(root)
+            foreign = root / "secrets/another-service/keep"
+            foreign.parent.mkdir(parents=True)
+            foreign.write_bytes(b"do-not-touch")
+            foreign.chmod(0o600)
+            provisioner = Provisioner(
+                filesystem=fs, backend=backend, marker_store=store, pki=pki,
+                plan_factory=lambda _path: report, token_source=lambda: "S" * 64,
+                operation_id_source=lambda: "operation-1", clock=lambda: NOW,
+                artifact_paths=artifacts,
+            )
+            provisioner.apply(pathlib.Path("/secrets/database-service/providers/postgresql-main/deployment.toml"), report.machine_plan["plan_sha256"])
+            self.assertEqual(foreign.read_bytes(), b"do-not-touch")
+            self.assertEqual(foreign.stat().st_mode & 0o777, 0o600)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- share the existing PLAN_READY model directly between the read-only planner and the new hash-bound deploy path
- add atomic marker, exclusive lock, per-item phase progress, secure `/secrets` handling, versioned PKI policy, LXC command construction, and bounded host/guest phases
- model Ubuntu 26.04 plus PostgreSQL 18 provisioning, TLS/SCRAM/HBA, four isolated allocations, streamed verified backups, and explicit resume without automatic rollback
- keep allocation readiness at `consumer_validation_pending` until a real consumer proves TLS/SCRAM connectivity

## Safety boundary

This PR adds real usable apply/resume code but does not execute it. No real deployment configuration, marker, secret, PKI object, LXC, PostgreSQL package, database, role, or backup was created. `/secrets` and infrastructure were not changed.

## Verification

- 117 Python tests, including fault injection after every persistent boundary
- `python3 -m compileall -q scripts tests`
- real local OpenSSL chain, SAN, key/certificate, and file-mode checks
- `pct help create` read-only syntax availability check
- Markdown heading and internal-link validation
- ADR ordering 0001 through 0008
- `git diff --check`
- static checks for `shell=True`, `eval`, destructive Proxmox commands, product test switches, credential-bearing connection strings, and secrets exclusions

## Next step

After review and merge, create the real deployment configuration under `/secrets` and run exactly one real read-only plan. A real apply remains separately blocked on review and explicit confirmation of that plan hash.